### PR TITLE
Timing and CobayaComponent refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,16 +39,13 @@ matrix:
         - PYVER="2"
       python: "2.7"
     - name: "Typical scenario: latest Ubuntu LTS"
+      dist: bionic
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
-            - gcc-7
-            - gfortran-7
-            - g++-7
+            - gfortran
       env:
-        - GCC_VERSION="7"
+        - GCC_VERSION="bionic"
         - PYVER="3"
       python: "3.6"
     - name: "Edge scenario: gcc-8, Python 3.7 with Anaconda"
@@ -84,11 +81,13 @@ matrix:
 
 before_install:
   # Configure right compilers version
-  - mkdir -p gcc-symlinks ;
-    ln -s /usr/bin/gfortran-$GCC_VERSION gcc-symlinks/gfortran ;
-    ln -s /usr/bin/gcc-$GCC_VERSION gcc-symlinks/gcc ;
-    ln -s /usr/bin/g++-$GCC_VERSION gcc-symlinks/g++ ;
-    export PATH=$PWD/gcc-symlinks:$PATH ;
+  - if [[ "$GCC_VERSION" != "bionic" ]]; then
+      mkdir -p gcc-symlinks;
+      ln -s /usr/bin/gfortran-$GCC_VERSION gcc-symlinks/gfortran;
+      ln -s /usr/bin/gcc-$GCC_VERSION gcc-symlinks/gcc;
+      ln -s /usr/bin/g++-$GCC_VERSION gcc-symlinks/g++;
+      export PATH=$PWD/gcc-symlinks:$PATH;
+    fi
   - gfortran --version
   # Install rest of system requisites
   - sudo apt install openmpi-bin openmpi-common libopenmpi-dev libopenblas-dev liblapack-dev
@@ -124,6 +123,14 @@ script:
       python $MODULES/code/CAMB/setup.py build ;
     fi
   - pytest tests/ -v -s -k "cosmo" --modules=$MODULES --boxed
+  - python $MODULES/code/CAMB/setup.py install
+  - git clone --depth=1 https://github.com/CobayaSampler/planck_lensing_external
+  - python planck_lensing_external/setup.py install
+  - python planck_lensing_external/setup.py test
+  - git clone --depth=1 https://github.com/CobayaSampler/example_external_likelihood
+  - python example_external_likelihood/setup.py install
+  - python example_external_likelihood/setup.py test
+
 ###############################################################################
 deploy: # only if it builds and if the commit has been tagged
   provider: pypi
@@ -133,7 +140,6 @@ deploy: # only if it builds and if the commit has been tagged
   on:
     tags: true
     python: '3.6'
-    condition: "$GCC_VERSION = 7"
     branch: master
     repo: CobayaSampler/cobaya
 ###############################################################################

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -27,7 +27,7 @@ modification) and re-licensed from the more liberally licensed
 CosmoMC (https://github.com/cmbant/CosmoMC):
 
 - mcmc.py and proposal.py
-- _sn_prototype.py, _cmblikes_prototype.py , _bao_prototype
+- _sn_prototype.py, _cmblikes.pyototype
 - most of the files under grid_tools/
 
 

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -27,7 +27,7 @@ modification) and re-licensed from the more liberally licensed
 CosmoMC (https://github.com/cmbant/CosmoMC):
 
 - mcmc.py and proposal.py
-- _sn_prototype.py, _cmblikes.pyototype
+- _sn_prototype.py, _CMBlikes
 - most of the files under grid_tools/
 
 

--- a/cobaya/__init__.py
+++ b/cobaya/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Jesus Torrado and Antony Lewis"
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 __obsolete__ = False
 __year__ = "2019"
 __url__ = "https://cobaya.readthedocs.io"

--- a/cobaya/__init__.py
+++ b/cobaya/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Jesus Torrado and Antony Lewis"
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 __obsolete__ = False
 __year__ = "2019"
 __url__ = "https://cobaya.readthedocs.io"

--- a/cobaya/bib.py
+++ b/cobaya/bib.py
@@ -28,12 +28,7 @@ _default_length = 80
 def get_bib_module(module, kind):
     cls = get_class(module, kind, None_if_not_found=True)
     if cls:
-        filename = cls.get_bibtex_file()
-        if filename:
-            with open(filename, "r") as f:
-                lines = "".join(f.readlines())
-        else:
-            lines = "[no bibliography information found]"
+        lines = cls.get_bibtex() or "[no bibliography information found]"
     else:
         lines = "[Module '%s.%s' not known.]" % (kind, module)
     return lines + "\n"

--- a/cobaya/collection.py
+++ b/cobaya/collection.py
@@ -17,7 +17,6 @@ import six
 
 # Global
 import os
-from copy import deepcopy
 import logging
 import numpy as np
 import pandas as pd
@@ -137,7 +136,7 @@ class Collection(HasLogger):
             except ValueError:
                 raise LoggedError(
                     self.log, "If a log-posterior is not specified, you need to pass "
-                    "a log-likelihood and a log-prior.")
+                              "a log-likelihood and a log-prior.")
         self.data.at[self._n, _minuslogpost] = -logpost
         if logpriors is not None:
             for name, value in zip(self.minuslogprior_names, logpriors):

--- a/cobaya/collection.py
+++ b/cobaya/collection.py
@@ -67,7 +67,7 @@ class Collection(HasLogger):
                  initial_size=enlargement_size, name=None, extension=None, file_name=None,
                  resuming=False, load=False, onload_skip=0, onload_thin=1):
         self.name = name
