### PR TITLE
A few small documentation improvements and typo fixes

### DIFF
--- a/DEVEL.rst
+++ b/DEVEL.rst
@@ -138,7 +138,7 @@ Unfortunately, for many samplers, such as basic MH-MCMC, we do not know a priori
 Reparameterization layer
 """"""""""""""""""""""""
 
-**Statistical parameters** are specified according to their rôles for the **sampler**: as *fixed*, *sampled* and *derived*. On the other hand, the **likelihood** (and the **theory code**, if present) cares only about input and output arguments. In a trivial case, those would correspond respectively to *fixed+sampled* and *derived* parameters.
+**Statistical parameters** are specified according to their roles for the **sampler**: as *fixed*, *sampled* and *derived*. On the other hand, the **likelihood** (and the **theory code**, if present) cares only about input and output arguments. In a trivial case, those would correspond respectively to *fixed+sampled* and *derived* parameters.
 
 Actually, this needs not be the case in general, e.g. one may want to fix one or more likelihood arguments to a function of the value of a sampled parameter, or sample from some function or scaling of a likelihood argument, instead of from the likelihood argument directly. The **reparameterization layers** allow us to specify this non-trivial behaviour at run-time (i.e. in the *input*), instead of  having to change the likelihood code to make it understand different parameterizations or impose certain conditions as fixed input arguments.
 

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -208,6 +208,7 @@ class Model(object):
         of the likelihood (unnormalized, in general), and ``derived_params``
         are the values of the derived parameters in the order given by
         ``list([your_model].parameterization.derived_params())``.
+        If the model contains multiple likelihoods, the sum of the loglikes is returned.
 
         To return just the list of log-likelihood values, make ``return_derived=False``.
 

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -10,7 +10,7 @@ Basic parameter specification
 
 The ``params`` block contains all the information intrinsic
 to the parameters of the model: their prior pdf and reference pdf, their latex labels,
-and useful properties for particular samplers (e.g. width of a proposal pdf in and MCMC
+and useful properties for particular samplers (e.g. width of a proposal pdf in an MCMC
 -- see the documentation for each sampler).
 The prior and reference pdf are managed by the :class:`Prior` class.
 

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -36,7 +36,7 @@ You can specify any parameter that CLASS understands in the ``params`` block:
    theory:
      classy:
        extra_args:
-         [any param that CLASS understands, for FIXED and PRECISION]
+         [any param that CLASS understands]
 
    params:
        [any param that CLASS understands, fixed, sampled or derived]

--- a/docs/sampler_mcmc.rst
+++ b/docs/sampler_mcmc.rst
@@ -136,7 +136,7 @@ In this case, internally, the final covariance matrix of the proposal would be::
      0     0     0.04
 
 
-If the option `learn_proposal` is set to ``True``, the covariance matrix will be updated
+If the option ``learn_proposal`` is set to ``True``, the covariance matrix will be updated
 regularly. This means that accuracy of the initial covariance is not critical, and even if you do not initially know
 the covariance, it will be adaptively learnt (just make sure your ``proposal`` widths are sufficiently small that
 chains can move and hence explore the local shape; if your widths are too wide the parameter may just remain stuck).

--- a/docs/sampler_polychord.rst
+++ b/docs/sampler_polychord.rst
@@ -132,7 +132,7 @@ Troubleshooting
 
 If you are getting an error whose cause is not immediately obvious, try substituting ``polychord`` by :doc:`the dummy sampler <sampler_evaluate>` ``evaluate``.
 
-If still in doubt, run with debug output and check what the prior and likelihood are getting and producing: either set ``debug: True`` in the input file and set ``debug_file`` to some file name, or add the ``--debug`` flag to ``cobaya-run`` and pipe the output to a file with ``cobaya-run [input.yaml] --debug >file``.
+If still in doubt, run with debug output and check what the prior and likelihood are getting and producing: either set ``debug: True`` in the input file and set ``debug_file`` to some file name, or add the ``--debug`` flag to ``cobaya-run`` and pipe the output to a file with ``cobaya-run [input.yaml] --debug > file``.
 
 If PolyChord gets stuck in ``started sampling``, it probably means that your posterior is flat; if that was intentional, check the :ref:`polychord_bayes_ratios` section, where it is discussed how to deal with those cases.
 
@@ -161,7 +161,7 @@ If it has been installed this way, it is not necessary to specify a ``path`` for
 
    To run PolyChord with MPI (highly recommended!) you need to make sure that MPI+Python is working in your system, see :ref:`install_mpi`.
 
-   In addition, you need a MPI-wrapped Fortran compiler. You should have an MPI implementation installed if you followed  :ref:`the instructions to install mpi4py <install_mpi>`. On top of that, you need the Fortran compiler (we recommend the GNU one) and the *development* package of MPI. Use your system's package manager to install them (``sudo apt install gfortran libopenmpi-dev`` in Ubunto/Debian systems), or contact your local IT service. If everything is correctly installed, you should be able to type ``mpif90`` in the shell and not get a ``Command not found`` error.
+   In addition, you need a MPI-wrapped Fortran compiler. You should have an MPI implementation installed if you followed  :ref:`the instructions to install mpi4py <install_mpi>`. On top of that, you need the Fortran compiler (we recommend the GNU one) and the *development* package of MPI. Use your system's package manager to install them (``sudo apt install gfortran libopenmpi-dev`` in Ubuntu/Debian systems), or contact your local IT service. If everything is correctly installed, you should be able to type ``mpif90`` in the shell and not get a ``Command not found`` error.
 
 
 .. note::


### PR DESCRIPTION
While reading the docs I found a few typos in the documentation (first commit).
I also found two places confusing me so I edited them (see commit message for more details, commits 2 and 3). Feel free to skip one if it isn't good (especially the classy one).

I also noticed your [old repo](https://github.com/JesusTorrado/cobaya) (at the top of the page) links to [this](http://cobaya.readthedocs.io/en/latest/intro.html) readthedocs page, you could maybe put a redirect there (or a note that they are using the wrong repo) or just remove the link.