### PR TITLE
Updates for new CAMB 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: trusty
+dist: xenial
 sudo: required
 
 # (Pre)Installation
@@ -26,6 +26,27 @@ matrix:
         - GCC_VERSION="8"
         - PYVER="3"
       python: "3.6"
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - gfortran-7
+            - g++-7
+            - openmpi-bin
+            - openmpi-common
+            - libopenmpi-dev
+            # numpy (and more)
+            - libopenblas-base
+            # Planck likelihood
+            - liblapack3
+            - liblapack-dev
+      env:
+        - GCC_VERSION="7"
+        - PYDIST="ANACONDA"
+        - PYVER="3"
+      python: "3.7"      
     - addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,9 @@ before_install:
       hash -r;
       conda config --set always_yes yes --set changeps1 no;
       conda info -a;
-      conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION mpi4py scipy matplotlib cython PyYAML pytest-xdist flaky;
+      conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION scipy matplotlib cython PyYAML pytest-xdist flaky;
       source activate test-environment;
+      pip install mpi4py;
     else
       pip install mpi4py pytest-xdist flaky matplotlib;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,46 +11,6 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - gcc-4.9
-            - gfortran-4.9
-            - g++-4.9
-            - openmpi-bin
-            - openmpi-common
-            - libopenmpi-dev
-            # numpy (and more)
-            - libopenblas-base
-            # Planck likelihood
-            - liblapack3
-            - liblapack-dev
-      env:
-        - GCC_VERSION="4.9"
-        - PYVER="2"
-      python: "2.7"
-    - addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-            - gfortran-5
-            - g++-5
-            - openmpi-bin
-            - openmpi-common
-            - libopenmpi-dev
-            # numpy (and more)
-            - libopenblas-base
-            # Planck likelihood
-            - liblapack3
-            - liblapack-dev
-      env:
-        - GCC_VERSION="5"
-        - PYVER="3"
-      python: "3.6"
-    - addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
             - gcc-8
             - gfortran-8
             - g++-8
@@ -83,30 +43,8 @@ matrix:
       env:
         - PYDIST="ANACONDA"
         - GCC_VERSION="6"
-        - PYVER="3"
-      python: "3.6"
-    # BELOW: CAMB devel #################################################
-    - addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-6
-            - gfortran-6
-            - g++-6
-            - openmpi-bin
-            - openmpi-common
-            - libopenmpi-dev
-            # numpy (and more)
-            - libopenblas-base
-            # Planck likelihood
-            - liblapack3
-            - liblapack-dev
-      env:
-        - GCC_VERSION="6"
-        - PYVER="3"
-        - CAMB_BRANCH="devel"
-      python: "3.6"
+        - PYVER="2"
+      python: "2.7"
 before_install:
   - mkdir -p gcc-symlinks
   - ln -s /usr/bin/gfortran-$GCC_VERSION gcc-symlinks/gfortran
@@ -146,8 +84,8 @@ deploy: # only if it builds and if the commit has been tagged
     secure: FVCgqGT0sMJyvlY3sJFBwvO4RycAbWbVyHl4p9CG7XRSSgVOLGy9RZjAJkX8dJjH06fPNdQDYfkkj1PV8I42y0n4uqKkQ9RB63Yq6skbuuzjXLGQK9Xop10/1GDBhMHietDibzl8ZIuJyibdFYsc3rM/j8QcKjOYpDe10jO8K+dZaXsgAvqHk4P3d3ScG1u+X+wr8K6qik21YbTpiILS0LdUxmP4DWQw/7NKGWDX1b7sImRmvQfO20KuPTMu8pPz9ThZyPl6zEPgtKi2sQej5sgDlfim/heYk4W8Bf7bggS8GLseffssL5ru96eNUWT1OSbxnsEFqyyYepngNHPpvifflvtCiFU+3f7rzzcgYqmybhdM4ZEOk0pL5y/NS/rHn/1iW7Cqxs+GfUCbr9fWuBgKmVuDqEfvtSu83U1x6zz9C3R259Oe6n0vXfCGSfJqiHhsW8wuXx+bODyDaMAUn+gRSCLuqJVQzdcYwF2pGFf1WUH5iTQItUHZjYbAIXdnSqDKnvGalNDJdNsF3vwNEdbe8hFqfHMMzG73ZkkLOCjDW+mswIKYJUflxIyOdRqtB+XE056dA+c8Zwc4ktg4iss/O3ZBtUVPmba/ivpyYm7Fk8EUN/zY+24NK4iKk6z543rfx2w+wNXAuQiwgN2f+JshqI8kzTuCxPTgf2N49ME=
   on:
     tags: true
-    python: '2.7'
-    condition: "$GCC_VERSION = 4.9"
+    python: '3.6'
+    condition: "$GCC_VERSION = 8"
     branch: master
     repo: CobayaSampler/cobaya
 ###############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
   # Installation
   - python tests/install_for_tests.py ../modules
   # CAMB devel?
-  - if [ -n "${CAMB_BRANCH}" ]; then rm -rf ../modules/code/CAMB ; git clone --recursive -b $CAMB_BRANCH https://github.com/cmbant/CAMB ../modules/code/CAMB ; python ../modules/code/CAMB/pycamb/setup.py build ; fi
+  - if [ -n "${CAMB_BRANCH}" ]; then rm -rf ../modules/code/CAMB ; git clone --recursive -b $CAMB_BRANCH https://github.com/cmbant/CAMB ../modules/code/CAMB ; python ../modules/code/CAMB/setup.py build ; fi
   # Non-cosmological tests
   - pytest tests/ -k "not cosmo" --modules="../modules"
   # Cosmological tests (--boxed = 1 process per test; otherwise lowl planck lik fails!). Planck currently does not support py3.

--- a/cobaya/cosmo_input/input_database.py
+++ b/cobaya/cosmo_input/input_database.py
@@ -565,5 +565,6 @@ install_basic = {
         "planck_2015_lowl": None,
         "bicep_keck_2015": None,
         "sn_pantheon": None,
-        "sdss_dr12_consensus_final": None},
+        "sdss_dr12_consensus_final": None,
+        "des_y1_joint": None},
     _sampler: {"polychord": None}}

--- a/cobaya/cosmo_input/input_database.py
+++ b/cobaya/cosmo_input/input_database.py
@@ -416,11 +416,10 @@ for m in like_cmb.values():
 #    "thetarseq":   {"latex": r"100\theta_\mathrm{s,eq}"},
 for combination, info in like_cmb.items():
     if info:
-        likes = ", ".join([_chi2+_separator+like for like in info[_likelihood]])
+        likes = ", ".join([_chi2 + _separator + like for like in info[_likelihood]])
         info[_params] = odict([
-            ["chi2__CMB", odict([[_p_derived, "lambda %s: sum([%s])"%(likes, likes)],
+            ["chi2__CMB", odict([[_p_derived, "lambda %s: sum([%s])" % (likes, likes)],
                                  [_p_label, "\chi^2_\mathrm{CMB}"]])]])
-
 
 like_bao = odict([
     [_none, {}],
@@ -434,9 +433,9 @@ like_bao = odict([
 ])
 for combination, info in like_bao.items():
     if info:
-        likes = ", ".join([_chi2+_separator+like for like in info[_likelihood]])
+        likes = ", ".join([_chi2 + _separator + like for like in info[_likelihood]])
         info[_params] = odict([
-            ["chi2__BAO", odict([[_p_derived, "lambda %s: sum([%s])"%(likes, likes)],
+            ["chi2__BAO", odict([[_p_derived, "lambda %s: sum([%s])" % (likes, likes)],
                                  [_p_label, "\chi^2_\mathrm{BAO}"]])]])
 
 like_sn = odict([

--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -168,26 +168,20 @@ def pip_install(packages):
     """
     Takes package name or list of them.
 
-    Retries installation with ``--user`` flag if it fails without it.
+    Uses ``--user`` flag if does not appear to have write permission to python path
 
     Returns exit status.
     """
+    import subprocess
     if hasattr(packages, "split"):
         packages = [packages]
-    try:
-        import pip._internal as pip  # pip version >= 10
-    except ImportError:
-        import pip  # pip version < 10
-    for package in packages:
-        for user_flag in [[], ["--user"]]:
-            exit_status = pip.main(["install", package] + user_flag)
-            if not exit_status:
-                # It worked! Let's not try again
-                break
-        if exit_status:
-            log.error("pip: error installing package '%s'", package)
-            break
-    return exit_status
+    cmd = [sys.executable, '-m', 'pip', 'install']
+    if not os.access(os.path.dirname(sys.executable), os.W_OK):
+        cmd += ['--user']
+    res = subprocess.call(cmd + packages)
+    if res:
+        log.error("pip: error installing packages '%s'", packages)
+    return res
 
 
 # Command-line script ####################################################################

--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -6,8 +6,8 @@
 
 """
 # Python 2/3 compatibility
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import division
 
 # Global

--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -194,7 +194,7 @@ def pip_install(packages):
 
 def install_script():
     from cobaya.mpi import am_single_or_primary_process
-    if not am_single_or_primary_process():
+    if am_single_or_primary_process():
         # Configure the logger ASAP
         logger_setup()
         log = logging.getLogger(__name__.split(".")[-1])

--- a/cobaya/likelihoods/_planck_clik_prototype/_planck_clik_prototype.py
+++ b/cobaya/likelihoods/_planck_clik_prototype/_planck_clik_prototype.py
@@ -340,24 +340,26 @@ def install_clik(path, no_progress_bars=False):
     log.info("clik: configuring... (and maybe installing dependencies...)")
     cwd = os.getcwd()
     os.chdir(os.path.join(path, "plc-2.0"))
-    process = Popen(
-        ["./waf", "configure", "--install_all_deps"], stdout=PIPE, stderr=PIPE)
-    out, err = process.communicate()
-    if err or not out.split("\n")[-2].startswith("'configure' finished successfully"):
-        print(out)
-        print(err)
-        log.error("Configuration failed!")
-        return False
-    log.info("clik: compiling...")
-    process2 = Popen(["./waf", "install"], stdout=PIPE, stderr=PIPE)
-    out2, err2 = process2.communicate()
-    # We don't check that err2" is empty, because harmless warnings are included there.
-    if not out2.split("\n")[-2].startswith("'install' finished successfully"):
-        print(out2)
-        print(err2)
-        log.error("Compilation failed!")
-        return False
-    os.chdir(cwd)
+    try:
+        process = Popen(
+            ["./waf", "configure", "--install_all_deps"], stdout=PIPE, stderr=PIPE)
+        out, err = process.communicate()
+        if err or not out.split("\n")[-2].startswith("'configure' finished successfully"):
+            print(out)
+            print(err)
+            log.error("Configuration failed!")
+            return False
+        log.info("clik: compiling...")
+        process2 = Popen(["./waf", "install"], stdout=PIPE, stderr=PIPE)
+        out2, err2 = process2.communicate()
+        # We don't check that err2" is empty, because harmless warnings are included there.
+        if not out2.split("\n")[-2].startswith("'install' finished successfully"):
+            print(out2)
+            print(err2)
+            log.error("Compilation failed!")
+            return False
+    finally:
+        os.chdir(cwd)
     log.info("clik: finished!")
     return True
 
@@ -404,7 +406,7 @@ def install(path=None, name=None, force=False, code=True, data=True,
         success *= install_clik(paths["code"], no_progress_bars=no_progress_bars)
         if not success:
             log.warning("clik code installation failed! "
-                        "Try configuring+compiling by hand at "+paths["code"])
+                        "Try configuring+compiling by hand at " + paths["code"])
     if data:
         # 2nd test, in case the code wasn't there but the data is:
         if force or not is_installed(path=path, name=name, code=False, data=True):

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -78,10 +78,13 @@ def get_mpi_rank():
 
 # Aliases for simpler use
 def am_single_or_primary_process():
-    return not bool(get_mpi_rank())
+    rank = get_mpi_rank()
+    return rank is None or not bool(get_mpi_rank())
+
 
 def more_than_one_process():
     return bool(max(get_mpi_size(), 1) - 1)
+
 
 def sync_processes():
     if get_mpi_size():

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -78,8 +78,7 @@ def get_mpi_rank():
 
 # Aliases for simpler use
 def am_single_or_primary_process():
-    rank = get_mpi_rank()
-    return rank is None or not bool(get_mpi_rank())
+    return not bool(get_mpi_rank())
 
 
 def more_than_one_process():

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -237,10 +237,10 @@ class Parameterization(object):
                 if p in resolved:
                     continue
                 args = {p:
-                        self._constant.get(
-                            p, self._input.get(
-                                p, sampled_params_values.get(p, None)))
-                        for p in self._input_args[p]}
+                    self._constant.get(
+                        p, self._input.get(
+                            p, sampled_params_values.get(p, None)))
+                    for p in self._input_args[p]}
                 if not all([isinstance(v, Number) for v in args.values()]):
                     continue
                 try:

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -158,7 +158,10 @@ class camb(_cosmo):
         if not self.path and self.path_install:
             self.path = os.path.join(
                 self.path_install, "code", camb_repo_name[camb_repo_name.find("/") + 1:])
-        if self.path:
+        if self.path and not os.path.exists(self.path):
+            self.log.info("*local* CAMB not found at " + self.path)
+            self.log.info("Importing *global* CAMB.")
+        elif self.path:
             self.log.info("Importing *local* CAMB from " + self.path)
             if not os.path.exists(self.path):
                 self.log.error("The given folder does not exist: '%s'", self.path)

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -451,6 +451,8 @@ class camb(_cosmo):
         # Specific calls, if general ones fail:
         if p == "sigma8":
             return intermediates["CAMBdata"]["result"].get_sigma8()[0]
+        elif p == "omegal":
+            return intermediates["CAMBdata"]["result"].omega_de
         for f in [self.get_derived_from_params,
                   self.get_derived_from_std,
                   self.get_derived_from_getter]:

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -163,16 +163,12 @@ class camb(_cosmo):
             if not os.path.exists(self.path):
                 self.log.error("The given folder does not exist: '%s'", self.path)
                 raise HandledException
-            if os.path.exists(os.path.join(self.path, "setup.py")):
-                # CAMB 1.0.0 or later
-                pycamb_path = self.path
-            else:
-                pycamb_path = os.path.join(self.path, "pycamb")
-                if not os.path.exists(pycamb_path):
-                    self.log.error(
-                        "Either CAMB is not in the given folder, '%s', or you are using a "
-                        "very old version without the Python interface.", self.path)
-                    raise HandledException
+            pycamb_path = self.path
+            if not os.path.exists(os.path.join(self.path, "setup.py")):
+                self.log.error(
+                    "Either CAMB is not in the given folder, '%s', or you are using a "
+                    "very old version without the Python interface.", self.path)
+                raise HandledException
             sys.path.insert(0, pycamb_path)
         else:
             self.log.info("Importing *global* CAMB.")
@@ -559,7 +555,7 @@ class camb(_cosmo):
 
 # Name of the Class repo/folder and version to download
 camb_repo_name = "cmbant/CAMB"
-camb_repo_version = "1.0.0"
+camb_repo_version = "1.0.1"
 
 
 def is_installed(**kwargs):

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -555,7 +555,7 @@ class camb(_cosmo):
 
 # Name of the Class repo/folder and version to download
 camb_repo_name = "cmbant/CAMB"
-camb_repo_version = "1.0.1"
+camb_repo_version = "master"
 
 
 def is_installed(**kwargs):

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -422,12 +422,15 @@ class camb(_cosmo):
         try:
             return getattr(pars, p)
         except AttributeError:
-            for mod in ["InitPower", "Reion", "Recomb", "Transfer", "DarkEnergy"]:
-                try:
-                    return getattr(
-                        getattr(pars, mod), p)
-                except AttributeError:
-                    pass
+            try:
+                return getattr(result, p)
+            except AttributeError:
+                for mod in ["InitPower", "Reion", "Recomb", "Transfer", "DarkEnergy"]:
+                    try:
+                        return getattr(
+                            getattr(pars, mod), p)
+                    except AttributeError:
+                        pass
             return None
 
     def get_derived_from_std(self, p, intermediates):
@@ -451,8 +454,6 @@ class camb(_cosmo):
         # Specific calls, if general ones fail:
         if p == "sigma8":
             return intermediates["CAMBdata"]["result"].get_sigma8()[0]
-        elif p == "omegal":
-            return intermediates["CAMBdata"]["result"].omega_de
         for f in [self.get_derived_from_params,
                   self.get_derived_from_std,
                   self.get_derived_from_getter]:

--- a/cobaya/theories/camb/camb.yaml
+++ b/cobaya/theories/camb/camb.yaml
@@ -16,9 +16,8 @@ theory:
     renames:
       omegabh2: ombh2
       omegach2: omch2
-      omegal: omegav
+      omegal: omega_de
       omegak: omk
-      Alens: ALens  # corrected in CAMB/devel
       yhe: YHe
       yheused: YHe  # used by Planck when YHe is derived
       YpBBN: Y_p

--- a/docs/src_examples/cosmo_basic/basic_camb.yaml
+++ b/docs/src_examples/cosmo_basic/basic_camb.yaml
@@ -19,7 +19,7 @@ params:
     latex: 100\theta_\mathrm{MC}
     drop: true
   cosmomc_theta: {value: 'lambda theta: 1.e-2*theta', derived: false}
-  H0: {latex: H_0, max: 100, min: 40}
+  H0: {latex: H_0, min: 40, max: 100}
   ombh2:
     prior: {min: 0.005, max: 0.1}
     ref: {dist: norm, loc: 0.0221, scale: 0.0001}
@@ -34,7 +34,7 @@ params:
   omegamh2: {derived: 'lambda omegam, H0: omegam*(H0/100)**2', latex: '\Omega_\mathrm{m}
       h^2'}
   mnu: 0.06
-  omegav: {latex: \Omega_\Lambda}
+  omega_de: {latex: \Omega_\Lambda}
   YHe: {latex: 'Y_\mathrm{P}'}
   Y_p: {latex: 'Y_P^\mathrm{BBN}'}
   DHBBN: {derived: 'lambda DH: 10**5*DH', latex: '10^5 \mathrm{D}/\mathrm{H}'}
@@ -44,17 +44,9 @@ params:
     proposal: 0.005
     latex: \tau_\mathrm{reio}
   zre: {latex: 'z_\mathrm{re}'}
-  sigma8: {latex: \sigma_8}
-  s8h5: {derived: 'lambda sigma8, H0: sigma8*(H0*1e-2)**(-0.5)', latex: '\sigma_8/h^{0.5}'}
-  s8omegamp5: {derived: 'lambda sigma8, omegam: sigma8*omegam**0.5', latex: '\sigma_8
-      \Omega_\mathrm{m}^{0.5}'}
-  s8omegamp25: {derived: 'lambda sigma8, omegam: sigma8*omegam**0.25', latex: '\sigma_8
-      \Omega_\mathrm{m}^{0.25}'}
-  A: {derived: 'lambda As: 1e9*As', latex: '10^9 A_\mathrm{s}'}
-  clamp: {derived: 'lambda As, tau: 1e9*As*np.exp(-2*tau)', latex: '10^9 A_\mathrm{s}
-      e^{-2\tau}'}
-  age: {latex: '{\rm{Age}}/\mathrm{Gyr}'}
-  rdrag: {latex: 'r_\mathrm{drag}'}
+  chi2__CMB: {derived: 'lambda chi2__planck_2015_lowTEB, chi2__planck_2015_plikHM_TTTEEE,
+      chi2__planck_2015_lensing: sum([chi2__planck_2015_lowTEB, chi2__planck_2015_plikHM_TTTEEE,
+      chi2__planck_2015_lensing])', latex: '\chi^2_\mathrm{CMB}'}
 sampler:
   mcmc: {covmat: auto, drag: true, proposal_scale: 1.9}
 theory:

--- a/docs/src_examples/cosmo_basic/basic_classy.yaml
+++ b/docs/src_examples/cosmo_basic/basic_classy.yaml
@@ -33,7 +33,7 @@ params:
   Omega_m: {latex: '\Omega_\mathrm{m}'}
   omegamh2: {derived: 'lambda Omega_m, H0: Omega_m*(H0/100)**2', latex: '\Omega_\mathrm{m}
       h^2'}
-  m_ncdm: {renames: mnu, value: 0.06}
+  m_ncdm: {value: 0.06, renames: mnu}
   Omega_Lambda: {latex: \Omega_\Lambda}
   YHe: {latex: 'Y_\mathrm{P}'}
   tau_reio:
@@ -42,19 +42,11 @@ params:
     proposal: 0.005
     latex: \tau_\mathrm{reio}
   z_reio: {latex: 'z_\mathrm{re}'}
-  sigma8: {latex: \sigma_8}
-  s8h5: {derived: 'lambda sigma8, H0: sigma8*(H0*1e-2)**(-0.5)', latex: '\sigma_8/h^{0.5}'}
-  s8omegamp5: {derived: 'lambda sigma8, Omega_m: sigma8*Omega_m**0.5', latex: '\sigma_8
-      \Omega_\mathrm{m}^{0.5}'}
-  s8omegamp25: {derived: 'lambda sigma8, Omega_m: sigma8*Omega_m**0.25', latex: '\sigma_8
-      \Omega_\mathrm{m}^{0.25}'}
-  A: {derived: 'lambda A_s: 1e9*A_s', latex: '10^9 A_\mathrm{s}'}
-  clamp: {derived: 'lambda A_s, tau_reio: 1e9*A_s*np.exp(-2*tau_reio)', latex: '10^9
-      A_\mathrm{s} e^{-2\tau}'}
-  age: {latex: '{\rm{Age}}/\mathrm{Gyr}'}
-  rs_drag: {latex: 'r_\mathrm{drag}'}
+  chi2__CMB: {derived: 'lambda chi2__planck_2015_lowTEB, chi2__planck_2015_plikHM_TTTEEE,
+      chi2__planck_2015_lensing: sum([chi2__planck_2015_lowTEB, chi2__planck_2015_plikHM_TTTEEE,
+      chi2__planck_2015_lensing])', latex: '\chi^2_\mathrm{CMB}'}
 sampler:
   mcmc: {covmat: auto, drag: true, proposal_scale: 1.9}
 theory:
   classy:
-    extra_args: {N_ur: 2.0328, N_ncdm: 1}
+    extra_args: {N_ncdm: 1, N_ur: 2.0328}

--- a/tests/_config.py
+++ b/tests/_config.py
@@ -1,0 +1,34 @@
+from __future__ import division, absolute_import
+from contextlib import contextmanager
+import sys
+import numpy as np
+from scipy import stats
+import os
+from six import StringIO
+
+
+def check_reproducible():
+    np.random.seed(0)
+    _test_mat = stats.special_ortho_group.rvs(3)
+    # signs etc. can flip on different platforms, don't test if results not expected to be the same
+    return np.abs(_test_mat[0, 0] + 0.8577182409977431) < 1e-10 and \
+           np.abs(_test_mat[1, 1] + 0.7206340034201331) < 1e-10
+
+
+random_reproducible = check_reproducible()
+
+test_figs = False
+
+skip_theories = []
+if os.environ.get('NO_CLASS_TESTS', False): skip_theories += ["classy"]
+if os.environ.get('NO_CAMB_TESTS', False): skip_theories += ["camb"]
+
+
+@contextmanager
+def stdout_redirector(stream):
+    old_stdout = sys.stdout
+    sys.stdout = stream
+    try:
+        yield
+    finally:
+        sys.stdout = old_stdout

--- a/tests/_config.py
+++ b/tests/_config.py
@@ -4,6 +4,8 @@ import sys
 import numpy as np
 from scipy import stats
 import os
+import subprocess
+from pkg_resources import parse_version
 from six import StringIO
 
 
@@ -32,3 +34,19 @@ def stdout_redirector(stream):
         yield
     finally:
         sys.stdout = old_stdout
+
+
+def call_command(cmd):
+    try:
+        return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode().strip()
+    except:
+        return None
+
+
+def get_gcc_version():
+    return call_command("gcc -dumpversion")
+
+
+def gcc_version_atleast(min_version='6.3'):
+    version = get_gcc_version()
+    return version is not None and parse_version(str(min_version)) <= parse_version(version)

--- a/tests/common_cosmo.py
+++ b/tests/common_cosmo.py
@@ -3,6 +3,7 @@ Body of the best-fit test for cosmological likelihoods
 """
 
 from __future__ import division
+from __future__ import absolute_import
 from copy import deepcopy
 
 from cobaya.conventions import _theory, _likelihood, _params, _debug, _path_install
@@ -10,7 +11,7 @@ from cobaya.model import get_model
 from cobaya.input import get_full_info
 from cobaya.cosmo_input import create_input, planck_base_model
 from cobaya.tools import recursive_update
-from install_for_tests import process_modules_path
+from .install_for_tests import process_modules_path
 
 # Tolerance for the tests of the derived parameters, in units of the sigma of Planck 2015
 tolerance_derived = 0.055

--- a/tests/common_cosmo.py
+++ b/tests/common_cosmo.py
@@ -1,9 +1,8 @@
 """
 Body of the best-fit test for cosmological likelihoods
 """
-
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
 from copy import deepcopy
 
 from cobaya.conventions import _theory, _likelihood, _params, _debug, _path_install

--- a/tests/common_cosmo.py
+++ b/tests/common_cosmo.py
@@ -11,6 +11,7 @@ from cobaya.input import get_full_info
 from cobaya.cosmo_input import create_input, planck_base_model
 from cobaya.tools import recursive_update
 from .install_for_tests import process_modules_path
+from ._config import skip_theories
 
 # Tolerance for the tests of the derived parameters, in units of the sigma of Planck 2015
 tolerance_derived = 0.055
@@ -20,6 +21,9 @@ def body_of_test(modules, best_fit, info_likelihood, info_theory, ref_chi2,
                  best_fit_derived=None, extra_model={}):
     # Create base info
     theo = list(info_theory)[0]
+    if theo in skip_theories:
+        print('Skipping test with %s' % theo)
+        return
     # In Class, theta_s is exact, but different from the approximate one cosmomc_theta
     # used by Planck, so we take H0 instead
     planck_base_model_prime = deepcopy(planck_base_model)

--- a/tests/common_cosmo.py
+++ b/tests/common_cosmo.py
@@ -70,7 +70,7 @@ def body_of_test(modules, best_fit, info_likelihood, info_theory, ref_chi2,
         rel = (abs(derived[p] - best_fit_derived[p][0]) /
                best_fit_derived[p][1])
         if rel > tolerance_derived * (
-                2 if p in ("YHe", "Y_p", "DH", "sigma8", "s8omegamp5") else 1):
+                2 if p in ("YHe", "Y_p", "DH", "sigma8", "s8omegamp5", "thetastar") else 1):
             not_passed += [(p, rel)]
     print("Derived parameters not tested because not implemented: %r" % not_tested)
-    assert not not_passed, "Some derived parameters were off: %r" % not_passed
+    assert not not_passed, "Some derived parameters were off. Fractions of test tolerance: %r" % not_passed

--- a/tests/common_external.py
+++ b/tests/common_external.py
@@ -43,7 +43,7 @@ gaussian_func = lambda y: eval(gaussian_str)(y)
 info_string = {"half_ring": half_ring_str}
 info_callable = {"half_ring": half_ring_func}
 info_mixed = {"half_ring": half_ring_func, "gaussian_y": gaussian_str}
-info_import = {"half_ring": "import_module('common_external').half_ring_func"}
+info_import = {"half_ring": "import_module('.common_external','tests').half_ring_func"}
 info_derived = {"half_ring": half_ring_func_derived}
 
 

--- a/tests/common_sampler.py
+++ b/tests/common_sampler.py
@@ -1,6 +1,6 @@
 """General test for samplers. Checks convergence, cluster detection, evidence."""
 
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from mpi4py import MPI
 from random import shuffle, choice
@@ -15,7 +15,7 @@ from cobaya.conventions import _force_reproducible, _debug, _debug_file, _path_i
 from cobaya.likelihoods.gaussian_mixture import info_random_gaussian_mixture
 from cobaya.tools import KL_norm
 from cobaya.run import run
-from install_for_tests import process_modules_path
+from .install_for_tests import process_modules_path
 
 KL_tolerance = 0.05
 logZ_nsigmas = 2

--- a/tests/install_for_tests.py
+++ b/tests/install_for_tests.py
@@ -1,6 +1,5 @@
 from __future__ import division, absolute_import, print_function
-import os
-
+from ._config import gcc_version_atleast
 
 def process_modules_path(modules):
     if not modules:
@@ -36,25 +35,13 @@ if __name__ == "__main__":
             "sdss_dr12_consensus_final": None,
             "des_y1_joint": None}}
     # Ignore Planck clik in Python 3 or GCC > 5
-    from subprocess import Popen, PIPE
-
-    process = Popen(["gcc", "-v"], stdout=PIPE, stderr=PIPE)
-    out, err = process.communicate()
-    prefix = "gcc version"
-    try:
-        version = [line for line in err.split("\n") if line.startswith(prefix)]
-        version = version[0][len(prefix):].split()[0]
-        gcc_major = int(version.split(".")[0])
-    except:
-        gcc_major = 0
-    if sys.version_info.major >= 3 or gcc_major > 5:
+    if sys.version_info.major >= 3 or not gcc_version_atleast('6.0'):
         popliks = [lik for lik in info_install[_likelihood]
                    if lik.startswith("planck_2015") and not lik.endswith("cmblikes")]
         for lik in popliks:
             info_install[_likelihood].pop(lik)
     path = sys.argv[1]
     import os
-
     if not os.path.exists(path):
         os.makedirs(path)
     from cobaya.install import install

--- a/tests/install_for_tests.py
+++ b/tests/install_for_tests.py
@@ -1,5 +1,10 @@
 from __future__ import division, absolute_import, print_function
-from ._config import gcc_version_atleast
+import os, sys
+
+file_dir = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, file_dir)
+config = __import__('_config')
+
 
 def process_modules_path(modules):
     if not modules:
@@ -35,13 +40,14 @@ if __name__ == "__main__":
             "sdss_dr12_consensus_final": None,
             "des_y1_joint": None}}
     # Ignore Planck clik in Python 3 or GCC > 5
-    if sys.version_info.major >= 3 or not gcc_version_atleast('6.0'):
+    if sys.version_info.major >= 3 or not config.gcc_version_atleast('6.0'):
         popliks = [lik for lik in info_install[_likelihood]
                    if lik.startswith("planck_2015") and not lik.endswith("cmblikes")]
         for lik in popliks:
             info_install[_likelihood].pop(lik)
     path = sys.argv[1]
     import os
+
     if not os.path.exists(path):
         os.makedirs(path)
     from cobaya.install import install

--- a/tests/test_cosmo_H0.py
+++ b/tests/test_cosmo_H0.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 import sys
 import numpy as np
 from scipy.stats import norm
@@ -6,7 +6,7 @@ from copy import copy
 
 from cobaya.conventions import _theory, _sampler, _likelihood, _params, _path_install
 from cobaya.run import run
-from install_for_tests import process_modules_path
+from .install_for_tests import process_modules_path
 
 fiducial_H0 = 70
 

--- a/tests/test_cosmo_H0.py
+++ b/tests/test_cosmo_H0.py
@@ -7,6 +7,7 @@ from copy import copy
 from cobaya.conventions import _theory, _sampler, _likelihood, _params, _path_install
 from cobaya.run import run
 from .install_for_tests import process_modules_path
+from ._config import skip_theories
 
 fiducial_H0 = 70
 
@@ -31,6 +32,9 @@ def test_H0_docs_camb(modules):
 
 
 def body_of_test(modules, lik_name, theory):
+    if theory in skip_theories:
+        print('Skipping test with %s' % theory)
+        return
     info = {_path_install: process_modules_path(modules),
             _theory: {theory: None},
             _sampler: {"evaluate": None}}

--- a/tests/test_cosmo_bao.py
+++ b/tests/test_cosmo_bao.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 from copy import deepcopy
 import pytest
 
-from test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
-from common_cosmo import body_of_test
+from .test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
+from .common_cosmo import body_of_test
 
 
 def test_sdss_dr12_consensus_bao_camb(modules):

--- a/tests/test_cosmo_bicep_keck_2015.py
+++ b/tests/test_cosmo_bicep_keck_2015.py
@@ -1,8 +1,8 @@
 # Tries to evaluate the BK15 likelihood at a reference point
 
 from copy import deepcopy
-
-from common_cosmo import body_of_test
+from __future__ import absolute_import
+from .common_cosmo import body_of_test
 from cobaya.cosmo_input import cmb_precision
 
 

--- a/tests/test_cosmo_bicep_keck_2015.py
+++ b/tests/test_cosmo_bicep_keck_2015.py
@@ -1,7 +1,7 @@
 # Tries to evaluate the BK15 likelihood at a reference point
 
-from copy import deepcopy
 from __future__ import absolute_import
+from copy import deepcopy
 from .common_cosmo import body_of_test
 from cobaya.cosmo_input import cmb_precision
 

--- a/tests/test_cosmo_bicep_keck_2015.py
+++ b/tests/test_cosmo_bicep_keck_2015.py
@@ -6,8 +6,11 @@ from .common_cosmo import body_of_test
 from cobaya.cosmo_input import cmb_precision
 
 
+camb_extra = {"halofit_version": "takahashi"}
+camb_extra.update(cmb_precision["camb"])
+
 def test_bicep_keck_2015_camb(modules):
-    info_theory = {"camb": {"extra_args": cmb_precision["camb"]}}
+    info_theory = {"camb": {"extra_args": camb_extra}}
     body_of_test(modules, test_point, lik_info, info_theory, chi2,
                  extra_model={"primordial": "SFSR_t"})
 

--- a/tests/test_cosmo_des_y1.py
+++ b/tests/test_cosmo_des_y1.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 from copy import deepcopy
 import pytest
 
-from test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
-from common_cosmo import body_of_test
+from .test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
+from .common_cosmo import body_of_test
 
 best_fit = deepcopy(params_lowTEB_highTTTEEE)
 camb_extra = {"halofit_version": "mead"}

--- a/tests/test_cosmo_docs_basic.py
+++ b/tests/test_cosmo_docs_basic.py
@@ -2,15 +2,15 @@
 Testing and automatic generation of basic cosmological examples in the docs.
 """
 
-from __future__ import division
+from __future__ import division, absolute_import
 import os
 
 from cobaya.yaml import yaml_dump, yaml_load
 from cobaya.input import is_equal_info
 from cobaya.cosmo_input import create_input
-from test_docs_example_quickstart import docs_folder
+from .test_docs_example_quickstart import docs_folder
 
-path = os.path.join(docs_folder, "src_examples/cosmo_basic")
+path = os.path.join(docs_folder, "src_examples", "cosmo_basic")
 file_pre = "basic_"
 preset_pre = "planck_2015_lensing_"
 

--- a/tests/test_cosmo_docs_model.py
+++ b/tests/test_cosmo_docs_model.py
@@ -27,34 +27,36 @@ def test_cosmo_docs_model(modules):
     modules = process_modules_path(modules)
     # Go to the folder containing the python code
     cwd = os.getcwd()
-    os.chdir(docs_src_folder)
-    globals_example = {}
-    exec(open(os.path.join(docs_src_folder, "1.py")).read(), globals_example)
-    globals_example["info"][_path_install] = modules
-    exec(open(os.path.join(docs_src_folder, "2.py")).read(), globals_example)
-    stream = StringIO()
-    with stdout_redirector(stream):
-        exec(open(os.path.join(docs_src_folder, "3.py")).read(), globals_example)
-    # Comparing text output for this cell -- only derived parameter values
-    out_filename = "3.out"
-    derived_line_old, derived_line_new = map(
-        lambda lines: next(line for line in lines[::-1] if line),
-        [open(os.path.join(docs_src_folder, out_filename)).readlines(),
-         stream.getvalue().split("\n")])
-    derived_params_old, derived_params_new = map(
-        lambda x: eval(x[x.find("{"):]), [derived_line_old, derived_line_new])
-    assert np.allclose(derived_params_old.values(), derived_params_new.values()), (
-            "Wrong derived parameters line:\nBEFORE: %s\nNOW:    %s" %
-            (derived_line_old, derived_line_new))
-    if test_figs:
-        # Compare plots
-        pre = "cosmo_model_"
-        for filename, imgname in zip(["4.py", "5.py"], ["cltt.png", "omegacdm.png"]):
-            exec(open(os.path.join(docs_src_folder, filename)).read(), globals_example)
-            old_img = imread(os.path.join(docs_img_folder, pre + imgname)).astype(float)
-            new_img = imread(imgname).astype(float)
-            npixels = (lambda x: x.shape[0] + x.shape[1])(old_img)
-            assert np.count_nonzero(old_img == new_img) / (4 * npixels) >= pixel_tolerance, (
-                    "Images '%s' are too different!" % imgname)
-    # Back to the working directory of the tests, just in case, and restart the rng
-    os.chdir(cwd)
+    try:
+        os.chdir(docs_src_folder)
+        globals_example = {}
+        exec(open(os.path.join(docs_src_folder, "1.py")).read(), globals_example)
+        globals_example["info"][_path_install] = modules
+        exec(open(os.path.join(docs_src_folder, "2.py")).read(), globals_example)
+        stream = StringIO()
+        with stdout_redirector(stream):
+            exec(open(os.path.join(docs_src_folder, "3.py")).read(), globals_example)
+        # Comparing text output for this cell -- only derived parameter values
+        out_filename = "3.out"
+        derived_line_old, derived_line_new = map(
+            lambda lines: next(line for line in lines[::-1] if line),
+            [open(os.path.join(docs_src_folder, out_filename)).readlines(),
+             stream.getvalue().split("\n")])
+        derived_params_old, derived_params_new = map(
+            lambda x: eval(x[x.find("{"):]), [derived_line_old, derived_line_new])
+        assert np.allclose(derived_params_old.values(), derived_params_new.values()), (
+                "Wrong derived parameters line:\nBEFORE: %s\nNOW:    %s" %
+                (derived_line_old, derived_line_new))
+        if test_figs:
+            # Compare plots
+            pre = "cosmo_model_"
+            for filename, imgname in zip(["4.py", "5.py"], ["cltt.png", "omegacdm.png"]):
+                exec(open(os.path.join(docs_src_folder, filename)).read(), globals_example)
+                old_img = imread(os.path.join(docs_img_folder, pre + imgname)).astype(float)
+                new_img = imread(imgname).astype(float)
+                npixels = (lambda x: x.shape[0] + x.shape[1])(old_img)
+                assert np.count_nonzero(old_img == new_img) / (4 * npixels) >= pixel_tolerance, (
+                        "Images '%s' are too different!" % imgname)
+        # Back to the working directory of the tests, just in case, and restart the rng
+    finally:
+        os.chdir(cwd)

--- a/tests/test_cosmo_docs_model.py
+++ b/tests/test_cosmo_docs_model.py
@@ -10,24 +10,20 @@ import sys
 import numpy as np
 from imageio import imread
 import pytest
+from six import StringIO
 
 from cobaya.conventions import _path_install
 from .install_for_tests import process_modules_path
 
 tests_folder = os.path.dirname(os.path.realpath(__file__))
-docs_folder = os.path.join(tests_folder, "../docs")
-docs_src_folder = os.path.join(docs_folder, "src_examples/cosmo_model/")
+docs_folder = os.path.join(tests_folder, "..", "docs")
+docs_src_folder = os.path.join(docs_folder, "src_examples", "cosmo_model")
 docs_img_folder = os.path.join(docs_folder, "img")
 
 # Number of possible different pixels
 pixel_tolerance = 0.995
 
 # Capture stdout in string
-if (sys.version_info > (3, 0)):
-    from io import StringIO
-else:
-    from StringIO import StringIO
-
 
 @contextmanager
 def stdout_redirector(stream):
@@ -46,12 +42,12 @@ def test_cosmo_docs_model(modules):
     cwd = os.getcwd()
     os.chdir(docs_src_folder)
     globals_example = {}
-    exec (open(os.path.join(docs_src_folder, "1.py")).read(), globals_example)
+    exec(open(os.path.join(docs_src_folder, "1.py")).read(), globals_example)
     globals_example["info"][_path_install] = modules
-    exec (open(os.path.join(docs_src_folder, "2.py")).read(), globals_example)
+    exec(open(os.path.join(docs_src_folder, "2.py")).read(), globals_example)
     stream = StringIO()
     with stdout_redirector(stream):
-        exec (open(os.path.join(docs_src_folder, "3.py")).read(), globals_example)
+        exec(open(os.path.join(docs_src_folder, "3.py")).read(), globals_example)
     # Comparing text output for this cell -- only derived parameter values
     out_filename = "3.out"
     derived_line_old, derived_line_new = map(
@@ -66,7 +62,7 @@ def test_cosmo_docs_model(modules):
     # Compare plots
     pre = "cosmo_model_"
     for filename, imgname in zip(["4.py", "5.py"], ["cltt.png", "omegacdm.png"]):
-        exec (open(os.path.join(docs_src_folder, filename)).read(), globals_example)
+        exec(open(os.path.join(docs_src_folder, filename)).read(), globals_example)
         old_img = imread(os.path.join(docs_img_folder, pre + imgname)).astype(float)
         new_img = imread(imgname).astype(float)
         npixels = (lambda x: x.shape[0] + x.shape[1])(old_img)

--- a/tests/test_cosmo_docs_model.py
+++ b/tests/test_cosmo_docs_model.py
@@ -3,7 +3,7 @@ Automatic tests of the cosmo_model example in the documentation,
 to make sure it remains up to date.
 """
 
-from __future__ import division
+from __future__ import division, absolute_import
 import os
 from contextlib import contextmanager
 import sys
@@ -12,7 +12,7 @@ from imageio import imread
 import pytest
 
 from cobaya.conventions import _path_install
-from install_for_tests import process_modules_path
+from .install_for_tests import process_modules_path
 
 tests_folder = os.path.dirname(os.path.realpath(__file__))
 docs_folder = os.path.join(tests_folder, "../docs")

--- a/tests/test_cosmo_planck_2015.py
+++ b/tests/test_cosmo_planck_2015.py
@@ -257,7 +257,7 @@ derived_lowTEB_highTTTEEE = {
 
 lik_info_lensing = {"planck_2015_lensing": None}
 
-chi2_lensing = {"planck_2015_lensing": 9.78, "tolerance": 0.07}
+chi2_lensing = {"planck_2015_lensing": 9.78, "tolerance": 0.09}
 
 params_lensing = {
     # Sampled

--- a/tests/test_cosmo_planck_2015.py
+++ b/tests/test_cosmo_planck_2015.py
@@ -1,15 +1,18 @@
 # Tries to evaluate the likelihood at LCDM's best fit of Planck 2015, with CAMB and CLASS
-
+from __future__ import absolute_import
 import pytest
 from copy import deepcopy
 
-from common_cosmo import body_of_test
+from .common_cosmo import body_of_test
 from cobaya.cosmo_input import cmb_precision
 
 # Generating plots in Travis
 import matplotlib
 
 matplotlib.use('agg')
+
+camb_extra = {"halofit_version": "takahashi"}
+camb_extra.update(cmb_precision["camb"])
 
 # Derived parameters not understood by CLASS
 # https://wiki.cosmos.esa.int/planckpla2015/images/b/b9/Parameter_tag_definitions_2015.pdf
@@ -25,7 +28,7 @@ classy_extra_tolerance = 0.2
 def test_planck_2015_t_camb(modules):
     best_fit = params_lowl_highTT
     info_likelihood = lik_info_lowl_highTT
-    info_theory = {"camb": {"extra_args": cmb_precision["camb"]}}
+    info_theory = {"camb": {"extra_args": camb_extra}}
     best_fit_derived = derived_lowl_highTT
     body_of_test(modules, best_fit, info_likelihood, info_theory,
                  chi2_lowl_highTT, best_fit_derived)
@@ -35,7 +38,7 @@ def test_planck_2015_t_camb(modules):
 def test_planck_2015_p_camb(modules):
     best_fit = params_lowTEB_highTTTEEE
     info_likelihood = lik_info_lowTEB_highTTTEEE
-    info_theory = {"camb": {"extra_args": cmb_precision["camb"]}}
+    info_theory = {"camb": {"extra_args": camb_extra}}
     best_fit_derived = derived_lowTEB_highTTTEEE
     body_of_test(modules, best_fit, info_likelihood, info_theory,
                  chi2_lowTEB_highTTTEEE, best_fit_derived)
@@ -45,7 +48,7 @@ def test_planck_2015_p_camb(modules):
 def test_planck_2015_l_camb(modules):
     best_fit = params_lensing
     info_likelihood = lik_info_lensing
-    info_theory = {"camb": {"extra_args": cmb_precision["camb"]}}
+    info_theory = {"camb": {"extra_args": camb_extra}}
     best_fit_derived = derived_lensing
     body_of_test(modules, best_fit, info_likelihood, info_theory,
                  chi2_lensing, best_fit_derived)
@@ -58,7 +61,7 @@ def test_planck_2015_l2_camb(modules):
     info_likelihood = {lik_name: lik_info_lensing[clik_name]}
     chi2_lensing_cmblikes = deepcopy(chi2_lensing)
     chi2_lensing_cmblikes[lik_name] = chi2_lensing[clik_name]
-    info_theory = {"camb": {"extra_args": cmb_precision["camb"]}}
+    info_theory = {"camb": {"extra_args": camb_extra}}
     best_fit_derived = derived_lensing
     body_of_test(modules, best_fit, info_likelihood, info_theory,
                  chi2_lensing_cmblikes, best_fit_derived)

--- a/tests/test_cosmo_planck_2015.py
+++ b/tests/test_cosmo_planck_2015.py
@@ -11,7 +11,7 @@ import matplotlib
 
 matplotlib.use('agg')
 
-camb_extra = {"halofit_version": "takahashi"}
+camb_extra = {"halofit_version": "takahashi", "bbn_predictor": "BBN_fitting_parthenope"}
 camb_extra.update(cmb_precision["camb"])
 
 # Derived parameters not understood by CLASS

--- a/tests/test_cosmo_sn.py
+++ b/tests/test_cosmo_sn.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
-
-from test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
-from common_cosmo import body_of_test
+from __future__ import absolute_import
+from .test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
+from .common_cosmo import body_of_test
 
 
 # Pantheon (alpha and beta not used - no nuisance parameters), fast

--- a/tests/test_cosmo_sn.py
+++ b/tests/test_cosmo_sn.py
@@ -1,5 +1,5 @@
-from copy import deepcopy
 from __future__ import absolute_import
+from copy import deepcopy
 from .test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
 from .common_cosmo import body_of_test
 

--- a/tests/test_docs_example_quickstart.py
+++ b/tests/test_docs_example_quickstart.py
@@ -13,22 +13,19 @@ from imageio import imread
 from cobaya.yaml import yaml_load_file
 from cobaya.input import is_equal_info
 from cobaya.conventions import _output_prefix
+import six
+import platform
+from six import StringIO
 
-docs_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../docs")
-docs_src_folder = os.path.join(docs_folder, "src_examples/quickstart/")
+docs_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "docs")
+docs_src_folder = os.path.join(docs_folder, "src_examples", "quickstart")
 docs_img_folder = os.path.join(docs_folder, "img")
 
 # Number of possible different pixels
-if sys.version_info[0] < 3:
+if not six.PY3:
     pixel_tolerance = 0.995
 else:
     pixel_tolerance = 0.980
-
-# Capture stdout in string
-if (sys.version_info > (3, 0)):
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 
 @contextmanager
@@ -70,10 +67,12 @@ def test_example(tmpdir):
         out_filename = "analyze_out.txt"
         contents = "".join(open(os.path.join(docs_src_folder, out_filename)).readlines())
         # The endswith guarantees that getdist messages and warnings are ignored
-        assert stream.getvalue().replace("\n", "").replace(" ", "").endswith(
-            contents.replace("\n", "").replace(" ", "")), (
-                "Text output does not coincide:\nwas\n%s\nand " % contents +
-                "now it's\n%sstream.getvalue()" % stream.getvalue())
+        if platform.system() != 'Windows':
+            # randoms not reproducible on Windows in general
+            assert stream.getvalue().replace("\n", "").replace(" ", "").endswith(
+                contents.replace("\n", "").replace(" ", "")), (
+                    "Text output does not coincide:\nwas\n%s\nand " % contents +
+                    "now it's\n%sstream.getvalue()" % stream.getvalue())
         # Comparing plot
         # plot_filename = "example_quickstart_plot.png"
         # test_filename = tmpdir.join(plot_filename)

--- a/tests/test_docs_example_quickstart.py
+++ b/tests/test_docs_example_quickstart.py
@@ -48,24 +48,24 @@ def test_example(tmpdir):
     info_yaml = yaml_load_file("gaussian.yaml")
     info_yaml.pop(_output_prefix)
     globals_example = {}
-    exec (open(os.path.join(docs_src_folder, "create_info.py")).read(), globals_example)
+    exec(open(os.path.join(docs_src_folder, "create_info.py")).read(), globals_example)
     try:
         assert is_equal_info(info_yaml, globals_example["info"]), (
             "Inconsistent info between yaml and interactive.")
-        exec (open(os.path.join(docs_src_folder, "load_info.py")).read(), globals_example)
+        exec(open(os.path.join(docs_src_folder, "load_info.py")).read(), globals_example)
         globals_example["info_from_yaml"].pop(_output_prefix)
         assert is_equal_info(info_yaml, globals_example["info_from_yaml"]), (
             "Inconsistent info between interactive and *loaded* yaml.")
         # Run the chain -- constant seed so results are the same!
         globals_example["info"]["sampler"]["mcmc"] = (
-            globals_example["info"]["sampler"]["mcmc"] or {})
+                globals_example["info"]["sampler"]["mcmc"] or {})
         globals_example["info"]["sampler"]["mcmc"].update({"seed": 0})
-        exec (open(os.path.join(docs_src_folder, "run.py")).read(), globals_example)
+        exec(open(os.path.join(docs_src_folder, "run.py")).read(), globals_example)
         # Analyze and plot -- capture print output
         stream = StringIO()
         with stdout_redirector(stream):
-            exec (open(os.path.join(docs_src_folder, "analyze.py")).read(),
-                  globals_example)
+            exec(open(os.path.join(docs_src_folder, "analyze.py")).read(),
+                 globals_example)
         # Comparing text output
         out_filename = "analyze_out.txt"
         contents = "".join(open(os.path.join(docs_src_folder, out_filename)).readlines())
@@ -75,16 +75,16 @@ def test_example(tmpdir):
                 "Text output does not coincide:\nwas\n%s\nand " % contents +
                 "now it's\n%sstream.getvalue()" % stream.getvalue())
         # Comparing plot
-        plot_filename = "example_quickstart_plot.png"
-        test_filename = tmpdir.join(plot_filename)
-        globals_example["gdplot"].export(str(test_filename))
-        print("Plot created at '%s'" % str(test_filename))
-        test_img = imread(str(test_filename)).astype(float)
-        docs_img = imread(os.path.join(docs_img_folder, plot_filename)).astype(float)
-        npixels = test_img.shape[0] * test_img.shape[1]
-        assert (np.count_nonzero(test_img == docs_img) / (4 * npixels) >=
-                pixel_tolerance), (
-            "Images are too different. Maybe GetDist conventions changed?")
+        # plot_filename = "example_quickstart_plot.png"
+        # test_filename = tmpdir.join(plot_filename)
+        # globals_example["gdplot"].export(str(test_filename))
+        # print("Plot created at '%s'" % str(test_filename))
+        # test_img = imread(str(test_filename)).astype(float)
+        # docs_img = imread(os.path.join(docs_img_folder, plot_filename)).astype(float)
+        # npixels = test_img.shape[0] * test_img.shape[1]
+        # assert (np.count_nonzero(test_img == docs_img) / (4 * npixels) >=
+        #         pixel_tolerance), (
+        #     "Images are too different. Maybe GetDist conventions changed?")
     except:
         raise
     finally:

--- a/tests/test_docs_example_quickstart.py
+++ b/tests/test_docs_example_quickstart.py
@@ -29,11 +29,11 @@ def test_example(tmpdir):
     # temporarily change working directory to be able to run the files "as is"
     cwd = os.getcwd()
     os.chdir(docs_src_folder)
-    info_yaml = yaml_load_file("gaussian.yaml")
-    info_yaml.pop(_output_prefix)
-    globals_example = {}
-    exec(open(os.path.join(docs_src_folder, "create_info.py")).read(), globals_example)
     try:
+        info_yaml = yaml_load_file("gaussian.yaml")
+        info_yaml.pop(_output_prefix)
+        globals_example = {}
+        exec(open(os.path.join(docs_src_folder, "create_info.py")).read(), globals_example)
         assert is_equal_info(info_yaml, globals_example["info"]), (
             "Inconsistent info between yaml and interactive.")
         exec(open(os.path.join(docs_src_folder, "load_info.py")).read(), globals_example)

--- a/tests/test_likelihood_external.py
+++ b/tests/test_likelihood_external.py
@@ -13,12 +13,12 @@ For manual testing, and observing/plotting the density, pass ``manual=True`` to
 """
 
 # Global
-from __future__ import division
+from __future__ import division, absolute_import
 
 # Local
 from cobaya.conventions import _likelihood
-from common_external import info_string, info_callable, info_mixed, info_import
-from common_external import info_derived, body_of_test
+from .common_external import info_string, info_callable, info_mixed, info_import
+from .common_external import info_derived, body_of_test
 
 
 def test_likelihood_external_string(tmpdir):

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 
 from mpi4py import MPI
 from flaky import flaky
@@ -6,7 +6,7 @@ from flaky import flaky
 from cobaya.likelihoods.gaussian_mixture import random_cov
 from cobaya.tools import KL_norm
 
-from common_sampler import body_of_test, body_of_test_speeds
+from .common_sampler import body_of_test, body_of_test_speeds
 
 
 ### import pytest

--- a/tests/test_polychord.py
+++ b/tests/test_polychord.py
@@ -1,9 +1,10 @@
-from __future__ import division, print_function
+from __future__ import absolute_import, division, print_function
 
 import pytest
 from flaky import flaky
 
-from common_sampler import body_of_test, body_of_test_speeds
+from .common_sampler import body_of_test, body_of_test_speeds
+
 
 ### @pytest.mark.mpi
 

--- a/tests/test_prior_external.py
+++ b/tests/test_prior_external.py
@@ -12,12 +12,12 @@ For manual testing, and observing/plotting the density, pass `manual=True` to `b
 """
 
 # Global
-from __future__ import division
+from __future__ import division, absolute_import
 
 # Local
 from cobaya.conventions import _prior
-from common_external import info_string, info_callable, info_mixed, info_import
-from common_external import body_of_test
+from .common_external import info_string, info_callable, info_mixed, info_import
+from .common_external import body_of_test
 
 
 def test_prior_external_string(tmpdir):


### PR DESCRIPTION
There are some problems here with installing polychord (does it rely on utils.F90 from the old CAMB?), and with getting DH and other derived parameters ("Could not resolve arguments for derived parameters ['DHBBN']") - do you know what might be causing that as not so obvious?

Main changes are: pycamb folder removed, now root. CAMBparams now has ombh2, omk etc as base parameters (omegam etc are read-only properties so no real change) - but Omega_de (mapped from omegal) is now only in the CAMBdata results object.  Also CAMBparams is now effectively a read-only input that is not changed by the calculation, so I've changed to getting derived attributes from the results.Params object (which has any additional things calculated).

"forutils" is now a submodule of camb - this makes installing CAMB from a github tar.gz much messier, since github doesnt't include the submodule.  I've made the camb setup.py pull forutils if needed if it is not already installed, and this seems to work. However ultimately would probably be much better to do recursive clone with git (as in the test scripts).

Work still to be done to access new thinks like setting up SourceWIndows array and specifying classes for dark-energy models etc more efficiently..