-        self.set_logger()
+        self.set_logger(name)
         self.sampled_params = list(model.parameterization.sampled_params())
         self.derived_params = list(model.parameterization.derived_params())
         self.minuslogprior_names = [

--- a/cobaya/component.py
+++ b/cobaya/component.py
@@ -1,0 +1,73 @@
+from cobaya.log import HasLogger
+from cobaya.input import HasDefaults
+import numpy as np
+import time
+
+
+class Timer(object):
+    def __init__(self):
+        self.n = 0
+        self.time_avg = 0
+        self.time_sqsum = 0
+        self.time_std = np.inf  # not actually used?
+        self._start = None
+        self._time_func = getattr(time, "perf_counter", time.time)
+
+    def start(self):
+        self._start = self._time_func()
+
+    def increment(self, logger=None):
+        delta_time = self._time_func() - self._start
+        self.n += 1
+        # TODO: Protect against caching in first call by discarding first time
+        # if too different from second one (maybe check difference in log10 > 1)
+        # In that case, take into account that #timed_evals is now (self.n - 1)
+        if logger and self.n == 2:
+            if delta_time:
+                log10diff = np.log10(self.time_avg / delta_time)
+                if log10diff > 1:
+                    logger.warning(
+                        "It seems the first call has done some caching (difference "
+                        " of a factor %g). Average timing will not be reliable "
+                        "unless many evaluations are carried out.", 10 ** log10diff)
+            else:
+                logger.warning("Timing returning zero, may be inaccurate. First call may have done some caching.")
+        self.time_avg = (delta_time + self.time_avg * (self.n - 1)) / self.n
+        self.time_sqsum += delta_time ** 2
+        if self.n > 1:
+            self.time_std = np.sqrt((self.time_sqsum - self.n * self.time_avg ** 2) / (self.n - 1))
+        if logger:
+            logger.debug("Average evaluation time: %g s", self.time_avg)
+
+
+class CobayaComponent(HasLogger, HasDefaults):
+
+    def __init__(self, info={}, name=None, timing=None, path_install=None):
+        self.name = name or self.get_qualified_class_name()
+        self.path_install = path_install
+        # Load info of the sampler
+        for k in info:
+            setattr(self, k, info[k])
+        self.set_logger(name=self.name)
+        if timing:
+            self.timer = Timer()
+        else:
+            self.timer = None
+
+    # Optional
+    def close(self):
+        """Finalizes the class, if something needs to be cleaned up."""
+        pass
+
+    # Optional
+    def initialize(self):
+        """
+        Initializes the class.
+        """
+        pass
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        if self.timer:
+            self.log.info("Average evaluation time for %s: %g s  (%d evaluations)" % (
+                self.name, self.timer.time_avg, self.timer.n))
+        self.close()

--- a/cobaya/containers.py
+++ b/cobaya/containers.py
@@ -60,7 +60,6 @@ RUN mkdir $%s && \
     mkdir $COBAYA_PRODUCTS
 # COBAYA  --------------------------------------------------------------------
 # getdist fork (it will be an automatic requisite in the future)
-RUN pip install git+https://github.com/JesusTorrado/getdist/\#egg=getdist --force
 RUN cd $%s && git clone https://github.com/JesusTorrado/cobaya.git && \
     cd $%s/cobaya && pip install -e .
 """ % (_modules_path_env, _modules_path, _products_path,

--- a/cobaya/conventions.py
+++ b/cobaya/conventions.py
@@ -42,6 +42,7 @@ _resume = "resume"
 _resume_default = False
 _timing = "timing"
 _force = "force"
+_module_path = "python_path"
 _kinds = [_sampler, _theory, _likelihood]
 
 # Separator for fields in parameter names and files

--- a/cobaya/conventions.py
+++ b/cobaya/conventions.py
@@ -43,6 +43,7 @@ _resume_default = False
 _timing = "timing"
 _force = "force"
 _module_path = "python_path"
+_module_class_name = "class_name"
 _kinds = [_sampler, _theory, _likelihood]
 
 # Separator for fields in parameter names and files

--- a/cobaya/conventions.py
+++ b/cobaya/conventions.py
@@ -44,6 +44,7 @@ _timing = "timing"
 _force = "force"
 _module_path = "python_path"
 _module_class_name = "class_name"
+_self_name = "__self__"
 _kinds = [_sampler, _theory, _likelihood]
 
 # Separator for fields in parameter names and files

--- a/cobaya/grid_tools/runbatch.py
+++ b/cobaya/grid_tools/runbatch.py
@@ -66,7 +66,6 @@ def run():
     if args.combine_one_job_name:
         print('Combining multiple (hopefully fast) into single job script: ' +
               args.combine_one_job_name)
-    global iniFiles
     iniFiles = []
     jobqueue.checkArguments(**args.__dict__)
 
@@ -80,7 +79,6 @@ def run():
         return base + '__' + hashlib.md5(s).hexdigest()[:16]
 
     def submitJob(ini):
-        global iniFiles
         if not args.dryrun:
             print('Submitting...' + ini)
         else:
@@ -92,7 +90,7 @@ def run():
             if args.runs_per_job > 1:
                 print('--> jobName: ', jobName())
             jobqueue.submitJob(jobName(), iniFiles, **args.__dict__)
-            iniFiles = []
+            iniFiles.clear()
 
     for jobItem in Opts.filteredBatchItems(wantSubItems=args.subitems):
         if ((not args.notexist or isMinimize and not jobItem.chainMinimumExists()

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -18,7 +18,6 @@ import inspect
 from six import string_types
 from itertools import chain
 import pkg_resources
-import six
 
 # Local
 from cobaya.conventions import _package, _products_path, _path_install, _resume, _force
@@ -408,7 +407,7 @@ class HasDefaults(object):
             return ['.'.join(parts[i:]) + '.' + cls.__name__ for i in range(len(parts))]
 
     @classmethod
-    def get_module_name(cls):
+    def get_qualified_class_name(cls):
         """get cls.__name__ if class is same name as the module, otherwise module.class_name"""
         qualified_names = cls.get_qualified_names()
         if qualified_names[0].startswith('cobaya.'):

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -388,7 +388,7 @@ def is_equal_info(info1, info2, strict=True, print_not_log=False, ignore_blocks=
                     for kignore in [_input_params, _output_params]:
                         block1k.pop(kignore, None)
                         block2k.pop(kignore, None)
-                if (recursive_odict_to_dict(block1k) != recursive_odict_to_dict(block2k)):
+                if recursive_odict_to_dict(block1k) != recursive_odict_to_dict(block2k):
                     myprint(myname + ": different content of [%s:%s]" % (
                         block_name, k))
                     return False

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -413,9 +413,12 @@ class HasDefaults(object):
             return qualified_names[0]
 
     @classmethod
+    def get_class_path(cls):
+        return os.path.dirname(inspect.getfile(cls))
+
+    @classmethod
     def get_root_file_name(cls):
-        folder = os.path.dirname(inspect.getfile(cls))
-        return os.path.join(folder, cls.__name__)
+        return os.path.join(cls.get_class_path(), cls.__name__)
 
     @classmethod
     def get_yaml_file(cls):

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -396,6 +396,8 @@ class HasDefaults(object):
 
     @classmethod
     def get_qualified_names(cls):
+        if cls.__module__ == '__main__':
+            return [cls.__name__]
         parts = cls.__module__.split('.')
         if parts[-1] == cls.__name__:
             return ['.'.join(parts[i:]) for i in range(len(parts))]

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -24,7 +24,7 @@ from cobaya.conventions import _package, _products_path, _path_install, _resume,
 from cobaya.conventions import _output_prefix, _debug, _debug_file
 from cobaya.conventions import _params, _prior, _theory, _likelihood, _sampler, _external
 from cobaya.conventions import _p_label, _p_derived, _p_ref, _p_drop, _p_value, _p_renames
-from cobaya.conventions import _p_proposal, _input_params, _output_params
+from cobaya.conventions import _p_proposal, _input_params, _output_params, _module_path
 from cobaya.conventions import _yaml_extensions
 from cobaya.tools import get_class_module, recursive_update, recursive_odict_to_dict
 from cobaya.tools import fuzzy_match, deepcopy_where_possible, get_class, get_kind
@@ -91,14 +91,14 @@ def get_used_modules(*infos):
 
 
 def get_default_info(module, kind=None, fail_if_not_found=False,
-                     return_yaml=False, yaml_expand_defaults=True):
+                     return_yaml=False, yaml_expand_defaults=True, module_path=None):
     """
     Get default info for a module.
     """
     try:
         if kind is None:
             kind = get_kind(module)
-        cls = get_class(module, kind, None_if_not_found=not fail_if_not_found)
+        cls = get_class(module, kind, None_if_not_found=not fail_if_not_found, module_path=module_path)
         if cls:
             default_module_info = cls.get_defaults(
                 return_yaml=return_yaml, yaml_expand_defaults=yaml_expand_defaults)
@@ -146,12 +146,13 @@ def update_info(info):
             updated_info[block][module] = deepcopy(getattr(
                 import_module(_package + "." + block, package=_package),
                 "class_options", {}))
-            default_module_info = get_default_info(module, block)
+            default_module_info = get_default_info(module, block,
+                                                   module_path=input_info[block][module].get(_module_path, None))
             # TODO: check - get_default_info was ignoring this extra arg: input_info[block][module])
             updated_info[block][module].update(default_module_info[block][module] or {})
             # Update default options with input info
             # Consistency is checked only up to first level! (i.e. subkeys may not match)
-            ignore = set([_external, _p_renames, _input_params, _output_params])
+            ignore = set([_external, _p_renames, _input_params, _output_params, _module_path])
             options_not_recognized = (set(input_info[block][module])
                                       .difference(ignore)
                                       .difference(set(updated_info[block][module])))
@@ -401,7 +402,12 @@ class HasDefaults(object):
     @classmethod
     def get_module_name(cls):
         """get cls.__name__ if class is same name as the module, otherwise module.class_name"""
-        return cls.get_qualified_names()[2]
+        qualified_names = cls.get_qualified_names()
+        if qualified_names[0].startswith('cobaya.'):
+            return qualified_names[2]
+        else:
+            # external
+            return qualified_names[0]
 
     @classmethod
     def get_root_file_name(cls):

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -436,7 +436,7 @@ class HasDefaults(object):
     def get_bibtex(cls):
         bib = cls.get_associated_file_content('.bibtex')
         if bib:
-            return bib
+            return bib.decode('utf-8')
         for base in cls.__bases__:
             if issubclass(base, HasDefaults):
                 bib = base.get_bibtex()
@@ -478,6 +478,10 @@ class HasDefaults(object):
         Also note that if you return a dictionary it may be modified (return a deep copy if you want to keep it).
         """
         yaml_text = cls.get_associated_file_content('.yaml')
+        if not yaml_text:
+            for base in cls.__bases__:
+                if issubclass(base, HasDefaults):
+                    return base.get_defaults(return_yaml=return_yaml, yaml_expand_defaults=yaml_expand_defaults)
         if return_yaml:
             if yaml_expand_defaults:
                 return yaml_dump(yaml_load_file(cls.get_yaml_file(), yaml_text))

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -1,7 +1,7 @@
 """
 .. module:: likelihood
 
-:Synopsis: Prototype likelihood and likelihood manager
+:Synopsis: Likelihood class and likelihood manager
 :Author: Jesus Torrado
 
 This module defines the main :class:`Likelihood` class, from which every likelihood
@@ -29,8 +29,8 @@ else:
 
 # Local
 from cobaya.conventions import _external, _theory, _params, _overhead_per_param
-from cobaya.conventions import _timing, _p_renames, _chi2, _separator, _likelihood
-from cobaya.conventions import _input_params, _output_params, _module_class_name, _module_path
+from cobaya.conventions import _timing, _p_renames, _chi2, _separator, _likelihood, _self_name
+from cobaya.conventions import _input_params, _output_params, _module_path
 from cobaya.conventions import _input_params_prefix, _output_params_prefix
 from cobaya.tools import get_class, get_external_function, getargspec
 from cobaya.tools import are_different_params_lists
@@ -53,7 +53,8 @@ class Likelihood(HasLogger, HasDefaults):
         if standalone:
             default_info = self.get_defaults()
             if _likelihood in default_info:
-                default_info = default_info[_likelihood][self.name]
+                default_info = default_info[_likelihood][
+                    self.name if _self_name not in default_info[_likelihood] else _self_name]
             default_info.update(info)
             info = default_info
         self.set_logger()
@@ -310,8 +311,7 @@ class LikelihoodCollection(HasLogger):
                 self._likelihoods[name] = LikelihoodExternalFunction(
                     name, info, _theory=getattr(self, _theory, None), timing=timing)
             else:
-                like_class = get_class(name, kind=_likelihood, class_name=info.pop(_module_class_name, None),
-                                       module_path=info.pop(_module_path, None))
+                like_class = get_class(name, kind=_likelihood, module_path=info.pop(_module_path, None))
                 self._likelihoods[name] = like_class(info, modules=modules, timing=timing, standalone=False)
         # Assign input/output parameters
         self._assign_params(parameterization, info_likelihood, info_theory)

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -30,7 +30,7 @@ else:
 # Local
 from cobaya.conventions import _external, _theory, _params, _overhead_per_param
 from cobaya.conventions import _timing, _p_renames, _chi2, _separator, _likelihood
-from cobaya.conventions import _input_params, _output_params
+from cobaya.conventions import _input_params, _output_params, _module_class_name, _module_path
 from cobaya.conventions import _input_params_prefix, _output_params_prefix
 from cobaya.tools import get_class, get_external_function, getargspec
 from cobaya.tools import are_different_params_lists
@@ -296,8 +296,8 @@ class LikelihoodCollection(HasLogger):
                 self._likelihoods[name] = LikelihoodExternalFunction(
                     name, info, _theory=getattr(self, _theory, None), timing=timing)
             else:
-                like_class = get_class(name, kind=_likelihood, class_name=info.pop('class_name', None),
-                                       module_path=info.pop('module_path', None))
+                like_class = get_class(name, kind=_likelihood, class_name=info.pop(_module_class_name, None),
+                                       module_path=info.pop(_module_path, None))
                 self._likelihoods[name] = like_class(info, modules=modules, timing=timing)
         # Assign input/output parameters
         self._assign_params(parameterization, info_likelihood, info_theory)

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -50,7 +50,7 @@ class Likelihood(HasLogger, HasDefaults):
     # Generic initialization -- do not touch
     def __init__(self, info, modules=None, timing=None):
         self.name = getattr(
-            self.__class__, "get_module_name", lambda : self.__class__.__name__)()
+            self.__class__, "get_module_name", lambda: self.__class__.__name__)()
         self.set_logger()
         self.log = logging.getLogger(self.name)
         self.path_install = modules
@@ -152,17 +152,17 @@ class Likelihood(HasLogger, HasDefaults):
                     # if too different from second one (maybe check difference in log10 > 1)
                     # In that case, take into account that #timed_evals is now (self.n - 1)
                     if self.n == 2:
-                        log10diff = np.log10(self.time_avg/delta_time)
+                        log10diff = np.log10(self.time_avg / delta_time)
                         if log10diff > 1:
                             self.log.warning(
                                 "It seems the first call has done some caching (difference "
                                 " of a factor %g). Average timing will not be reliable "
-                                "unless many evaluations are carried out.", 10**log10diff)
+                                "unless many evaluations are carried out.", 10 ** log10diff)
                     self.time_avg = (delta_time + self.time_avg * (self.n - 1)) / self.n
                     self.time_sqsum += delta_time ** 2
                     if self.n > 1:
                         self.time_std = np.sqrt(
-                            (self.time_sqsum - self.n * self.time_avg**2)/(self.n-1))
+                            (self.time_sqsum - self.n * self.time_avg ** 2) / (self.n - 1))
                     self.log.debug("Average 'logp' evaluation time: %g s", self.time_avg)
             except Exception as e:
                 if self.stop_at_error:
@@ -296,7 +296,8 @@ class LikelihoodCollection(HasLogger):
                 self._likelihoods[name] = LikelihoodExternalFunction(
                     name, info, _theory=getattr(self, _theory, None), timing=timing)
             else:
-                like_class = get_class(name, kind=_likelihood)
+                like_class = get_class(name, kind=_likelihood, class_name=info.pop('class_name', None),
+                                       module_path=info.pop('module_path', None))
                 self._likelihoods[name] = like_class(info, modules=modules, timing=timing)
         # Assign input/output parameters
         self._assign_params(parameterization, info_likelihood, info_theory)

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -464,7 +464,7 @@ class LikelihoodCollection(HasLogger):
             p for p, assigned in params_assign["input"].items() if not assigned]
         if unassigned_input:
             raise LoggedError(
-                self.log, "Could not find whom to assign input parameters %r.",
+                self.log, "Could not find anything to use input parameter(s) %r.",
                 unassigned_input)
         # Assign the "chi2__" output parameters
         for p in params_assign["output"]:

--- a/cobaya/likelihoods/_base_classes/_DataSetLikelihood.py
+++ b/cobaya/likelihoods/_base_classes/_DataSetLikelihood.py
@@ -44,6 +44,7 @@ class _DataSetLikelihood(_InstallableLikelihood):
             # If no path specified, use the modules path
             if not self.path and self.path_install:
                 self.path = self.get_path(self.path_install)
+            self.path = self.path or self.get_class_path()
             if not self.path:
                 raise LoggedError(self.log,
                                   "No path given for %s. Set the likelihood property 'path' "
@@ -53,12 +54,12 @@ class _DataSetLikelihood(_InstallableLikelihood):
         if not os.path.exists(data_file):
             raise LoggedError(
                 self.log, "The data file '%s' could not be found at '%s'. "
-                "Either you have not installed this likelihood, "
-                "or have given the wrong modules installation path.",
+                          "Either you have not installed this likelihood, "
+                          "or have given the wrong modules installation path.",
                 self.dataset_file, self.path)
-        self.load_dataset_file(data_file, self.dataset_params)
+        self.load_dataset_file(data_file, getattr(self, 'dataset_params', {}))
 
-    def load_dataset_file(self, filename, dataset_params):
+    def load_dataset_file(self, filename, dataset_params={}):
         if '.dataset' not in filename:
             filename += '.dataset'
         ini = IniFile(filename)

--- a/cobaya/likelihoods/_base_classes/_DataSetLikelihood.py
+++ b/cobaya/likelihoods/_base_classes/_DataSetLikelihood.py
@@ -69,4 +69,4 @@ class _DataSetLikelihood(_InstallableLikelihood):
         self.init_params(ini)
 
     def init_params(self, ini):
-        assert False, "set_file_params should be inherited"
+        assert False, "init_params should be inherited"

--- a/cobaya/likelihoods/_base_classes/_H0_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_H0_prototype.py
@@ -55,8 +55,8 @@ class _H0_prototype(Likelihood):
     def initialize(self):
         self.norm = norm(loc=self.H0, scale=self.H0_std)
 
-    def add_theory(self):
-        self.theory.needs(H0=None)
+    def get_requirements(self):
+        return {'H0': None}
 
     def logp(self, **params_values):
         H0_theory = self.theory.get_param("H0")

--- a/cobaya/likelihoods/_base_classes/_H0_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_H0_prototype.py
@@ -40,9 +40,6 @@ standard deviation, simply add the following likelihood, substituting ``mu_H0`` 
 
 """
 
-# Python 2/3 compatibility
-from __future__ import division
-
 # Global
 from scipy.stats import norm
 

--- a/cobaya/likelihoods/_base_classes/_InstallableLikelihood.py
+++ b/cobaya/likelihoods/_base_classes/_InstallableLikelihood.py
@@ -42,7 +42,7 @@ class _InstallableLikelihood(Likelihood):
     def install(cls, path=None, force=False, code=False, data=True, no_progress_bars=False):
         if not data:
             return True
-        log = logging.getLogger(cls.get_module_name())
+        log = logging.getLogger(cls.get_qualified_class_name())
         opts = cls.get_install_options()
         repo = opts.get("github_repository", None)
         if repo:

--- a/cobaya/likelihoods/_base_classes/_InstallableLikelihood.py
+++ b/cobaya/likelihoods/_base_classes/_InstallableLikelihood.py
@@ -12,12 +12,10 @@ import logging
 
 # Local
 from cobaya.likelihood import Likelihood
-from cobaya.likelihoods._base_classes._planck_clik_prototype import last_version_supp_data_and_covmats
 
 
 class _InstallableLikelihood(Likelihood):
-    install_options = {"github_repository": "CobayaSampler/planck_supp_data_and_covmats",
-                       "github_release": last_version_supp_data_and_covmats}
+    install_options = {}
 
     @classmethod
     def get_install_options(cls):

--- a/cobaya/likelihoods/_base_classes/__init__.py
+++ b/cobaya/likelihoods/_base_classes/__init__.py
@@ -1,7 +1,7 @@
 from ._InstallableLikelihood import _InstallableLikelihood
 from ._bao_prototype import _bao_prototype
 from ._DataSetLikelihood import _DataSetLikelihood, _fast_chi_square
-from ._cmblikes_prototype import _cmblikes_prototype
+from ._cmblikes import _CMBlikes
 from ._des_prototype import _des_prototype
 from ._H0_prototype import _H0_prototype
 from ._planck_2018_CamSpec_python import _planck_2018_CamSpec_python

--- a/cobaya/likelihoods/_base_classes/_bao_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_bao_prototype.py
@@ -219,7 +219,7 @@ class _bao_prototype(_InstallableLikelihood):
             self.logpdf = lambda x: (lambda x_: -0.5 * x_.dot(self.invcov).dot(x_))(
                 x - self.data["value"].values)
 
-    def add_theory(self):
+    def get_requirements(self):
         if self.theory.__class__ == "classy":
             raise LoggedError(
                 self.log,
@@ -263,7 +263,7 @@ class _bao_prototype(_InstallableLikelihood):
         if self.has_type:
             for obs in self.data["observable"].unique():
                 requisites.update(theory_reqs[obs])
-        self.theory.needs(**requisites)
+        return requisites
 
     def theory_fun(self, z, observable):
         # Functions to get the corresponding theoretical prediction:

--- a/cobaya/likelihoods/_base_classes/_bao_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_bao_prototype.py
@@ -131,7 +131,6 @@ import logging
 from cobaya.log import LoggedError
 from cobaya.conventions import _path_install, _c_km_s
 from cobaya.likelihoods._base_classes import _InstallableLikelihood
-from cobaya.input import HasDefaults
 
 
 class _bao_prototype(_InstallableLikelihood):

--- a/cobaya/likelihoods/_base_classes/_cmblikes.py
+++ b/cobaya/likelihoods/_base_classes/_cmblikes.py
@@ -1,5 +1,5 @@
 """
-.. module:: _cmblikes_prototype
+.. module:: _cmblikes
 
 :Synopsis: Definition of the CMBlikes class for CMB real or simulated data.
 :Author: Antony Lewis (adapted to Cobaya by Jesus Torrado with little modification)
@@ -23,7 +23,7 @@ from cobaya.log import LoggedError
 from cobaya.likelihoods._base_classes import _DataSetLikelihood
 
 
-class _cmblikes_prototype(_DataSetLikelihood):
+class _CMBlikes(_DataSetLikelihood):
 
     def get_requirements(self):
         # State requisites to the theory code

--- a/cobaya/likelihoods/_base_classes/_cmblikes_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_cmblikes_prototype.py
@@ -20,12 +20,12 @@ from scipy.linalg import sqrtm
 
 # Local
 from cobaya.log import LoggedError
-from cobaya.likelihoods._base_classes import _fast_chi_square, _DataSetLikelihood
+from cobaya.likelihoods._base_classes import _DataSetLikelihood
 
 
 class _cmblikes_prototype(_DataSetLikelihood):
 
-    def add_theory(self):
+    def get_requirements(self):
         # State requisites to the theory code
         requested_cls = [self.field_names[i] + self.field_names[j]
                          for i, j in zip(*np.where(self.cl_lmax != 0))]
@@ -38,7 +38,7 @@ class _cmblikes_prototype(_DataSetLikelihood):
                           "The likelihood value will probably not be correct. "
                           "Make sure to make 'l_max'>=%d", requested_l_max)
         self.l_max = max(requested_l_max, getattr(self, "l_max", 0) or 0)
-        self.theory.needs(**{"Cl": {cl: self.l_max for cl in requested_cls}})
+        return {"Cl": {cl: self.l_max for cl in requested_cls}}
 
     def typeIndex(self, field):
         return self.field_names.index(field)
@@ -106,7 +106,7 @@ class _cmblikes_prototype(_DataSetLikelihood):
         else:
             return name1 + name2
 
-    def GetColsFromOrder(self, order):
+    def get_cols_from_order(self, order):
         # Converts string Order = TT TE EE XY... or AAAxBBB AAAxCCC BBxCC
         # into indices into array of power spectra (and -1 if not present)
         cols = np.empty(self.ncl, dtype=int)
@@ -120,7 +120,7 @@ class _cmblikes_prototype(_DataSetLikelihood):
                     name = self.Cl_used_i_j_name([j, i])
                 if name in names:
                     if cols[ix] != -1:
-                        raise LoggedError(self.log, 'GetColsFromOrder: duplicate CL type')
+                        raise LoggedError(self.log, 'get_cols_from_order: duplicate CL type')
                     cols[ix] = names.index(name)
                 ix += 1
         return cols
@@ -140,18 +140,18 @@ class _cmblikes_prototype(_DataSetLikelihood):
             X[ix:ix + i + 1] = M[i, 0:i + 1]
             ix += i + 1
 
-    def ReadClArr(self, ini, file_stem, return_full=False):
+    def read_cl_array(self, ini, file_stem, return_full=False):
         # read file of CL or bins (indexed by L)
         filename = ini.relativeFileName(file_stem + '_file')
         cl = np.zeros((self.ncl, self.nbins_used))
         order = ini.string(file_stem + '_order', '')
         if not order:
-            incols = lastTopComment(filename)
+            incols = last_top_comment(filename)
             if not incols:
                 raise LoggedError(self.log, 'No column order given for ' + filename)
         else:
             incols = 'L ' + order
-        cols = self.GetColsFromOrder(incols)
+        cols = self.get_cols_from_order(incols)
         data = np.loadtxt(filename)
         Ls = data[:, 0].astype(int)
         if self.binned:
@@ -170,7 +170,7 @@ class _cmblikes_prototype(_DataSetLikelihood):
         else:
             return cl
 
-    def readBinWindows(self, ini, file_stem):
+    def read_bin_windows(self, ini, file_stem):
         bins = BinWindows(self.pcl_lmin, self.pcl_lmax, self.nbins_used)
         in_cl = ini.split(file_stem + '_in_order')
         out_cl = ini.split(file_stem + '_out_order', in_cl)
@@ -185,13 +185,13 @@ class _cmblikes_prototype(_DataSetLikelihood):
         windows = ini.relativeFileName(file_stem + '_files')
         for b in range(self.nbins_used):
             window = np.loadtxt(windows % (b + 1 + self.bin_min))
-            Err = False
+            err = False
             for i, L in enumerate(window[:, 0].astype(int)):
                 if self.pcl_lmin <= L <= self.pcl_lmax:
                     bins.binning_matrix[:, b, L - self.pcl_lmin] = window[i, 1:]
                 else:
-                    Err = Err or any(window[i, 1:] != 0)
-            if Err:
+                    err = err or any(window[i, 1:] != 0)
+            if err:
                 self.log.warning('%s %u outside pcl_lmin-cl_max range: %s' %
                                  (file_stem, b, windows % (b + 1)))
         if ini.hasKey(file_stem + '_fix_cl_file'):
@@ -216,6 +216,7 @@ class _cmblikes_prototype(_DataSetLikelihood):
         return cls
 
     def init_params(self, ini):
+        self.field_names = getattr(self, 'field_names', ['T', 'E', 'B', 'P'])
         self.tot_theory_fields = len(self.field_names)
         self.map_names = ini.split('map_names', default=[])
         self.has_map_names = len(self.map_names)
@@ -296,8 +297,8 @@ class _cmblikes_prototype(_DataSetLikelihood):
             self.nbins = ini.int('nbins')
             self.bin_min = ini.int('use_min', 1) - 1
             self.bin_max = ini.int('use_max', self.nbins) - 1
-            self.nbins_used = self.bin_max - self.bin_min + 1  # needed by readBinWindows
-            self.bins = self.readBinWindows(ini, 'bin_window')
+            self.nbins_used = self.bin_max - self.bin_min + 1  # needed by read_bin_windows
+            self.bins = self.read_bin_windows(ini, 'bin_window')
         else:
             if self.nmaps != self.nmaps_required:
                 raise LoggedError(
@@ -309,15 +310,15 @@ class _cmblikes_prototype(_DataSetLikelihood):
             self.bin_max = ini.int('use_max', self.pcl_lmax)
             self.nbins_used = self.bin_max - self.bin_min + 1
         self.full_bandpower_headers, self.full_bandpowers, self.bandpowers = \
-            self.ReadClArr(ini, 'cl_hat', return_full=True)
+            self.read_cl_array(ini, 'cl_hat', return_full=True)
         if self.like_approx == 'HL':
-            self.cl_fiducial = self.ReadClArr(ini, 'cl_fiducial')
+            self.cl_fiducial = self.read_cl_array(ini, 'cl_fiducial')
         else:
             self.cl_fiducial = None
         includes_noise = ini.bool('cl_hat_includes_noise', False)
         self.cl_noise = None
         if self.like_approx != 'gaussian' or includes_noise:
-            self.cl_noise = self.ReadClArr(ini, 'cl_noise')
+            self.cl_noise = self.read_cl_array(ini, 'cl_noise')
             if not includes_noise:
                 self.bandpowers += self.cl_noise
             elif self.like_approx == 'gaussian':
@@ -350,9 +351,9 @@ class _cmblikes_prototype(_DataSetLikelihood):
             self.cov = self.ReadCovmat(ini)
             self.covinv = np.linalg.inv(self.cov)
         if 'linear_correction_fiducial_file' in ini.params:
-            self.fid_correction = self.ReadClArr(ini, 'linear_correction_fiducial')
+            self.fid_correction = self.read_cl_array(ini, 'linear_correction_fiducial')
             self.linear_correction = (
-                self.readBinWindows(ini, 'linear_correction_bin_window'))
+                self.read_bin_windows(ini, 'linear_correction_bin_window'))
         else:
             self.linear_correction = None
         if ini.hasKey('nuisance_params'):
@@ -569,13 +570,21 @@ class _cmblikes_prototype(_DataSetLikelihood):
             return ((2 * L + 1) * self.fsky *
                     (np.trace(M) - self.nmaps - np.linalg.slogdet(M)[1]))
 
-    fast_chi_squared = _fast_chi_square()
-
     def logp(self, **data_params):
-        Cls = self.theory.get_Cl(ell_factor=True)
-        self.get_theory_map_cls(Cls, data_params)
+        cls = self.theory.get_Cl(ell_factor=True)
+        return self.log_likelihood(cls, **data_params)
+
+    def log_likelihood(self, dls, **data_params):
+        r"""
+        Get log likelihood from the dls (CMB C_l scaled by L(L+1)/2\pi)
+
+        :param dls: dictionary of d_l ('tt', etc)
+        :param data_params: likelihood nuistance parameters
+        :return: log likelihood
+        """
+        self.get_theory_map_cls(dls, data_params)
         C = np.empty((self.nmaps, self.nmaps))
-        bigX = np.empty(self.nbins_used * self.ncl_used)
+        big_x = np.empty(self.nbins_used * self.ncl_used)
         vecp = np.empty(self.ncl)
         chisq = 0
         if self.binned:
@@ -611,10 +620,10 @@ class _cmblikes_prototype(_DataSetLikelihood):
             elif self.like_approx == 'gaussian':
                 C -= self.bandpower_matrix[bin]
             self.matrix_to_elements(C, vecp)
-            bigX[bin * self.ncl_used:(bin + 1) * self.ncl_used] = vecp[self.cl_used_index]
+            big_x[bin * self.ncl_used:(bin + 1) * self.ncl_used] = vecp[self.cl_used_index]
         if self.like_approx == 'exact':
             return -0.5 * chisq
-        return -0.5 * self.fast_chi_squared(self.covinv, bigX)
+        return -0.5 * self.fast_chi_squared(self.covinv, big_x)
 
 
 class BinWindows(object):
@@ -623,11 +632,11 @@ class BinWindows(object):
         self.lmax = lmax
         self.nbins = nbins
 
-    def bin(self, TheoryCls, cls=None):
+    def bin(self, theory_cl, cls=None):
         if cls is None:
             cls = np.zeros((self.nbins, max([x for x in self.cols_out if x >= 0]) + 1))
         for i, ((x, y), ix_out) in enumerate(zip(self.cols_in.T, self.cols_out)):
-            cl = TheoryCls[x, y]
+            cl = theory_cl[x, y]
             if cl is not None and ix_out >= 0:
                 cls[:, ix_out] += np.dot(self.binning_matrix[i, :, :], cl.CL)
         return cls
@@ -643,7 +652,7 @@ class BinWindows(object):
                         (L, self.binning_matrix[:, b, L]))
 
 
-def lastTopComment(fname):
+def last_top_comment(fname):
     result = None
     with open(fname) as f:
         x = f.readline()
@@ -655,16 +664,3 @@ def lastTopComment(fname):
                 result = x[1:].strip()
             x = f.readline()
     return None
-
-
-def readTextCommentColumns(fname, cols):
-    incols = lastTopComment(fname).split()
-    colnums = [incols.index(col) for col in cols]
-    return np.loadtxt(fname, usecols=colnums, unpack=True)
-
-
-def readWithHeader(fname):
-    x = lastTopComment(fname)
-    if not x:
-        raise Exception('No Comment')
-    return x.split(), np.loadtxt(fname)

--- a/cobaya/likelihoods/_base_classes/_des_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_des_prototype.py
@@ -161,7 +161,7 @@ else:
 class _des_prototype(_DataSetLikelihood):
     install_options = {"github_repository": "CobayaSampler/des_data", "github_release": "v1.0"}
 
-    def load_dataset_file(self, filename, dataset_params):
+    def load_dataset_file(self, filename, dataset_params={}):
         self.l_max = self.l_max or int(50000 * self.acc)  # lmax here is an internal parameter for transforms
         if filename.endswith(".fits"):
 

--- a/cobaya/likelihoods/_base_classes/_des_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_des_prototype.py
@@ -370,8 +370,8 @@ class _des_prototype(_DataSetLikelihood):
         assert self.zmax <= 5, "z max too large!"
         self.zs_interp = np.linspace(0, self.zmax, 100)
 
-    def add_theory(self):
-        self.theory.needs(**{
+    def get_requirements(self):
+        return {
             "omegan": None,
             "omegam": None,
             "Pk_interpolator": {
@@ -380,7 +380,7 @@ class _des_prototype(_DataSetLikelihood):
                 "vars_pairs": ([["delta_tot", "delta_tot"]] +
                                ([["Weyl", "Weyl"]] if self.use_Weyl else []))},
             "comoving_radial_distance": {"z": self.zs},
-            "H": {"z": self.zs, "units": "km/s/Mpc"}})
+            "H": {"z": self.zs, "units": "km/s/Mpc"}}
 
     def get_theory(self, PKdelta, PKWeyl, bin_bias, shear_calibration_parameters,
                    intrinsic_alignment_A, intrinsic_alignment_alpha,

--- a/cobaya/likelihoods/_base_classes/_planck_2018_CamSpec_python.py
+++ b/cobaya/likelihoods/_base_classes/_planck_2018_CamSpec_python.py
@@ -26,7 +26,6 @@ import scipy
 # Local
 from cobaya.likelihoods._base_classes import _DataSetLikelihood
 
-
 use_cache = True
 
 
@@ -49,7 +48,7 @@ def range_to_ells(use_range):
 class _planck_2018_CamSpec_python(_DataSetLikelihood):
     install_options = {
         "download_url":
-        r"https://cdn.cosmologist.info/cosmobox/test2019_kaml/CamSpec2018.zip",
+            r"https://cdn.cosmologist.info/cosmobox/test2019_kaml/CamSpec2018.zip",
         "data_path": "planck_2018_CamSpec_native"}
 
     def read_normalized(self, filename, pivot=None):
@@ -251,14 +250,14 @@ class _planck_2018_CamSpec_python(_DataSetLikelihood):
         Cls = self.theory.get_Cl(ell_factor=True)
         return -0.5 * self.chi_squared(Cls.get('tt'), Cls.get('te'), Cls.get('ee'), data_params)
 
-    def add_theory(self):
+    def get_requirements(self):
         # State requisites to the theory code
         l_max = np.max(self.lmax)
         used = []
         if np.any(self.cl_used[:4]): used += ['tt']
         if 'TE' in self.use_cl: used += ['te']
         if 'EE' in self.use_cl: used += ['ee']
-        self.theory.needs(**{"Cl": {cl: l_max for cl in used}})
+        return {"Cl": {cl: l_max for cl in used}}
 
     def coadded_TT(self, data_params=None, foregrounds=None, cals=None,
                    want_cov=True, data_vector=None):

--- a/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
@@ -113,7 +113,7 @@ class _planck_clik_prototype(Likelihood, HasDefaults):
         length = (len(self.l_maxs) if self.lensing else len(self.clik.get_has_cl()))
         self.vector = np.zeros(np.sum(self.l_maxs) + length + len(self.expected_params))
 
-    def add_theory(self):
+    def get_requirements(self):
         # State requisites to the theory code
         requested_cls = ["tt", "ee", "bb", "te", "tb", "eb"]
         if self.lensing:
@@ -123,7 +123,7 @@ class _planck_clik_prototype(Likelihood, HasDefaults):
             has_cl = self.clik.get_has_cl()
         self.requested_cls = [cl for cl, i in zip(requested_cls, has_cl) if int(i)]
         self.l_maxs_cls = [lmax for lmax, i in zip(self.l_maxs, has_cl) if int(i)]
-        self.theory.needs(Cl=dict(zip(self.requested_cls, self.l_maxs_cls)))
+        return {'Cl': dict(zip(self.requested_cls, self.l_maxs_cls))}
 
     def logp(self, **params_values):
         # get Cl's from the theory code

--- a/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
@@ -17,7 +17,6 @@ import os
 import sys
 import numpy as np
 import logging
-import textwrap
 import six
 
 # Local
@@ -51,7 +50,7 @@ class _planck_clik_prototype(Likelihood, HasDefaults):
             for line in _deprecation_msg_2015.split("\n"):
                 self.log.warning(line)
         code_path = common_path
-        data_path = get_data_path(self.__class__.get_module_name())
+        data_path = get_data_path(self.__class__.get_qualified_class_name())
         if self.path:
             has_clik = False
         else:
@@ -149,13 +148,13 @@ class _planck_clik_prototype(Likelihood, HasDefaults):
     @classmethod
     def is_installed(cls, **kwargs):
         code_path = common_path
-        data_path = get_data_path(cls.get_module_name())
+        data_path = get_data_path(cls.get_qualified_class_name())
         result = True
         if kwargs["code"]:
             result &= is_installed_clik(os.path.realpath(
                 os.path.join(kwargs["path"], "code", code_path)))
         if kwargs["data"]:
-            _, filename = get_product_id_and_clik_file(cls.get_module_name())
+            _, filename = get_product_id_and_clik_file(cls.get_qualified_class_name())
             result &= os.path.exists(os.path.realpath(
                 os.path.join(kwargs["path"], "data", data_path, filename)))
             # Check for additional data and covmats
@@ -165,7 +164,7 @@ class _planck_clik_prototype(Likelihood, HasDefaults):
 
     @classmethod
     def install(cls, path=None, force=False, code=True, data=True, no_progress_bars=False):
-        name = cls.get_module_name()
+        name = cls.get_qualified_class_name()
         log = logging.getLogger(name)
         path_names = {"code": common_path, "data": get_data_path(name)}
         import platform

--- a/cobaya/likelihoods/_base_classes/_planck_pliklite_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_planck_pliklite_prototype.py
@@ -18,7 +18,6 @@ import numpy as np
 # Local
 from cobaya.likelihoods._base_classes import _DataSetLikelihood
 
-
 cl_names = ['tt', 'te', 'ee']
 
 
@@ -105,10 +104,10 @@ class _planck_pliklite_prototype(_DataSetLikelihood):
         self.cov = cov[np.ix_(self.used_indices, self.used_indices)]
         self.invcov = np.linalg.inv(self.cov)
 
-    def add_theory(self):
+    def get_requirements(self):
         # State requisites to the theory code
         self.l_max = self.lmax
-        self.theory.needs(**{"Cl": {cl: self.l_max for cl in self.use_cl}})
+        return {"Cl": {cl: self.l_max for cl in self.use_cl}}
 
     def binning_matrix(self, ix=0):
         # not used by main likelihood code
@@ -132,8 +131,9 @@ class _planck_pliklite_prototype(_DataSetLikelihood):
         return self.fast_chi_squared(self.invcov, diff)
 
     def chi_squared(self, c_l_arr, calPlanck=1):
-        """
+        r"""
         Get chi squared from CL array from file
+
         :param c_l_arr: file of L and L(L+1)CL/2\pi values for C_TT, C_TE, C_EE
         :param calPlanck: calibration parameter
         :return: chi-squared

--- a/cobaya/likelihoods/_base_classes/_sn_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_sn_prototype.py
@@ -239,9 +239,9 @@ class _sn_prototype(_DataSetLikelihood):
         elif not self.alphabeta_covmat:
             self.inverse_covariance_matrix()
 
-    def add_theory(self):
+    def get_requirements(self):
         # State requisites to the theory code
-        self.theory.needs(**{"angular_diameter_distance": {"z": self.zcmb}})
+        return {"angular_diameter_distance": {"z": self.zcmb}}
 
     def _read_covmat(self, filename):
         cov = np.loadtxt(filename)

--- a/cobaya/likelihoods/bicep_keck_2015/__init__.py
+++ b/cobaya/likelihoods/bicep_keck_2015/__init__.py
@@ -78,14 +78,14 @@ After this, mention the path to this likelihood when you include it in an input 
 import numpy as np
 
 # Local
-from cobaya.likelihoods._base_classes import _cmblikes_prototype
+from cobaya.likelihoods._base_classes import _CMBlikes
 from cobaya.conventions import _h_J_s, _kB_J_K, _T_CMB_K
 
 # Physical constants
 Ghz_Kelvin = _h_J_s / _kB_J_K * 1e9
 
 
-class bicep_keck_2015(_cmblikes_prototype):
+class bicep_keck_2015(_CMBlikes):
     install_options = {"download_url": r"http://bicepkeck.org/BK15_datarelease/BK15_cosmomc.tgz"}
 
     def init_params(self, ini):

--- a/cobaya/likelihoods/bicep_keck_2015/__init__.py
+++ b/cobaya/likelihoods/bicep_keck_2015/__init__.py
@@ -141,12 +141,12 @@ class bicep_keck_2015(_CMBlikes):
         if bandcenter_err != 1:
             nu_bar = Ghz_Kelvin * bandpass.nu_bar
             # Conversion factor error due to bandcenter error.
-            th_err = (bandcenter_err) ** 4 * \
+            th_err = bandcenter_err ** 4 * \
                      np.exp(Ghz_Kelvin * bandpass % nu_bar * (bandcenter_err - 1) / _T_CMB_K) \
                          (np.exp(nu_bar / _T_CMB_K) - 1) ** 2 / \
                      (np.exp(nu_bar * bandcenter_err / _T_CMB_K) - 1) ** 2
             # Greybody scaling error due to bandcenter error.
-            gb_err = (bandcenter_err) ** (3 + beta) * \
+            gb_err = bandcenter_err ** (3 + beta) * \
                      (np.exp(nu_bar / Tdust) - 1) / \
                      (np.exp(nu_bar * bandcenter_err / Tdust) - 1)
         else:
@@ -166,11 +166,11 @@ class bicep_keck_2015(_CMBlikes):
         pl0 = nu0 ** (2 + beta)
         if bandcenter_err != 1:
             nu_bar = Ghz_Kelvin * bandpass.nu_bar
-            th_err = (bandcenter_err) ** 4 * \
+            th_err = bandcenter_err ** 4 * \
                      np.exp(nu_bar * (bandcenter_err - 1) / _T_CMB_K) * \
                      (np.exp(nu_bar / _T_CMB_K) - 1) ** 2 / \
                      (np.exp(nu_bar * bandcenter_err / _T_CMB_K) - 1) ** 2
-            pl_err = (bandcenter_err) ** (2 + beta)
+            pl_err = bandcenter_err ** (2 + beta)
         else:
             pl_err = 1
             th_err = 1

--- a/cobaya/likelihoods/bicep_keck_2015/bicep_keck_2015.yaml
+++ b/cobaya/likelihoods/bicep_keck_2015/bicep_keck_2015.yaml
@@ -32,7 +32,6 @@ likelihood:
       maps_use: [BK15_95_B, BK15_150_B, BK15_220_B, W023_B, P030_B, W033_B, P044_B, P070_B, P100_B, P143_B, P217_B, P353_B]
       use_min: 1
       use_max: 9
-    field_names: [T, E, B, P]
     map_separator: x
     # Actually computed l_max (takes into account the lensing window function)
     l_max: 2700

--- a/cobaya/likelihoods/planck_2015_lensing_cmblikes/planck_2015_lensing_cmblikes.yaml
+++ b/cobaya/likelihoods/planck_2015_lensing_cmblikes/planck_2015_lensing_cmblikes.yaml
@@ -7,8 +7,6 @@ likelihood:
     dataset_file: lensing/2015/smica_g30_ftl_full_pp.dataset
     # Overriding of .dataset parameters
     dataset_params:
-      # field: value
-    field_names: [T, E, B, P]
     # Overriding of the maximum ell computed
     l_max:
     # Aliases for automatic covariance matrix

--- a/cobaya/likelihoods/planck_2018_highl_CamSpec/TT.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_CamSpec/TT.yaml
@@ -2,7 +2,7 @@
 # See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/CMB_spectrum_%26_Likelihood_Code
 
 likelihood:
-  planck_2018_highl_CamSpec.TT:
+  __self__:
     path:
     clik_file: extended_camspec/plc_3.0/hi_l/camspec/camspec_10.7HM_1400_TT_small.clik
     product_id: "151903"

--- a/cobaya/likelihoods/planck_2018_highl_CamSpec/TTTEEE.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_CamSpec/TTTEEE.yaml
@@ -2,7 +2,7 @@
 # See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/CMB_spectrum_%26_Likelihood_Code#
 
 likelihood:
-  planck_2018_highl_CamSpec.TTTEEE:
+  __self__:
     path:
     clik_file: extended_camspec/plc_3.0/hi_l/camspec/camspec_10.7HM_1400_TTTEEE.clik
     product_id: "151903"

--- a/cobaya/likelihoods/planck_2018_highl_CamSpec/TTTEEE_native.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_CamSpec/TTTEEE_native.yaml
@@ -3,7 +3,7 @@
 # Native python re-implemetation, allowing multipole/bin selection
 
 likelihood:
-  planck_2018_highl_CamSpec.TTTEEE_native:
+  __self__:
     # Path to the data: where the planck_supp_data_and_covmats has been cloned
     path: null
     dataset_file: CamSpec2018/CamSpecHM_10_7.dataset  

--- a/cobaya/likelihoods/planck_2018_highl_CamSpec/TT_native.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_CamSpec/TT_native.yaml
@@ -3,7 +3,7 @@
 # Native python re-implemetation, allowing multipole/bin selection
 
 likelihood:
-  planck_2018_highl_CamSpec.TT_native:
+  __self__:
     # Path to the data: where the planck_supp_data_and_covmats has been cloned
     path: null
     dataset_file: CamSpec2018/CamSpecHM_10_7.dataset  

--- a/cobaya/likelihoods/planck_2018_lensing/clik.yaml
+++ b/cobaya/likelihoods/planck_2018_lensing/clik.yaml
@@ -2,7 +2,7 @@
 # See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/CMB_spectrum_%26_Likelihood_Code
 
 likelihood:
-  planck_2018_lensing.clik:
+  __self__:
     path:
     clik_file: baseline/plc_3.0/lensing/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8.clik_lensing
     product_id: "151902"

--- a/cobaya/likelihoods/planck_2018_lensing/cmbmarged.yaml
+++ b/cobaya/likelihoods/planck_2018_lensing/cmbmarged.yaml
@@ -9,8 +9,6 @@ likelihood:
     dataset_file: lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8_CMBmarged.dataset
     # Overriding of .dataset parameters
     dataset_params:
-      # field: value
-    field_names: [T, E, B, P]
     # Overriding of the maximum ell computed
     l_max:
     # Aliases for automatic covariance matrix

--- a/cobaya/likelihoods/planck_2018_lensing/cmbmarged.yaml
+++ b/cobaya/likelihoods/planck_2018_lensing/cmbmarged.yaml
@@ -3,7 +3,7 @@
 # See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/CMB_spectrum_%26_Likelihood_Code
 
 likelihood:
-  planck_2018_lensing.cmbmarged:
+  __self__:
     # Path to the data: where the planck_supp_data_and_covmats has been cloned
     path: null
     dataset_file: lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8_CMBmarged.dataset

--- a/cobaya/likelihoods/planck_2018_lensing/native.py
+++ b/cobaya/likelihoods/planck_2018_lensing/native.py
@@ -1,7 +1,7 @@
-from cobaya.likelihoods._base_classes import _cmblikes_prototype
+from cobaya.likelihoods._base_classes import _CMBlikes
 from cobaya.likelihoods._base_classes._planck_clik_prototype import last_version_supp_data_and_covmats
 
 
-class native(_cmblikes_prototype):
+class native(_CMBlikes):
     install_options = {"github_repository": "CobayaSampler/planck_supp_data_and_covmats",
                        "github_release": last_version_supp_data_and_covmats}

--- a/cobaya/likelihoods/planck_2018_lensing/native.yaml
+++ b/cobaya/likelihoods/planck_2018_lensing/native.yaml
@@ -3,7 +3,7 @@
 # See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/CMB_spectrum_%26_Likelihood_Code
 
 likelihood:
-  planck_2018_lensing.native:
+  __self__:
     # Path to the data: where the planck_supp_data_and_covmats has been cloned
     path: null
     dataset_file: lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8.dataset

--- a/cobaya/likelihoods/planck_2018_lensing/native.yaml
+++ b/cobaya/likelihoods/planck_2018_lensing/native.yaml
@@ -9,8 +9,6 @@ likelihood:
     dataset_file: lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8.dataset
     # Overriding of .dataset parameters
     dataset_params:
-      # field: value
-    field_names: [T, E, B, P]
     # Overriding of the maximum ell computed
     l_max:
     # Aliases for automatic covariance matrix

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -27,6 +27,7 @@ class LoggedError(Exception):
     Dummy exception, to be raised when the originating exception
     has been cleanly handled and logged.
     """
+
     def __init__(self, logger, *args, **kwargs):
         if args:
             logger.error(*args, **kwargs)
@@ -125,12 +126,9 @@ class HasLogger(object):
     Has magic methods to ignore the logger at (de)serialization.
     """
 
-    def set_logger(self, lowercase=True):
-        module_name = getattr(
-            self.__class__, "get_module_name", lambda : self.__class__.__name__)()
-        self.log = logging.getLogger(
-            (lambda x: x.lower() if lowercase else x)(
-                getattr(self, "name", module_name)))
+    def set_logger(self, lowercase=True, name=None):
+        name = name or self.__class__.__name__
+        self.log = logging.getLogger(name.lower() if lowercase else name)
 
     # Copying and pickling
     def __deepcopy__(self, memo={}):

--- a/cobaya/output.py
+++ b/cobaya/output.py
@@ -37,7 +37,7 @@ re_uint = re.compile("[0-9]+")
 class Output(HasLogger):
     def __init__(self, output_prefix=None, resume=_resume_default, force_output=False):
         self.name = "output"  # so that the MPI-wrapped class conserves the name
-        self.set_logger()
+        self.set_logger(self.name)
         self.folder = os.sep.join(output_prefix.split(os.sep)[:-1]) or "."
         self.prefix = (lambda x: x if x != "." else "")(output_prefix.split(os.sep)[-1])
         self.force_output = force_output
@@ -57,7 +57,7 @@ class Output(HasLogger):
                                        ["\n"] + ["-"] * 37))
                 raise LoggedError(
                     self.log, "Could not create folder '%s'. "
-                    "See traceback on top of this message.", self.folder)
+                              "See traceback on top of this message.", self.folder)
         self.log.info("Output to be read-from/written-into folder '%s', with prefix '%s'",
                       self.folder, self.prefix)
         # Prepare file names, and check if chain exists
@@ -89,10 +89,10 @@ class Output(HasLogger):
                 else:
                     raise LoggedError(
                         self.log, "Delete the previous sample manually, automatically "
-                        "('-%s', '--%s', '%s: True')" % (
-                            _force[0], _force, _force) +
-                        " or request resuming ('-%s', '--%s', '%s: True')" % (
-                            _resume[0], _resume, _resume))
+                                  "('-%s', '--%s', '%s: True')" % (
+                                      _force[0], _force, _force) +
+                                  " or request resuming ('-%s', '--%s', '%s: True')" % (
+                                      _resume[0], _resume, _resume))
         # Output kind and collection extension
         self.kind = "txt"
         self.ext = "txt"
@@ -134,15 +134,16 @@ class Output(HasLogger):
                 if not is_equal_info(old_info, new_info, strict=False,
                                      ignore_blocks=ignore_blocks):
                     # HACK!!! NEEDS TO BE FIXED
+                    # TODO: should check any Minimizer subclass
                     if list(updated_info.get(_sampler, [None]))[0] == "minimize":
                         raise LoggedError(
                             self.log, "Old and new sample information not compatible! "
-                            "At this moment it is not possible to 'force' deletion of "
-                            "and old 'minimize' run. Please delete it by hand. "
-                            "We are working on fixing this very soon!")
+                                      "At this moment it is not possible to 'force' deletion of "
+                                      "and old 'minimize' run. Please delete it by hand. "
+                                      "We are working on fixing this very soon!")
                     raise LoggedError(
                         self.log, "Old and new sample information not compatible! "
-                        "Resuming not possible!")
+                                  "Resuming not possible!")
             except IOError:
                 # There was no previous chain
                 pass

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -19,7 +19,7 @@ from itertools import chain
 # Local
 from cobaya.conventions import _prior, _p_drop, _p_derived, _p_label, _p_value, _p_renames
 from cobaya.tools import get_external_function, ensure_nolatex, is_valid_variable_name
-from cobaya.tools import getargspec, deepcopy_where_possible as deepcopy
+from cobaya.tools import getfullargspec, deepcopy_where_possible as deepcopy
 from cobaya.log import LoggedError, HasLogger
 
 
@@ -132,7 +132,7 @@ class Parameterization(HasLogger):
                 else:
                     self._input[p] = None
                     self._input_funcs[p] = get_external_function(info[_p_value])
-                    self._input_args[p] = getargspec(self._input_funcs[p]).args
+                    self._input_args[p] = getfullargspec(self._input_funcs[p]).args
             if is_sampled_param(info):
                 self._sampled[p] = None
                 if not info.get(_p_drop, False):
@@ -149,7 +149,7 @@ class Parameterization(HasLogger):
                     self._output[p] = None
                 else:
                     self._derived_funcs[p] = get_external_function(info[_p_derived])
-                    self._derived_args[p] = getargspec(self._derived_funcs[p]).args
+                    self._derived_args[p] = getfullargspec(self._derived_funcs[p]).args
         # Check that the sampled and derived params are all valid python variable names
         for p in chain(self.sampled_params(), self.derived_params()):
             if not is_valid_variable_name(p):

--- a/cobaya/post.py
+++ b/cobaya/post.py
@@ -234,7 +234,7 @@ def post(info, sample=None):
     prior_add = Prior(dummy_model_out.parameterization, add.get(_prior))
     likelihood_add = Likelihood(
         add[_likelihood], parameterization_like,
-        info_theory=info_theory_out, modules=info.get(_path_install))
+        info_theory=info_theory_out, path_install=info.get(_path_install))
     # Remove auxiliary "one" before dumping -- 'add' *is* info_out[_post][_post_add]
     add[_likelihood].pop("one")
     if likelihood_add.theory:

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -352,7 +352,7 @@ from types import MethodType
 # Local
 from cobaya.conventions import _prior, _p_ref, _prior_1d_name
 from cobaya.tools import get_external_function, get_scipy_1d_pdf, read_dnumber
-from cobaya.tools import _fast_uniform_logpdf, _fast_norm_logpdf, getargspec
+from cobaya.tools import _fast_uniform_logpdf, _fast_norm_logpdf, getfullargspec
 from cobaya.log import LoggedError, HasLogger
 
 # Fast logpdf for uniforms and norms (do not understand nan masks!)
@@ -413,7 +413,7 @@ class Prior(HasLogger):
             self.external[name] = (
                 {"logp": get_external_function(info_prior[name], name=name)})
             self.external[name]["argspec"] = (
-                getargspec(self.external[name]["logp"]))
+                getfullargspec(self.external[name]["logp"]))
             self.external[name]["params"] = {
                 p: list(sampled_params_info).index(p)
                 for p in self.external[name]["argspec"].args if p in sampled_params_info}

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -55,13 +55,13 @@ import numpy as np
 from cobaya.conventions import _sampler, _resume_default, _checkpoint_extension
 from cobaya.conventions import _covmat_extension, _progress_extension
 from cobaya.tools import get_class
-from cobaya.log import LoggedError, HasLogger
+from cobaya.log import LoggedError
 from cobaya.yaml import yaml_load_file
 from cobaya.mpi import am_single_or_primary_process
-from cobaya.input import HasDefaults
+from cobaya.component import CobayaComponent
 
 
-class Sampler(HasLogger, HasDefaults):
+class Sampler(CobayaComponent):
     """Prototype of the sampler class."""
 
     # What you *must* implement to create your own sampler:
@@ -75,7 +75,7 @@ class Sampler(HasLogger, HasDefaults):
         automatically recognized as attributes, with the value given in the input file,
         if redefined there.
 
-        The prior and likelihood are also accesible through the attributes with the same
+        The prior and likelihood are also accessible through the attributes with the same
         names.
         """
         pass
@@ -93,13 +93,6 @@ class Sampler(HasLogger, HasDefaults):
         """
         pass
 
-    def close(self, exception_type, exception_value, traceback):
-        """
-        Finalizes the sampler, if something needs to be done
-        (e.g. generating additional output).
-        """
-        pass
-
     def products(self):
         """
         Returns the products expected in a scripted call of cobaya,
@@ -108,21 +101,19 @@ class Sampler(HasLogger, HasDefaults):
         return None
 
     # Private methods: just ignore them:
-    def __init__(self, info_sampler, model, output, resume=_resume_default, modules=None):
+    def __init__(self, info_sampler, model, output, resume=_resume_default, path_install=None, name=None):
         """
         Actual initialization of the class. Loads the default and input information and
         call the custom ``initialize`` method.
 
         [Do not modify this one.]
         """
-        self.name = self.__class__.__name__
-        self.set_logger()
+
         self.model = model
         self.output = output
-        self.path_install = modules
-        # Load info of the sampler
-        for k in info_sampler:
-            setattr(self, k, info_sampler[k])
+
+        super(Sampler, self).__init__(info_sampler, path_install=path_install, name=name)
+
         # Seed, if requested
         if getattr(self, "seed", None) is not None:
             self.log.warning("This run has been SEEDED with seed %d", self.seed)
@@ -134,7 +125,7 @@ class Sampler(HasLogger, HasDefaults):
                     self.seed, type(self.seed))
         # Load checkpoint info, if resuming
         self.resuming = resume
-        if self.resuming and self.name != "minimize":
+        if self.resuming and not isinstance(self, Minimizer):
             try:
                 checkpoint_info = yaml_load_file(self.checkpoint_filename())
                 try:
@@ -147,7 +138,7 @@ class Sampler(HasLogger, HasDefaults):
                     if am_single_or_primary_process():
                         raise LoggedError(
                             self.log, "Checkpoint file found at '%s' "
-                            "but it corresponds to a different sampler.",
+                                      "but it corresponds to a different sampler.",
                             self.checkpoint_filename())
             except (IOError, TypeError):
                 pass
@@ -177,6 +168,13 @@ class Sampler(HasLogger, HasDefaults):
                 self.output.folder, self.output.prefix + _covmat_extension)
         return None
 
