### PR TITLE
change default logzero from `np.nan_to_num(-np.inf)` to `-1e300`

### DIFF
--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -69,7 +69,7 @@ class polychord(Sampler):
         self.nDerived = (len(self.model.parameterization.derived_params()) +
                          len(self.model.prior) + len(self.model.likelihood._likelihoods))
         if self.logzero is None:
-            self.logzero = np.nan_to_num(-np.inf)
+            self.logzero = -1e300
         if self.max_ndead == np.inf:
             self.max_ndead = -1
         for p in ["nlive", "num_repeats", "nprior", "max_ndead"]:

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -69,7 +69,7 @@ class polychord(Sampler):
         self.nDerived = (len(self.model.parameterization.derived_params()) +
                          len(self.model.prior) + len(self.model.likelihood._likelihoods))
         if self.logzero is None:
-            self.logzero = -1e30
+            self.logzero = np.nan_to_num(-np.inf)
         if self.max_ndead == np.inf:
             self.max_ndead = -1
         for p in ["nlive", "num_repeats", "nprior", "max_ndead"]:

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -69,7 +69,7 @@ class polychord(Sampler):
         self.nDerived = (len(self.model.parameterization.derived_params()) +
                          len(self.model.prior) + len(self.model.likelihood._likelihoods))
         if self.logzero is None:
-            self.logzero = -1e300
+            self.logzero = -1e30
         if self.max_ndead == np.inf:
             self.max_ndead = -1
         for p in ["nlive", "num_repeats", "nprior", "max_ndead"]:

--- a/cobaya/samplers/polychord/polychord.yaml
+++ b/cobaya/samplers/polychord/polychord.yaml
@@ -27,7 +27,7 @@ sampler:
     # Callback function -- see documentation
     callback_function:
     # Numerical value of log(0) in PolyChord's Fortran code
-    logzero: null  # default: result of `numpy.nan_to_num(-numpy.inf)`
+    logzero: null  # default: -1e300
     # Increase number of posterior samples
     boost_posterior: 0  # increase up to `num_repeats`
     # Verbosity during the sampling process. Set to one of [0,1,2,3]

--- a/cobaya/samplers/polychord/polychord.yaml
+++ b/cobaya/samplers/polychord/polychord.yaml
@@ -26,8 +26,9 @@ sampler:
     compression_factor: 0.36787944117144233  # = exp(-1)
     # Callback function -- see documentation
     callback_function:
-    # Numerical value of log(0) in PolyChord's Fortran code
-    logzero: null  # default: -1e30
+    # Numerical value of log(0) sent to PolyChord's Fortran code
+    # If null: `numpy.nan_to_num(-numpy.inf)` (produces an error in `ifort`!)
+    logzero: -1e300  # safer
     # Increase number of posterior samples
     boost_posterior: 0  # increase up to `num_repeats`
     # Verbosity during the sampling process. Set to one of [0,1,2,3]

--- a/cobaya/samplers/polychord/polychord.yaml
+++ b/cobaya/samplers/polychord/polychord.yaml
@@ -27,7 +27,7 @@ sampler:
     # Callback function -- see documentation
     callback_function:
     # Numerical value of log(0) in PolyChord's Fortran code
-    logzero: null  # default: -1e300
+    logzero: null  # default: -1e30
     # Increase number of posterior samples
     boost_posterior: 0  # increase up to `num_repeats`
     # Verbosity during the sampling process. Set to one of [0,1,2,3]


### PR DESCRIPTION
fixes #39 

The issue was that reading PolyChord's resume files didn't work with an intel compiler. 

This PR changes the default for PolyChord's `logzero` from `np.nan_to_num(-np.inf)` to `-1e300`. 

Files changed:
* `cobaya/samplers/polychord/polychord.py`: changed default value
* `cobaya/samplers/polychord/polychord.yaml`: changed documentation to reflect new default

