### PR TITLE
add ability to define ._defaults class attribute for Likelihood subclass

### DIFF
--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -87,8 +87,12 @@ class Likelihood(HasLogger, HasDefaults):
             logging.info('No YAML defaults available; relying on ._defaults class attribute if provided.')
             defaults = odict([('likelihood', odict([('__self__', {})]))])
 
-        class_defaults = odict(cls._defaults) if cls._defaults is not None else {}
-        defaults['likelihood']['__self__'].update(class_defaults)
+        # Specifically for externally defined likelihoods?
+        if 'likelihood' in defaults:
+            if '__self__' in defaults['likelihood']:
+                class_defaults = odict(cls._defaults) if cls._defaults is not None else {}
+                defaults['likelihood']['__self__'].update(class_defaults)
+
         return defaults
 
     # Optional

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -45,6 +45,8 @@ class_options = {"speed": -1, "stop_at_error": False}
 
 
 class Likelihood(HasLogger, HasDefaults):
+
+    _defaults = None
     """Likelihood class prototype."""
 
     # Generic initialization -- do not touch
@@ -76,6 +78,18 @@ class Likelihood(HasLogger, HasDefaults):
         self.time_std = np.inf
         if standalone:
             self.initialize()
+
+    @classmethod
+    def get_defaults(cls, **kwargs):
+        try:
+            defaults = super().get_defaults(**kwargs)
+        except TypeError:
+            logging.info('No YAML defaults available; relying on ._defaults class attribute if provided.')
+            defaults = odict([('likelihood', odict([('__self__', {})]))])
+
+        class_defaults = odict(cls._defaults) if cls._defaults is not None else {}
+        defaults['likelihood']['__self__'].update(class_defaults)
+        return defaults
 
     # Optional
     def initialize(self):


### PR DESCRIPTION
Haven't added any tests yet, but this works for the simple example I've been playing with.  I figured I'd put this in `Likelihood` rather than in `HasDefaults` just because I didn't know what else uses `HasDefaults`.  You can define a `._defaults` dictionary as a class attribute and a YAML file will not be required.  Basing off `external_modules` branch because that's where I'm working.