+    def close(self, exception_type, exception_value, traceback):
+        """
+        Finalizes the sampler, if something needs to be done
+        (e.g. generating additional output).
+        """
+        pass
+
     # Python magic for the "with" statement
 
     def __enter__(self):
@@ -187,6 +185,13 @@ class Sampler(HasLogger, HasDefaults):
         if getattr(self, "seed", None) is not None:
             np.random.seed(self.seed)
         self.close(exception_type, exception_value, traceback)
+
+
+class Minimizer(Sampler):
+    """
+    base class for minimizers
+    """
+    pass
 
 
 def get_sampler(info_sampler, posterior, output_file,
@@ -203,5 +208,6 @@ def get_sampler(info_sampler, posterior, output_file,
         raise LoggedError(
             log, "The sampler block must be a dictionary 'sampler: {options}'.")
     sampler_class = get_class(name, kind=_sampler)
+    assert issubclass(sampler_class, Sampler)
     return sampler_class(
-        info_sampler[name], posterior, output_file, resume=resume, modules=modules)
+        info_sampler[name], posterior, output_file, resume=resume, path_install=modules, name=name)

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -46,6 +46,8 @@ class mcmc(Sampler):
     def initialize(self):
         """Initializes the sampler:
         creates the proposal distribution and draws the initial sample."""
+        if not self.model.prior.d():
+            raise LoggedError(self.log, "No parameters being varied for sampler")
         self.log.debug("Initializing")
         for p in [
             "burn_in", "max_tries", "output_every", "check_every", "callback_every"]:
@@ -115,7 +117,7 @@ class mcmc(Sampler):
             if np.all(speeds == speeds[0]):
                 raise LoggedError(
                     self.log, "All speeds are equal or too similar: cannot drag! "
-                    "Make sure to define accurate likelihoods' speeds.")
+                              "Make sure to define accurate likelihoods' speeds.")
             # Make the 1st factor 1:
             speeds = [1, speeds[1] / speeds[0]]
             # Target: dragging step taking as long as slow step
@@ -225,38 +227,38 @@ class mcmc(Sampler):
                 loaded_covmat = np.loadtxt(self.covmat)
             except TypeError:
                 raise LoggedError(self.log, "The property 'covmat' must be a file name,"
-                                  "but it's '%s'.", str(self.covmat))
+                                            "but it's '%s'.", str(self.covmat))
             except IOError:
                 raise LoggedError(self.log, "Can't open covmat file '%s'.", self.covmat)
             if header[0] != "#":
                 raise LoggedError(
-                    self.log,  "The first line of the covmat file '%s' "
-                    "must be one list of parameter names separated by spaces "
-                    "and staring with '#', and the rest must be a square matrix, "
-                    "with one row per line.", self.covmat)
+                    self.log, "The first line of the covmat file '%s' "
+                              "must be one list of parameter names separated by spaces "
+                              "and staring with '#', and the rest must be a square matrix, "
+                              "with one row per line.", self.covmat)
             loaded_params = header.strip("#").strip().split()
         elif hasattr(self.covmat, "__getitem__"):
             if not self.covmat_params:
                 raise LoggedError(
-                    self.log,  "If a covariance matrix is passed as a numpy array, "
-                    "you also need to pass the parameters it corresponds to "
-                    "via 'covmat_params: [name1, name2, ...]'.")
+                    self.log, "If a covariance matrix is passed as a numpy array, "
+                              "you also need to pass the parameters it corresponds to "
+                              "via 'covmat_params: [name1, name2, ...]'.")
             loaded_params = self.covmat_params
             loaded_covmat = np.array(self.covmat)
         if self.covmat is not None:
             if len(loaded_params) != len(set(loaded_params)):
                 raise LoggedError(
                     self.log, "There are duplicated parameters in the header of the "
-                    "covmat file '%s' ", self.covmat)
+                              "covmat file '%s' ", self.covmat)
             if len(loaded_params) != loaded_covmat.shape[0]:
                 raise LoggedError(
-                    self.log,  "The number of parameters in the header of '%s' and the "
-                    "dimensions of the matrix do not coincide.", self.covmat)
+                    self.log, "The number of parameters in the header of '%s' and the "
+                              "dimensions of the matrix do not coincide.", self.covmat)
             if not (np.allclose(loaded_covmat.T, loaded_covmat) and
                     np.all(np.linalg.eigvals(loaded_covmat) > 0)):
                 raise LoggedError(
                     self.log, "The covmat loaded from '%s' is not a positive-definite, "
-                    "symmetric square matrix.", self.covmat)
+                              "symmetric square matrix.", self.covmat)
             # Fill with parameters in the loaded covmat
             renames = [[p] + np.atleast_1d(v.get(_p_renames, [])).tolist()
                        for p, v in params_infos.items()]
@@ -304,8 +306,8 @@ class mcmc(Sampler):
             # we want to start learning the covmat earlier
             self.log.info("Covariance matrix " +
                           ("not present" if np.all(where_nan) else "not complete") + ". "
-                          "We will start learning the covariance of the proposal earlier:"
-                          " R-1 = %g (was %g).",
+                                                                                     "We will start learning the covariance of the proposal earlier:"
+                                                                                     " R-1 = %g (was %g).",
                           self.learn_proposal_Rminus1_max_early,
                           self.learn_proposal_Rminus1_max)
             self.learn_proposal_Rminus1_max = self.learn_proposal_Rminus1_max_early
@@ -558,7 +560,7 @@ class mcmc(Sampler):
                 if self.been_waiting > self.max_waiting:
                     raise LoggedError(
                         self.log, "Waiting for too long for all chains to be ready. "
-                        "Maybe one of them is stuck or died unexpectedly?")
+                                  "Maybe one of them is stuck or died unexpectedly?")
             self.model.dump_timing()
             # If not MPI size > 1, we are ready
             if not more_than_one_process():
@@ -617,7 +619,7 @@ class mcmc(Sampler):
             if cut <= 1:
                 raise LoggedError(
                     self.log, "Not enough points in chain to check convergence. "
-                    "Increase `check_every` or reduce `Rminus1_single_split`.")
+                              "Increase `check_every` or reduce `Rminus1_single_split`.")
             Ns = (m - 1) * [cut]
             means = np.array(
                 [self.collection.mean(first=i * cut, last=(i + 1) * cut - 1) for i in range(1, m)])
@@ -833,7 +835,7 @@ def plot_progress(progress, ax=None, index=None, figure_kwargs={}, legend_kwargs
     elif hasattr(type(progress), "__iter__"):
         # Assume is a list of progress'es
         for i, p in enumerate(progress):
-            plot_progress(p, ax=ax, index=i+1)
+            plot_progress(p, ax=ax, index=i + 1)
         return ax
     else:
         raise ValueError("Cannot understand progress argument: %r" % progress)

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -86,7 +86,7 @@ import logging
 from copy import deepcopy
 
 # Local
-from cobaya.sampler import Sampler
+from cobaya.sampler import Minimizer
 from cobaya.mpi import get_mpi_size, get_mpi_comm, am_single_or_primary_process
 from cobaya.collection import OnePoint
 from cobaya.log import LoggedError
@@ -99,7 +99,7 @@ evals_attr = {"scipy": "fun", "bobyqa": "f"}
 getdist_ext_ignore_prior = {True: ".bestfit", False: ".minimum"}
 
 
-class minimize(Sampler):
+class minimize(Minimizer):
     def initialize(self):
         """Prepares the arguments for `scipy.minimize`."""
         if am_single_or_primary_process():

--- a/cobaya/theories/_cosmo/_cosmo.py
+++ b/cobaya/theories/_cosmo/_cosmo.py
@@ -65,7 +65,7 @@ class _cosmo(Theory):
             if product in requirements:
                 raise LoggedError(
                     self.log, "You requested product '%s', which from now on should be "
-                    "capitalized as '%s'.", product, capitalization)
+                              "capitalized as '%s'.", product, capitalization)
         # Accumulate the requirements across several calls in a safe way;
         # e.g. take maximum of all values of a requested precision paramater
         for k, v in requirements.items():
@@ -103,10 +103,10 @@ class _cosmo(Theory):
                 if "sources" not in v:
                     raise LoggedError(
                         self.log, "Needs a 'sources' key, containing a dict with every "
-                        "source name and definition")
+                                  "source name and definition")
                 # Check that no two sources with equal name but diff specification
                 for source, window in v["sources"].items():
-                    if source in getattr(self, "sources", {}):
+                    if source in (getattr(self, "sources", {}) or {}):
                         # TODO: improve this test!!!
                         # (e.g. 2 z-vectors that fulfill np.allclose would fail a == test)
                         if window != self.sources[source]:
@@ -121,7 +121,7 @@ class _cosmo(Theory):
                     self._needs[k] = {}
                 self._needs[k]["z"] = np.unique(np.concatenate(
                     (self._needs[k].get("z", []), v["z"])))
-            # Extra derived paramaters and other unknown stuff (keep capitalization)
+            # Extra derived parameters and other unknown stuff (keep capitalization)
             elif v is None:
                 self._needs[k] = None
             else:
@@ -229,7 +229,7 @@ class _cosmo(Theory):
                 # End of deprecation block ------------------------------
                 raise LoggedError(
                     self.log, "Getter method for cosmology product %r is not known. "
-                    "Maybe you meant any of %r?",
+                              "Maybe you meant any of %r?",
                     method, fuzzy_match(method, dir(self), n=3))
 
 

--- a/cobaya/theories/_cosmo/_cosmo.py
+++ b/cobaya/theories/_cosmo/_cosmo.py
@@ -175,7 +175,7 @@ class _cosmo(Theory):
         """
         pass
 
-    def get_Pk_interpolator(self, z):
+    def get_Pk_interpolator(self):
         r"""
         Returns a (dict of) power spectrum interpolator(s)
         :class:`PowerSpectrumInterpolator`.

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -321,7 +321,7 @@ class classy(_cosmo):
 
     def add_z_for_matter_power(self, z):
         if not getattr(self, "z_for_matter_power"):
-            self.z_for_matter_power = np.empty((0))
+            self.z_for_matter_power = np.empty(0)
         self.z_for_matter_power = np.flip(np.sort(np.unique(np.concatenate(
             [self.z_for_matter_power, np.atleast_1d(z)]))), axis=0)
         self.extra_args["z_pk"] = " ".join(["%g" % zi for zi in self.z_for_matter_power])

--- a/cobaya/theory.py
+++ b/cobaya/theory.py
@@ -23,15 +23,14 @@ from __future__ import division
 
 # Local
 from cobaya.conventions import _input_params, _output_params
-from cobaya.log import HasLogger
-from cobaya.input import HasDefaults
+from cobaya.component import CobayaComponent
 
 # Default options for all subclasses
 class_options = {"speed": -1}
 
 
 # Theory code prototype
-class Theory(HasLogger, HasDefaults):
+class Theory(CobayaComponent):
     """Prototype of the theory class."""
 
     def initialize(self):
@@ -59,24 +58,7 @@ class Theory(HasLogger, HasDefaults):
         """
         pass
 
-    def close(self):
-        """Finalizes the theory code, if something needs to be done
-        (releasing memory, etc.)"""
-        pass
-
     # Generic methods: do not touch these
-
-    def __init__(self, info_theory, modules=None, timing=None):
-        self.name = self.__class__.__name__
-        self.set_logger()
-        self.path_install = modules
-        # Load info of the code
-        for k in info_theory:
-            setattr(self, k, info_theory[k])
-        # Timing
-        self.timing = timing
-        self.n = 0
-        self.time_avg = 0
 
     def d(self):
         """
@@ -86,9 +68,3 @@ class Theory(HasLogger, HasDefaults):
         fixed input parameters.
         """
         return len(self.input_params)
-
-    def __exit__(self, exception_type, exception_value, traceback):
-        if self.timing:
-            self.log.info("Average 'compute' evaluation time: %g s  (%d evaluations)" %
-                          (self.time_avg, self.n))
-        self.close()

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -55,7 +55,7 @@ def deepcopyfix(olddict):
         return deepcopy(olddict)
     newdict = {}
     for key in olddict:
-        if (key == 'theory' or key == 'instance' or key == 'external'):
+        if key == 'theory' or key == 'instance' or key == 'external':
             newdict[key] = olddict[key]
         else:
             # print(key)
@@ -498,7 +498,7 @@ def create_banner(msg, symbol="*", length=None):
     msg_clean = cleandoc(msg)
     if not length:
         length = max([len(line) for line in msg_clean.split("\n")])
-    return (symbol * length + "\n" + msg_clean + "\n" + symbol * length + "\n")
+    return symbol * length + "\n" + msg_clean + "\n" + symbol * length + "\n"
 
 
 def warn_deprecation_python2(logger=None):
@@ -559,7 +559,7 @@ def deepcopy_where_possible(base):
     compromise solution.
     """
     if isinstance(base, Mapping):
-        _copy = (base.__class__)()
+        _copy = base.__class__()
         for key, value in (base or {}).items():
             key_copy = deepcopy(key)
             _copy[key_copy] = deepcopy_where_possible(value)

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -123,7 +123,7 @@ def get_class(name, kind=None, None_if_not_found=False, allow_external=True, cla
         if allow_external and not module_path:
             try:
                 return getattr(import_module(name), class_name)
-            except:
+            except Exception as e:
                 pass
         if ((exc_info[0] is ModuleNotFoundError and
              str(exc_info[1]).rstrip("'").endswith(name))):

--- a/docs/cobaya-example.ipynb
+++ b/docs/cobaya-example.ipynb
@@ -587,10 +587,10 @@
     "import getdist.plots as gdplt\n",
     "\n",
     "gdsamples = MCSamplesFromCobaya(updated_info, products[\"sample\"])\n",
-    "gdplot = gdplt.getSubplotPlotter(width_inch=5)\n",
+    "gdplot = gdplt.get_subplot_plotter(width_inch=5)\n",
     "gdplot.triangle_plot(gdsamples, [\"x\", \"y\"], filled=True)\n",
     "gdplot.export(\"example_adv_ring.png\")\n",
-    "gdplot = gdplt.getSubplotPlotter(width_inch=5)\n",
+    "gdplot = gdplt.get_subplot_plotter(width_inch=5)\n",
     "gdplot.plots_1d(gdsamples, [\"r\", \"theta\"], nx=2)\n",
     "gdplot.export(\"example_adv_r_theta.png\")"
    ]
@@ -1968,7 +1968,7 @@
    "source": [
     "gdsamples_xGTy = MCSamplesFromCobaya(\n",
     "    updated_info_xGTy, products_xGTy[\"sample\"])\n",
-    "gdplot = gdplt.getSubplotPlotter(width_inch=5)\n",
+    "gdplot = gdplt.get_subplot_plotter(width_inch=5)\n",
     "gdplot.triangle_plot(gdsamples_xGTy, [\"x\", \"y\"], filled=True)\n",
     "gdplot.export(\"example_adv_half.png\")"
    ]
@@ -2972,9 +2972,9 @@
    "source": [
     "gdsamples_alt = MCSamplesFromCobaya(\n",
     "    updated_info_alt, products_alt[\"sample\"])\n",
-    "gdplot = gdplt.getSubplotPlotter(width_inch=5)\n",
+    "gdplot = gdplt.get_subplot_plotter(width_inch=5)\n",
     "gdplot.triangle_plot(gdsamples_alt, [\"x\", \"y\"], filled=True)\n",
-    "gdplot = gdplt.getSubplotPlotter(width_inch=5)\n",
+    "gdplot = gdplt.get_single_plotter(width_inch=5)\n",
     "gdplot.plots_1d(gdsamples_alt, [\"r\", \"theta\"], nx=2)"
    ]
   },
@@ -3557,9 +3557,9 @@
    "source": [
     "gdsamples_rtheta = MCSamplesFromCobaya(\n",
     "    updated_info_rtheta, products_rtheta[\"sample\"])\n",
-    "gdplot = gdplt.getSubplotPlotter(width_inch=5)\n",
+    "gdplot = gdplt.get_subplot_plotter(width_inch=5)\n",
     "gdplot.triangle_plot(gdsamples_rtheta, [\"x\", \"y\"], filled=True)\n",
-    "gdplot = gdplt.getSubplotPlotter(width_inch=5)\n",
+    "gdplot = gdplt.get_subplot_plotter(width_inch=5)\n",
     "gdplot.triangle_plot(gdsamples_rtheta, [\"r\", \"theta\"], filled=True)"
    ]
   },

--- a/docs/cosmo_basic_runs.rst
+++ b/docs/cosmo_basic_runs.rst
@@ -79,7 +79,7 @@ As an example, here is the input for Planck 2015 base :math:`\Lambda\mathrm{CDM}
 
 Save the input generated to a file and run it with ``cobaya-run [your_input_file_name.yaml]``. This will create output files as explained :ref:`here <output_shell>`, and, after some time, you should be able to run ``GetDistGUI`` to generate some plots.
 
-Typical running times for MCMC when using computationally heavy likelihoods (e.g. those involving :math:`C_\ell`, or non-linear :math:`P(k,z)` for several redshifts) are ~10 hours running 4 MPI processes with 4 OpenMP threads per process, provided that the initial covariance matrix is a good approximation to the one of the real posterior (Cobaya tries to select it automatically from a database; check the ``[mcmc]`` output towards the top to see if it succeded), or a few hours on top of that if the initial covariance matrix is not a good approximation.
+Typical running times for MCMC when using computationally heavy likelihoods (e.g. those involving :math:`C_\ell`, or non-linear :math:`P(k,z)` for several redshifts) are ~10 hours running 4 MPI processes with 4 OpenMP threads per process, provided that the initial covariance matrix is a good approximation to the one of the real posterior (Cobaya tries to select it automatically from a database; check the ``[mcmc]`` output towards the top to see if it succeeded), or a few hours on top of that if the initial covariance matrix is not a good approximation.
 
 It is much harder to provide typical PolyChord running times. We recommend starting with a low number of live points and a low convergence tolerance, and build up from there towards PolyChord's default settings (or higher, if needed).
 

--- a/docs/cosmo_external_likelihood.rst
+++ b/docs/cosmo_external_likelihood.rst
@@ -1,7 +1,8 @@
 Creating your own cosmological likelihood
 =========================================
 
-Creating your own cosmological likelihood with **cobaya** is super simple:
+Creating your own cosmological likelihood with **cobaya** is super simple. You can either define a likelihood class (see :doc:`cosmo_external_likelihood_class`),
+or here we simply make a likelihood function:
 
 #. Define your likelihood as a function that takes some parameters (experimental errors, foregrounds, etc, but **not theory** parameters) and returns a log-likelihood.
 #. Take note of the observables and other cosmological quantities that you will need to request from the theory code. Look them up in the :func:`~theories._cosmo._cosmo.needs` (clickable!) method documentation. *[If you cannot find the observable that you need, do let us know!]*

--- a/docs/cosmo_external_likelihood.rst
+++ b/docs/cosmo_external_likelihood.rst
@@ -182,6 +182,9 @@ Now we can start sampling. To do that, you can save all the definitions above in
    from cobaya.run import run
    run(info)
 
+.. note::
+
+    For the moment you must make a new info dictionary to call cobaya.run, you cannot reuse the same info previously used to call get_model for testing.
 
 Alternatively, specially if you are planning to share your likelihood, you can put its definition (including the fiducial spectrum, maybe saved as a table separately) in a separate file, say ``my_like_file.py``. In this case, to use it, use ``import_module([your_file_without_extension]).your_function``, here
 

--- a/docs/cosmo_external_likelihood_class.rst
+++ b/docs/cosmo_external_likelihood_class.rst
@@ -207,6 +207,6 @@ The provided BAO likelihoods base from :class:`_bao_prototype`, reading from sim
 The  :class:`_des_prototype` likelihood (based from *_DataSetLikelihood*) implements the DES Y1 likelihood, using the
 matter power spectra to calculate shear, count and cross-correlation angular power spectra internally.
 
-The `example external CMB likelihood <https://github.com/CobayaSampler/planck_lensing_external>_` is a complete example
+The `example external CMB likelihood <https://github.com/CobayaSampler/planck_lensing_external>`_ is a complete example
 of how to make a new likelihood class in an external Oython package.
 

--- a/docs/cosmo_external_likelihood_class.rst
+++ b/docs/cosmo_external_likelihood_class.rst
@@ -25,14 +25,13 @@ A minimal framework would look like this
 
             self.data = np.loadtxt(self.cl_file)
 
-        def add_theory(self):
+        def get_requirements(self):
             """
-             Specifying which quantities calculated by a theory code are needed
-             by calling self.theory.needs.
+             return dictionary specifying quantities calculated by a theory code are needed
 
              e.g. here we need C_L^{tt} to lmax=2500 and the H0 value
             """
-            self.theory.needs(Cl={'tt': 2500}, H0=None)
+            return {'Cl': {'tt': 2500}, 'H0': None}
 
         def logp(self, **params_values):
             """
@@ -46,8 +45,7 @@ A minimal framework would look like this
             my_foreground_amp = params_values['my_foreground_amp']
 
             chi2 = ...
-            return -chi2/2
-
+            return -chi2 / 2
 
 You can also implement an optional ``close`` method doing whatever needs to be done at the end of the sampling (e.g. releasing memory).
 
@@ -83,6 +81,14 @@ If it is more than a few milliseconds consider recoding more carefully or using 
 
 Many real-world examples are available in cobaya.likelihoods, which you may be able to adapt as needed for more
 complex cases, and a number of base class are pre-defined that you may find useful to inherit from instead of Likelihood directly.
+
+There is no fundamental difference between internal likelihood classes (in the Cobaya likelihoods pacakge) or
+distributed externally. However, if you are distributing externally you may also wish to provide a way to
+calculate the liklihood from pre-computed theory inputs as well as via Cobaya. This is easily done by extracting
+the theory results in ``logp`` and them passing them and the nuisance parametrss to a separate function,
+e.g. `log_likelihood` where the calculation is actually done. Your log_likelihood function can then be called outside
+Cobaya to calculate the likelihood for any externally provided theory results (as well as being directly usable in
+Cobaya via ``logp``).
 
 _InstallableLikelihood
 -------------------------
@@ -153,8 +159,7 @@ For example *planck_2018_lensing.native* (which is installed as an internal like
         dataset_file: lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8.dataset
         # Overriding of .dataset parameters
         dataset_params:
-          # field: value
-        field_names: [T, E, B, P]
+
         # Overriding of the maximum ell computed
         l_max:
         # Aliases for automatic covariance matrix

--- a/docs/cosmo_external_likelihood_class.rst
+++ b/docs/cosmo_external_likelihood_class.rst
@@ -176,7 +176,7 @@ Real-world examples
 
 The simplest example are the :class:`_H0_prototype` likelihoods, which are just implemented as simple Gaussians.
 
-For an examples of more complex real-world CMB likelihoods, see the `cobaya.likelihoods.bicep_keck_2015` and lensing likelihood shown above (both
+For an examples of more complex real-world CMB likelihoods, see :class:`bicep_keck_2015` and the lensing likelihood shown above (both
 using CMBlikes format), or :class:`_planck_2018_CamSpec_python` for a full Python implementation of the
 multi-frequency Planck likelihood (based from *_DataSetLikelihood*). The :class:`_planck_pliklite_prototype`
 likelihood implements the plik-lite foreground-marginalized likelihood. Both the plik-like and CamSpec likelihoods

--- a/docs/cosmo_external_likelihood_class.rst
+++ b/docs/cosmo_external_likelihood_class.rst
@@ -1,0 +1,189 @@
+Creating your own cosmological likelihood class
+===============================================
+
+Creating new internal likelihoods or external likelihood classes should be straightforward.
+For simple cases you can also just define a likelihood function (see :doc:`cosmo_external_likelihood`).
+
+Likelihoods should inherit from the base :class:`.likelihood.Likelihood` class, or one of the existing extensions.
+A minimal framework would look like this
+
+.. code:: python
+
+    from cobaya.likelihood import Likelihood
+    import numpy as np
+    import os
+
+    class my_likelihood(Likelihood):
+
+        def initialize(self):
+            """
+             Prepare any computation, importing any necessary code, files, etc.
+
+             e.g. here we load some data file, with default cl_file set in .yaml below,
+             or overriden when running cobaya.
+            """
+
+            self.data = np.loadtxt(self.cl_file)
+
+        def add_theory(self):
+            """
+             Specifying which quantities calculated by a theory code are needed
+             by calling self.theory.needs.
+
+             e.g. here we need C_L^{tt} to lmax=2500 and the H0 value
+            """
+            self.theory.needs(Cl={'tt': 2500}, H0=None)
+
+        def logp(self, **params_values):
+            """
+            Taking a dictionary of (sampled) nuisance parameter values params_values
+            and return a log-likelihood.
+
+            e.g. here we calculate chi^2  using cls['tt'], H0_theory, my_foreground_amp
+            """
+            H0_theory = self.theory.get_param("H0")
+            cls = self.theory.get_Cl(ell_factor=True)
+            my_foreground_amp = params_values['my_foreground_amp']
+
+            chi2 = ...
+            return -chi2/2
+
+
+You can also implement an optional ``close`` method doing whatever needs to be done at the end of the sampling (e.g. releasing memory).
+
+The default settings for your likelihood are specified in a ``my_likelihood.yaml`` file in the same folder as the class module, for example
+
+
+.. code:: yaml
+
+    likelihood:
+      mylikes.my_likelihood:
+        cl_file: /path/do/data_file
+        # Aliases for automatic covariance matrix
+        renames: [myOld]
+        # Speed in evaluations/second (after theory inputs calculated).
+        speed: 500
+    params:
+      my_foreground_amp:
+        prior:
+          dist: uniform
+          min: 0
+          max: 100
+        ref:
+          dist: norm
+          loc: 153
+          scale: 27
+        proposal: 27
+        latex: A^{f}_{\rm{mine}}
+
+
+Note that if you have several nuisance parameters, fast-slow samplers will benefit from making your
+likelihood faster even if it is already fast compared to the theory calculation.
+If it is more than a few milliseconds consider recoding more carefully or using numba where needed.
+
+Many real-world examples are available in cobaya.likelihoods, which you may be able to adapt as needed for more
+complex cases, and a number of base class are pre-defined that you may find useful to inherit from instead of Likelihood directly.
+
+_InstallableLikelihood
+-------------------------
+
+This supports the default auto-installation. Just add a class-level string specifying installation options, e.g.
+
+.. code:: python
+
+    from cobaya.likelihoods._base_classes import _InstallableLikelihood
+
+    class my_likelihood(_InstallableLikelihood):
+        install_options = {"github_repository": "MyGithub/my_repository",
+                           "github_release": "master"}
+
+        ...
+
+
+You can also use install_options = {"download_url":"..url.."}
+
+_DataSetLikelihood
+-------------------
+
+This inherits from *_InstallableLikelihood* and wraps loading settings from a .ini-format .dataset file giving setting
+related to the likelihood (specified as *dataset_file* in the input .yaml).
+
+.. code:: python
+
+    from cobaya.likelihoods._base_classes import _DataSetLikelihood
+
+    class my_likelihood(_DataSetLikelihood):
+
+        def init_params(self, ini):
+            """
+            Load any settings from the .dataset file (ini).
+
+            e.g. here load from "cl_file=..." specified in the dataset file
+            """
+
+            self.cl_data = np.load_txt(ini.string('cl_file'))
+        ...
+
+
+_cmblikes_prototype
+--------------------
+
+This the *CMBlikes* self-describing text .dataset format likelihood inherited from *_DataSetLikelihood* (as used by the
+Bicep and Planck lensing likelihoods). This already implements the calculation of Gaussian and Hammimeche-Lewis
+likelihoods from binned C_L data, so in simple cases you don't need to override anything, you just supply the
+.yaml and .dataset file (and corresponding references data and covariance files).
+Extensions and optimizations are welcome as pull requests.
+
+.. code:: python
+
+    from cobaya.likelihoods._base_classes import _cmblikes_prototype
+
+    class my_likelihood(_cmblikes_prototype):
+        install_options = {"github_repository": "CobayaSampler/planck_supp_data_and_covmats"}
+        pass
+
+For example *planck_2018_lensing.native* (which is installed as an internal likelihood) has this .yaml file
+
+.. code:: yaml
+
+    likelihood:
+      planck_2018_lensing.native:
+        # Path to the data: where the planck_supp_data_and_covmats has been cloned
+        path: null
+        dataset_file: lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8.dataset
+        # Overriding of .dataset parameters
+        dataset_params:
+          # field: value
+        field_names: [T, E, B, P]
+        # Overriding of the maximum ell computed
+        l_max:
+        # Aliases for automatic covariance matrix
+        renames: [lensing]
+        # Speed in evaluations/second
+        speed: 50
+
+    params: !defaults [../planck_2018_highl_plik/params_calib]
+
+The description of the data files and default settings are in the `dataset file <https://github.com/CobayaSampler/planck_supp_data_and_covmats/blob/master/lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8.dataset>`_.
+The :class:`bicep_keck_2015` likelihood provides a more complicated model that adds methods to implement the foreground model.
+
+This example also demonstrates how to share nuisance parameter settings between likelihoods: in this example all the
+Planck likelihoods depend on the calibration parameter, where here the default settings for that are loaded from the
+.yaml file under *planck_2018_highl_plik*.
+
+Real-world examples
+--------------------
+
+The simplest example are the :class:`_H0_prototype` likelihoods, which are just implemented as simple Gaussians.
+
+For an examples of more complex real-world CMB likelihoods, see the `cobaya.likelihoods.bicep_keck_2015` and lensing likelihood shown above (both
+using CMBlikes format), or :class:`_planck_2018_CamSpec_python` for a full Python implementation of the
+multi-frequency Planck likelihood (based from *_DataSetLikelihood*). The :class:`_planck_pliklite_prototype`
+likelihood implements the plik-lite foreground-marginalized likelihood. Both the plik-like and CamSpec likelihoods
+support doing general multipole and spectrum cuts on the fly by setting override dataset parameters in the input .yaml.
+
+The provided BAO likelihoods base from :class:`_bao_prototype`, reading from simlpe text files.
+
+The  :class:`_des_prototype` likelihood (based from *_DataSetLikelihood*) implements the DES Y1 likelihood, using the
+matter power spectra to calculate shear, count and cross-correlation angular power spectra internally.
+

--- a/docs/cosmo_external_likelihood_class.rst
+++ b/docs/cosmo_external_likelihood_class.rst
@@ -208,5 +208,5 @@ The  :class:`_des_prototype` likelihood (based from *_DataSetLikelihood*) implem
 matter power spectra to calculate shear, count and cross-correlation angular power spectra internally.
 
 The `example external CMB likelihood <https://github.com/CobayaSampler/planck_lensing_external>`_ is a complete example
-of how to make a new likelihood class in an external Oython package.
+of how to make a new likelihood class in an external Python package.
 

--- a/docs/cosmo_external_likelihood_class.rst
+++ b/docs/cosmo_external_likelihood_class.rst
@@ -13,14 +13,14 @@ A minimal framework would look like this
     import numpy as np
     import os
 
-    class my_likelihood(Likelihood):
+    class MyLikelihood(Likelihood):
 
         def initialize(self):
             """
              Prepare any computation, importing any necessary code, files, etc.
 
              e.g. here we load some data file, with default cl_file set in .yaml below,
-             or overriden when running cobaya.
+             or overridden when running Cobaya.
             """
 
             self.data = np.loadtxt(self.cl_file)
@@ -49,13 +49,13 @@ A minimal framework would look like this
 
 You can also implement an optional ``close`` method doing whatever needs to be done at the end of the sampling (e.g. releasing memory).
 
-The default settings for your likelihood are specified in a ``my_likelihood.yaml`` file in the same folder as the class module, for example
+The default settings for your likelihood are specified in a ``MyLikelihood.yaml`` file in the same folder as the class module, for example
 
 
 .. code:: yaml
 
     likelihood:
-      mylikes.my_likelihood:
+      __self__:
         cl_file: /path/do/data_file
         # Aliases for automatic covariance matrix
         renames: [myOld]
@@ -75,17 +75,32 @@ The default settings for your likelihood are specified in a ``my_likelihood.yaml
         latex: A^{f}_{\rm{mine}}
 
 
+You can use the special ``__self__`` likelihood name in default. yaml files instead of the explicit name of the likelihood,
+so that the .yaml does not need to be changed if you rename something or convert between internal and external installation.
+
+When running Cobaya, you reference your likelihood in the form ``module_name.ClassName``. For example,
+if your MyLikelihood class is in a module called ``mylikes` your input .yaml would be
+
+.. code:: yaml
+
+    likelihood:
+      mylikes.MyLikelihood:
+        # .. any parameters you want to override
+        # ..
+
+If your class name matches the module name, you can also just use the module name.
+
 Note that if you have several nuisance parameters, fast-slow samplers will benefit from making your
 likelihood faster even if it is already fast compared to the theory calculation.
-If it is more than a few milliseconds consider recoding more carefully or using numba where needed.
+If it is more than a few milliseconds consider recoding more carefully or using `numba <http://numba.pydata.org/>`_ where needed.
 
 Many real-world examples are available in cobaya.likelihoods, which you may be able to adapt as needed for more
 complex cases, and a number of base class are pre-defined that you may find useful to inherit from instead of Likelihood directly.
 
-There is no fundamental difference between internal likelihood classes (in the Cobaya likelihoods pacakge) or
+There is no fundamental difference between internal likelihood classes (in the Cobaya likelihoods package) or those
 distributed externally. However, if you are distributing externally you may also wish to provide a way to
-calculate the liklihood from pre-computed theory inputs as well as via Cobaya. This is easily done by extracting
-the theory results in ``logp`` and them passing them and the nuisance parametrss to a separate function,
+calculate the likelihood from pre-computed theory inputs as well as via Cobaya. This is easily done by extracting
+the theory results in ``logp`` and them passing them and the nuisance parameters to a separate function,
 e.g. `log_likelihood` where the calculation is actually done. Your log_likelihood function can then be called outside
 Cobaya to calculate the likelihood for any externally provided theory results (as well as being directly usable in
 Cobaya via ``logp``).
@@ -99,7 +114,7 @@ This supports the default auto-installation. Just add a class-level string speci
 
     from cobaya.likelihoods._base_classes import _InstallableLikelihood
 
-    class my_likelihood(_InstallableLikelihood):
+    class MyLikelihood(_InstallableLikelihood):
         install_options = {"github_repository": "MyGithub/my_repository",
                            "github_release": "master"}
 
@@ -118,7 +133,7 @@ related to the likelihood (specified as *dataset_file* in the input .yaml).
 
     from cobaya.likelihoods._base_classes import _DataSetLikelihood
 
-    class my_likelihood(_DataSetLikelihood):
+    class MyLikelihood(_DataSetLikelihood):
 
         def init_params(self, ini):
             """
@@ -131,7 +146,7 @@ related to the likelihood (specified as *dataset_file* in the input .yaml).
         ...
 
 
-_cmblikes_prototype
+_CMBlikes
 --------------------
 
 This the *CMBlikes* self-describing text .dataset format likelihood inherited from *_DataSetLikelihood* (as used by the
@@ -142,9 +157,9 @@ Extensions and optimizations are welcome as pull requests.
 
 .. code:: python
 
-    from cobaya.likelihoods._base_classes import _cmblikes_prototype
+    from cobaya.likelihoods._base_classes import _CMBlikes
 
-    class my_likelihood(_cmblikes_prototype):
+    class MyLikelihood(_CMBlikes):
         install_options = {"github_repository": "CobayaSampler/planck_supp_data_and_covmats"}
         pass
 
@@ -153,7 +168,7 @@ For example *planck_2018_lensing.native* (which is installed as an internal like
 .. code:: yaml
 
     likelihood:
-      planck_2018_lensing.native:
+      __self__:
         # Path to the data: where the planck_supp_data_and_covmats has been cloned
         path: null
         dataset_file: lensing/2018/smicadx12_Dec5_ftl_mv2_ndclpp_p_teb_consext8.dataset
@@ -191,4 +206,7 @@ The provided BAO likelihoods base from :class:`_bao_prototype`, reading from sim
 
 The  :class:`_des_prototype` likelihood (based from *_DataSetLikelihood*) implements the DES Y1 likelihood, using the
 matter power spectra to calculate shear, count and cross-correlation angular power spectra internally.
+
+The `example external CMB likelihood <https://github.com/CobayaSampler/planck_lensing_external>_` is a complete example
+of how to make a new likelihood class in an external Oython package.
 

--- a/docs/cosmo_external_likelihood_class.rst
+++ b/docs/cosmo_external_likelihood_class.rst
@@ -79,7 +79,7 @@ You can use the special ``__self__`` likelihood name in default. yaml files inst
 so that the .yaml does not need to be changed if you rename something or convert between internal and external installation.
 
 When running Cobaya, you reference your likelihood in the form ``module_name.ClassName``. For example,
-if your MyLikelihood class is in a module called ``mylikes` your input .yaml would be
+if your MyLikelihood class is in a module called ``mylikes`` your input .yaml would be
 
 .. code:: yaml
 

--- a/docs/example_advanced.rst
+++ b/docs/example_advanced.rst
@@ -70,9 +70,9 @@ And now we plot the posterior for ``x``, ``y``, the radius and the angle:
     import getdist.plots as gdplt
 
     gdsamples = MCSamplesFromCobaya(updated_info, products["sample"])
-    gdplot = gdplt.getSubplotPlotter(width_inch=5)
+    gdplot = gdplt.get_subplot_plotter(width_inch=5)
     gdplot.triangle_plot(gdsamples, ["x", "y"], filled=True)
-    gdplot = gdplt.getSubplotPlotter(width_inch=5)
+    gdplot = gdplt.get_subplot_plotter(width_inch=5)
     gdplot.plots_1d(gdsamples, ["r", "theta"], nx=2)
 
 
@@ -96,7 +96,7 @@ Let's run with the same configuration and analyse the output:
 
     gdsamples_xGTy = MCSamplesFromCobaya(
         updated_info_xGTy, products_xGTy["sample"])
-    gdplot = gdplt.getSubplotPlotter(width_inch=5)
+    gdplot = gdplt.get_subplot_plotter(width_inch=5)
     gdplot.triangle_plot(gdsamples_xGTy, ["x", "y"], filled=True)
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Table of contents
    cosmo_troubleshooting
    cosmo_model
    cosmo_external_likelihood
+   cosmo_external_likelihood_class
 
 .. toctree::
    :caption: Cosmological theory codes

--- a/docs/likelihoods.rst
+++ b/docs/likelihoods.rst
@@ -18,13 +18,15 @@ Likelihoods are specified under the `likelihood` block, together with their opti
 
 Likelihood parameters are specified within the ``params`` block, as explained in :doc:`params_prior`.
 
-**cobaya** comes with a number of *internal* general and cosmological likelihoods. You can define your *external* ones too with simple Python functions, as explained below.
+**cobaya** comes with a number of *internal* general and cosmological likelihoods.
+You can define your *external* ones too with simple Python functions, as explained below, or as a Python class
+defined in an external module.
 
 
 .. _likelihood_external:
 
-*External* likelihoods: how to quickly define your own
-------------------------------------------------------
+*External* likelihoods: how to quickly define your own functions
+----------------------------------------------------------------
 
 *External* likelihoods are defined as:
 
@@ -110,6 +112,35 @@ You only need to specify one, or at most four, functions (see the :class:`Likeli
 You can use the :doc:`Gaussian mixtures likelihood <likelihood_gaussian_mixture>` as a guide. If your likelihood needs a cosmological code, just define one in the input file and you can automatically access it as an attribute of your class: ``[your_likelihood].theory``. Use the :doc:`Planck likelihood <likelihood_planck>` as a guide to create your own cosmological likelihood.
 
 .. note:: ``_theory`` and ``_derived`` are reserved parameter names: you cannot use them as options in your defaults file!
+
+
+Implementing your own *external* likelihood class
+--------------------------------------------------
+
+Instead of including the likelihood within the standard Cobaya likelihood modules, you may wish to make an external
+package that can be redistributed easily. To do this you make a module containing a class defined exactly the same way
+as for internal likelihoods above (inheriting from :class:`Likelihood` as documentated below). By default the class is
+assumed to have the same name as the containing file, e.g. if you have a package called *mycodes*, containing
+a likelihood in *mycodes.mylike* you can use
+
+  .. code-block:: yaml
+
+     likelihood:
+       mycodes.mylike:
+         [option 1]: [value 1]
+         [...]
+
+This is assuming that *mycodes.mylike* contains a likelihood class called *mylike* and that the *mycodes* is on your
+Python path. You can also specify an explicit class name and path for the module, e.g.
+
+  .. code-block:: yaml
+
+     likelihood:
+       mycodes.mylike:
+         class_name: MyLikelihood
+         python_path: /path/to/mycodes_dir
+         [option 1]: [value 1]
+         [...]
 
 
 Likelihood module

--- a/docs/likelihoods.rst
+++ b/docs/likelihoods.rst
@@ -120,7 +120,7 @@ Implementing your own *external* likelihood class
 
 Instead of including the likelihood within the standard Cobaya likelihood modules, you may wish to make an external
 package that can be redistributed easily. To do this you make a module containing a class defined exactly the same way
-as for internal likelihoods above (inheriting from :class:`Likelihood` as documentated below). By default the class is
+as for internal likelihoods above (inheriting from :class:`Likelihood` as documented below). By default the class is
 assumed to have the same name as the containing file, e.g. if you have a package called *mycodes*, containing
 a likelihood in *mycodes.mylike* you can use
 

--- a/docs/likelihoods.rst
+++ b/docs/likelihoods.rst
@@ -165,7 +165,7 @@ You can also specify an explicit path for the module, e.g.
   .. code-block:: yaml
 
      likelihood:
-       mycodes.mylike.MyLike:
+       mycodes.mylikes.MyLike:
          python_path: /path/to/mycodes_dir
          [option 1]: [value 1]
          [...]

--- a/docs/likelihoods.rst
+++ b/docs/likelihoods.rst
@@ -106,7 +106,7 @@ You only need to specify one, or at most four, functions (see the :class:`.likel
 
 - A ``logp`` method taking a dictionary of (sampled) parameter values and returning a log-likelihood.
 - An (optional) ``initialize`` method preparing any computation, importing any necessary code, etc.
-- An (optional) ``add_theory`` method specifying the requests from the theory code, if it applies.
+- An (optional) ``get_requirements`` method returning dictionary of requests from the theory code, if needed.
 - An (optional) ``close`` method doing whatever needs to be done at the end of the sampling (e.g. releasing memory).
 
 You can use the :doc:`Gaussian mixtures likelihood <likelihood_gaussian_mixture>` as a guide. If your likelihood needs a cosmological code, just define one in the input file and you can automatically access it as an attribute of your class: ``[your_likelihood].theory``. Use the :doc:`Planck likelihood <likelihood_planck>` as a guide to create your own cosmological likelihood.
@@ -144,6 +144,7 @@ Python path. You can also specify an explicit class name and path for the module
          [...]
 
 For an example class implementation, check out :doc:`cosmo_external_likelihood_class`.
+There is also also a full example `external likelihood package <https://github.com/CobayaSampler/example_external_likelihood>`_.
 
 Likelihood module
 -----------------

--- a/docs/likelihoods.rst
+++ b/docs/likelihoods.rst
@@ -53,7 +53,7 @@ For an application, check out the :ref:`advanced example <example_advanced_likde
 If your external likelihood needs the products of a **theory code**:
 
 1. In your function definition, define a *keyword* argument ``_theory`` with a default value stating the *needs* of your theory code, i.e. the argument that will be passed to the ``needs`` method of the theory code, to let it know what needs to be computed at every iteration.
-2. At runtime, the current theory code instance will be passed through that keyword, so you can use it to invoke the methods that return the necessary producs.
+2. At runtime, the current theory code instance will be passed through that keyword, so you can use it to invoke the methods that return the necessary products.
 
 For an application, check out :doc:`cosmo_external_likelihood`.
 

--- a/docs/likelihoods.rst
+++ b/docs/likelihoods.rst
@@ -63,17 +63,18 @@ For an application, check out :doc:`cosmo_external_likelihood`.
 *Internal* likelihoods: code conventions and defaults
 -----------------------------------------------------
 
-*Internal* likelihoods are defined inside the ``likelihoods`` directory of the source tree. Each has its own directory, named as itself, containing at least *three* files:
+*Internal* likelihoods are defined inside the ``likelihoods`` directory of the source tree, where each subdirectory defines
+a subpackage containing one or more likelihoods. Each likelihood inherits from the :class:`.likelihood.Likelihood` class (see below).
+The subpackage contains at least two files:
 
-- A trivial ``__init__.py`` file containing a single line: ``from [name] import [name]``, where ``name`` is the name of the likelihood, and it's folder.
-- A ``[name].py`` file, containing the particular class definition of the likelihood, inheriting from the :class:`.likelihood.Likelihood` class (see below).
-- A ``[name].yaml`` file containing allowed options for the likelihood and the default *experimental model*:
+- the standard Python subpackage ``__init__.py`` file
+- a ``[ClassName].yaml`` file containing allowed options for each likelihood and the default *experimental model*:
 
   .. code-block:: yaml
 
      # Default options
      likelihood:
-       [name]:
+       __self__:
          [option 1]: [value 1]
          [...]
 
@@ -88,11 +89,38 @@ For an application, check out :doc:`cosmo_external_likelihood`.
 
   The options and parameters defined in this file are the only ones recognized by the likelihood, and they are loaded automatically with their default values (options) and priors (parameters) by simply mentioning the likelihood in the input file, where one can re-define any of those options with a different prior, value, etc (see :ref:`prior_inheritance`). The same parameter may be defined by different likelihoods; in those cases, it needs to have the same default information (prior, label, etc.) in the defaults file of all the likelihoods using it.
 
-- An *optional* ``[name].bibtex`` file containing *bibtex* references associated to the likelihood, if relevant.
+- An *optional* ``[ClassName].bibtex`` file containing *bibtex* references associated with each likelihood, if relevant.
+  Inherited likelihoods can be used to share a common .bibtex file, since the bibtex file is use by all descendants unless overridden.
 
 .. note::
 
-   Actually, there are some user-defined options that are common to all likelihoods and do not need to be specified in the defaults ``[name].yaml`` file, such as the computational ``speed`` of the likelihood (see :ref:`mcmc_speed_hierarchy`).
+   Actually, there are some user-defined options that are common to all likelihoods and do not need to be specified in the defaults ``[ClassName].yaml`` file, such as the computational ``speed`` of the likelihood (see :ref:`mcmc_speed_hierarchy`).
+
+
+It is up to you where to define your likelihood class(es): the ``__init__`` file can define a class [ClassName] directly, or you can define
+a class in a module.py file inside the likelihood directory (subpackage).
+
+Assuming your ``__init__`` file defines the class, or imports it (``from .module_name import ClassName``),
+when running Cobaya you can reference the internal likelihood using:
+
+  .. code-block:: yaml
+
+     likelihood:
+       directory_name.ClassName:
+         [option 1]: [value 1]
+         [...]
+
+If you defined the class in *module_name.py* then you would reference it as
+
+  .. code-block:: yaml
+
+     likelihood:
+       directory_name.module_name.ClassName:
+         [option 1]: [value 1]
+         [...]
+
+If the class name is the same as the module name it can be omitted.
+
 
 
 Implementing your own *internal* likelihood
@@ -100,7 +128,7 @@ Implementing your own *internal* likelihood
 
 Even if defining likelihoods with simple Python functions is easy, you may want to create a new *internal*-like likelihood to incorporate to your fork of **cobaya**, or to suggest us to include it in the main source.
 
-Since cobaya was created to be flexible, creating your own likelihood is very easy: simply create a folder with its name under ``likelihoods`` in the source tree and follow the conventions explained above for *internal* likelihoods. Options defined in the ``[name].yaml`` are automatically accessible as attributes of your likelihood class at runtime.
+Since cobaya was created to be flexible, creating your own likelihood is very easy: simply create a folder with its name under ``likelihoods`` in the source tree and follow the conventions explained above for *internal* likelihoods. Options defined in the ``[ClassName].yaml`` are automatically accessible as attributes of your likelihood class at runtime.
 
 You only need to specify one, or at most four, functions (see the :class:`.likelihood.Likelihood` class documentation below):
 
@@ -119,32 +147,32 @@ Implementing your own *external* likelihood class
 --------------------------------------------------
 
 Instead of including the likelihood within the standard Cobaya likelihood modules, you may wish to make an external
-package that can be redistributed easily. To do this you make a module containing a class defined exactly the same way
-as for internal likelihoods above (inheriting from :class:`Likelihood` as documented below). By default the class is
-assumed to have the same name as the containing file, e.g. if you have a package called *mycodes*, containing
-a likelihood in *mycodes.mylike* you can use
+package that can be redistributed easily. To do this you make a package containing a class defined exactly the same way
+as for internal likelihoods above (inheriting from :class:`Likelihood` as documented below). For example if you have a
+package called *mycodes*, containing a likelihood class called MyLike in *mycodes.mylikes*, when running Cobaya you can
+use the input
 
   .. code-block:: yaml
 
      likelihood:
-       mycodes.mylike:
+       mycodes.mylikes.MyLike:
          [option 1]: [value 1]
          [...]
 
-This is assuming that *mycodes.mylike* contains a likelihood class called *mylike* and that the *mycodes* is on your
-Python path. You can also specify an explicit class name and path for the module, e.g.
+This is assuming that *mycodes* is on your Python path (e.g. it is an installed package).
+You can also specify an explicit path for the module, e.g.
 
   .. code-block:: yaml
 
      likelihood:
-       mycodes.mylike:
-         class_name: MyLikelihood
+       mycodes.mylike.MyLike:
          python_path: /path/to/mycodes_dir
          [option 1]: [value 1]
          [...]
 
 For an example class implementation, check out :doc:`cosmo_external_likelihood_class`.
-There is also also a full example `external likelihood package <https://github.com/CobayaSampler/example_external_likelihood>`_.
+There is also a simple `external likelihood package <https://github.com/CobayaSampler/example_external_likelihood>`_
+and a real-word cosmology example in the `sample external CMB likelihood <https://github.com/CobayaSampler/planck_lensing_external>`_.
 
 Likelihood module
 -----------------

--- a/docs/likelihoods.rst
+++ b/docs/likelihoods.rst
@@ -19,7 +19,7 @@ Likelihoods are specified under the `likelihood` block, together with their opti
 Likelihood parameters are specified within the ``params`` block, as explained in :doc:`params_prior`.
 
 **cobaya** comes with a number of *internal* general and cosmological likelihoods.
-You can define your *external* ones too with simple Python functions, as explained below, or as a Python class
+You can also define your *external* likelihoods with simple Python functions, or by implementing a Python class
 defined in an external module.
 
 
@@ -28,7 +28,7 @@ defined in an external module.
 *External* likelihoods: how to quickly define your own functions
 ----------------------------------------------------------------
 
-*External* likelihoods are defined as:
+*External* likelihood functions are defined as:
 
 .. code:: yaml
 
@@ -66,7 +66,7 @@ For an application, check out :doc:`cosmo_external_likelihood`.
 *Internal* likelihoods are defined inside the ``likelihoods`` directory of the source tree. Each has its own directory, named as itself, containing at least *three* files:
 
 - A trivial ``__init__.py`` file containing a single line: ``from [name] import [name]``, where ``name`` is the name of the likelihood, and it's folder.
-- A ``[name].py`` file, containing the particular class definition of the likelihood, inheriting from the :class:`Likelihood` class (see below).
+- A ``[name].py`` file, containing the particular class definition of the likelihood, inheriting from the :class:`.likelihood.Likelihood` class (see below).
 - A ``[name].yaml`` file containing allowed options for the likelihood and the default *experimental model*:
 
   .. code-block:: yaml
@@ -102,7 +102,7 @@ Even if defining likelihoods with simple Python functions is easy, you may want 
 
 Since cobaya was created to be flexible, creating your own likelihood is very easy: simply create a folder with its name under ``likelihoods`` in the source tree and follow the conventions explained above for *internal* likelihoods. Options defined in the ``[name].yaml`` are automatically accessible as attributes of your likelihood class at runtime.
 
-You only need to specify one, or at most four, functions (see the :class:`Likelihood` class documentation below):
+You only need to specify one, or at most four, functions (see the :class:`.likelihood.Likelihood` class documentation below):
 
 - A ``logp`` method taking a dictionary of (sampled) parameter values and returning a log-likelihood.
 - An (optional) ``initialize`` method preparing any computation, importing any necessary code, etc.
@@ -113,6 +113,7 @@ You can use the :doc:`Gaussian mixtures likelihood <likelihood_gaussian_mixture>
 
 .. note:: ``_theory`` and ``_derived`` are reserved parameter names: you cannot use them as options in your defaults file!
 
+For an application, check out :doc:`cosmo_external_likelihood_class`.
 
 Implementing your own *external* likelihood class
 --------------------------------------------------
@@ -142,6 +143,7 @@ Python path. You can also specify an explicit class name and path for the module
          [option 1]: [value 1]
          [...]
 
+For an example class implementation, check out :doc:`cosmo_external_likelihood_class`.
 
 Likelihood module
 -----------------

--- a/docs/post.rst
+++ b/docs/post.rst
@@ -106,7 +106,7 @@ And let us define the additions and run post-processing:
    gdsamples_gaussian = MCSamplesFromCobaya(updinfo, results["sample"])
    gdsamples_post = MCSamplesFromCobaya(updinfo_post, results_post["sample"])
 
-   p = gdplt.getSubplotPlotter(width_inch=6)
+   p = gdplt.get_single_plotter(width_inch=6)
    p.plot_2d([gdsamples_gaussian, gdsamples_post], ["x", "y"], filled=True)
    p.add_x_bands(x_band_mean, x_band_std)
    p.add_legend(["Gaussian", "Post $y>0$ and $x$-band"], colored_text=True);

--- a/docs/src_examples/quickstart/analyze.py
+++ b/docs/src_examples/quickstart/analyze.py
@@ -12,5 +12,5 @@ print(covmat)
 # %matplotlib inline  # uncomment if running from the Jupyter notebook
 import getdist.plots as gdplt
 
-gdplot = gdplt.getSubplotPlotter()
+gdplot = gdplt.get_subplot_plotter()
 gdplot.triangle_plot(gd_sample, ["a", "b"], filled=True)

--- a/docs/src_examples/quickstart/analyze_alt2.py
+++ b/docs/src_examples/quickstart/analyze_alt2.py
@@ -3,5 +3,5 @@ import getdist.plots as gdplt
 import os
 
 folder, name = os.path.split(os.path.abspath(info["output"]))
-gdplot = gdplt.getSubplotPlotter(chain_dir=folder)
+gdplot = gdplt.get_subplot_plotter(chain_dir=folder)
 gdplot.triangle_plot(name, ["a", "b"], filled=True)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ setup(
     description='Bayesian Analysis in Cosmology',
     long_description=get_long_description(),
     url=__url__,
+    project_urls={
+        'Source': 'https://github.com/CobayaSampler/cobaya',
+        'Tracker': 'https://github.com/CobayaSampler/cobaya/issues',
+        'Licensing': 'https://github.com/CobayaSampler/cobaya/blob/master/LICENCE.txt'
+    },
     author=__author__,
     license='LGPL',
     zip_safe=False,
@@ -38,14 +43,15 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
     keywords='montecarlo sampling cosmology',
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['numpy>=1.12.0', 'scipy >= 1.0', 'pandas>=0.20',
                       'PyYAML>=5.1', 'wget>=3.2', 'imageio>=2.2.0', 'py-bobyqa>=1.1',
-                      'GetDist>=0.3.3', 'fuzzywuzzy>=0.17'],
+                      'GetDist>=1.0.2', 'fuzzywuzzy>=0.17'],
     extras_require={
         'test': ['pytest', 'pytest-xdist', 'flaky', 'mpi4py']},
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ setup(
         'Programming Language :: Python :: 3.8'
     ],
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
-    keywords='montecarlo sampling cosmology',
+    keywords='montecarlo sampling MCMC cosmology',
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['numpy>=1.12.0', 'scipy >= 1.0', 'pandas>=0.20',
                       'PyYAML>=5.1', 'wget>=3.2', 'imageio>=2.2.0', 'py-bobyqa>=1.1',
-                      'GetDist>=1.0.2', 'fuzzywuzzy>=0.17'],
+                      'GetDist>=1.0.2', 'fuzzywuzzy>=0.17', 'six'],
     extras_require={
         'test': ['pytest', 'pytest-xdist', 'flaky', 'mpi4py']},
     package_data={

--- a/tests/common_external.py
+++ b/tests/common_external.py
@@ -19,7 +19,7 @@ from cobaya.conventions import _chi2, _separator, _external, _input_params, _out
 from cobaya.run import run
 from cobaya.yaml import yaml_load
 from cobaya.likelihood import class_options
-from cobaya.tools import getargspec
+from cobaya.tools import getfullargspec
 
 # Definition of external (log)pdf's
 
@@ -90,7 +90,7 @@ def body_of_test(info_logpdf, kind, tmpdir, derived=False, manual=False):
         (info[_params]["y"][_prior]["max"] -
          info[_params]["y"][_prior]["min"]))
     logps = dict([
-        (name, logpdf(**dict([(arg, products["sample"][arg].values) for arg in getargspec(logpdf)[0]])))
+        (name, logpdf(**dict([(arg, products["sample"][arg].values) for arg in getfullargspec(logpdf)[0]])))
         for name, logpdf in {"half_ring": half_ring_func, "gaussian_y": gaussian_func}.items()])
     # Test #1: values of logpdf's
     if kind == _prior:

--- a/tests/common_external.py
+++ b/tests/common_external.py
@@ -131,7 +131,7 @@ def body_of_test(info_logpdf, kind, tmpdir, derived=False, manual=False):
             if not hasattr(value, "get"):
                 info_likelihood[lik] = {_external: value}
             info_likelihood[lik].update({k: v for k, v in class_options.items()
-                                         if not k in info_likelihood[lik]})
+                                         if k not in info_likelihood[lik]})
             for k in [_input_params, _output_params]:
                 updated_info[_likelihood][lik].pop(k)
         assert info_likelihood == dict(updated_info[_likelihood]), (

--- a/tests/common_sampler.py
+++ b/tests/common_sampler.py
@@ -198,14 +198,14 @@ def body_of_test_speeds(info_sampler={}, manual_blocking=False, modules=None):
     # Done! --> Tests
     if sampler == "polychord":
         tolerance = 0.2
-        assert abs((n2 - n1) / (n1) / (speed2 / speed1) - 1) < tolerance, (
+        assert abs((n2 - n1) / n1 / (speed2 / speed1) - 1) < tolerance, (
                 "#evaluations off: %g > %g" % (
-            abs((n2 - n1) / (n1) / (speed2 / speed1) - 1), tolerance))
+            abs((n2 - n1) / n1 / (speed2 / speed1) - 1), tolerance))
     # For MCMC tests, notice that there is a certain tolerance to be allowed for,
     # since for every proposed step the BlockedProposer cycles once, but the likelihood
     # may is not evaluated if the proposed point falls outside the prior bounds
     elif sampler == "mcmc" and info["sampler"][sampler].get("drag"):
-        assert abs((n2 - n1) / (n1) / (speed2 / speed1) - 1) < 0.1
+        assert abs((n2 - n1) / n1 / (speed2 / speed1) - 1) < 0.1
     elif sampler == "mcmc" and info["sampler"][sampler].get("oversample"):
         # Testing oversampling: number of evaluations per param * oversampling factor
         assert abs((n2 - n1) * dim / (n1 * dim) / (speed2 / speed1) - 1) < 0.1

--- a/tests/test_cosmo_camb.py
+++ b/tests/test_cosmo_camb.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from .common import process_modules_path
+import sys
+import os
+import pytest
+
+
+def test_sources(modules):
+    sys.path.insert(0, os.path.join(process_modules_path(modules), "code", "CAMB"))
+
+    import camb
+    from camb.sources import GaussianSourceWindow
+
+    params = {'ombh2': 0.02242, 'omch2': 0.11933, 'H0': 67.66, 'tau': 0.0561,
+              'mnu': 0.06, 'nnu': 3.046, 'num_massive_neutrinos': 1, 'ns': 0.9665, 'YHe': 0.2454, 'As': 2e-9}
+
+    pars = camb.set_params(**params)
+    pars.set_for_lmax(500)
+    pars.SourceWindows = [GaussianSourceWindow(redshift=0.17, source_type='counts', bias=1.2, sigma=0.04)]
+    results = camb.get_results(pars)
+    dic = results.get_source_cls_dict()
+
+    def test_likelihood(
+            _theory={'source_Cl': {'sources': {'source1':
+                                                   {'function': 'gaussian', 'source_type': 'counts', 'bias': 1.2,
+                                                    'redshift': 0.17, 'sigma': 0.04}},
+                                   'limber': True, 'lmax': 500}}):
+        assert abs(_theory.get_source_Cl()[('source1', 'source1')][100] / dic['W1xW1'][100] - 1) < 0.001, \
+            "CAMB gaussian source window results do not match"
+        return 0
+
+    info = {
+        'params': params,
+        'likelihood': {'test_likelihood': test_likelihood},
+        'theory': {'camb': {'stop_at_error': True}}
+    }
+
+    from cobaya.model import get_model
+    model = get_model(info)
+    model.loglike({})

--- a/tests/test_cosmo_planck_2015.py
+++ b/tests/test_cosmo_planck_2015.py
@@ -65,6 +65,8 @@ def test_planck_2015_l2_camb(modules):
     lik_name = "planck_2015_lensing_cmblikes"
     clik_name = "planck_2015_lensing"
     info_likelihood = {lik_name: lik_info_lensing[clik_name]}
+    info_likelihood ={lik_name: {'dataset_file':r'C:\Work\Dist\git\cosmomcplanck\data\planck_lensing\smica_g30_ftl_full_pp.dataset'}}
+
     chi2_lensing_cmblikes = deepcopy(chi2_lensing)
     chi2_lensing_cmblikes[lik_name] = chi2_lensing[clik_name]
     info_theory = {"camb": {"extra_args": cmb_precision["camb"]}}

--- a/tests/test_cosmo_planck_2018.py
+++ b/tests/test_cosmo_planck_2018.py
@@ -10,6 +10,7 @@ from cobaya.cosmo_input import cmb_precision
 # Generating plots in Travis
 try:
     import matplotlib
+
     matplotlib.use('agg')
 except:
     pass
@@ -34,6 +35,7 @@ def test_planck_2018_t_camb(modules):
     best_fit_derived = derived_lowl_highTT_lensing
     body_of_test(modules, best_fit, info_likelihood, info_theory,
                  chi2_lowl_highTT_lensing, best_fit_derived)
+
 
 def test_planck_2018_p_camb(modules):
     best_fit = deepcopy(params_lowTE_highTTTEEE_lensingcmblikes)
@@ -250,7 +252,6 @@ derived_lowl_highTT_lensing = {
     "thetaeq": [0.8255, 0.011],
     "thetarseq": [0.4557, 0.0057]}
 
-
 # Best fit polarization ##################################################################
 
 lik_info_lowTE_highTTTEEE_lensingcmblikes = {
@@ -323,7 +324,6 @@ derived_lowTE_highTTTEEE_lensingcmblikes = {
     "keq": [0.010393, 0.000081],
     "thetaeq": [0.81281, 0.0050],
     "thetarseq": [0.44912, 0.0026]}
-
 
 # Best fit CMB-marged lensing ############################################################
 


### PR DESCRIPTION
This is rebased to merge of getdist1, sources, external_modules merge.

It attempts to refactor some duplicated code into a base CobayaComponent class used by samplers, likelihoods and theories and tidies up some other random things. 

https://github.com/CobayaSampler/cobaya/issues/51 should be fixed in new Timer class (using py3). Some of the timing messages may have changed slightly.

I tried to rename references to "modules" where it actually more explicitly means an install path, and reduce the number of inherited variables in the base Likelihood class (and hence potentially conflicting) .

Is the d() function ever used anywhere except on a prior object? If not can be removed from all but prior.	