### PR TITLE
Add ability to *not* define YAML for external likelihood.

### DIFF
--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -18,6 +18,7 @@ import traceback
 from time import sleep
 import numpy as np
 from copy import deepcopy
+from collections import OrderedDict as odict
 
 # Local
 from cobaya.conventions import _external
@@ -37,6 +38,7 @@ class Likelihood(CobayaComponent):
     def __init__(self, info={}, name=None, timing=None, path_install=None,
                  standalone=True):
         name = name or self.get_qualified_class_name()
+        self.set_logger(name=name)
         if standalone:
             # TODO: would probably be more natural if defaults were already read here
             default_info = self.get_defaults()
@@ -55,6 +57,16 @@ class Likelihood(CobayaComponent):
                         for _ in range(self._n_states)]
         if standalone:
             self.initialize()
+
+    @classmethod
+    def update_defaults(cls, old, new):
+        if 'likelihood' not in old:
+            old['likelihood'] = odict([('__self__', odict())])
+        if 'likelihood' in new:
+            old['likelihood']['__self__'].update(new['likelihood']['__self__'])
+        else:
+            old['likelihood']['__self__'].update(new)
+        return old
 
     # Optional
     def initialize(self):


### PR DESCRIPTION
This promotes the existing `.class_options` dictionary to be used as defaults, if no YAML file is provided.  If both a YAML and `.class_options` are present, then values in `.class_options` will supersede those in the YAML.  The reasoning for this is to allow subclasses of `Likelihood` or subclasses thereof to override default values without having to create YAML files.  Default values also inherit from base classes, such that anything inheriting from `Likelihood` will have at least "default" defaults: `{'speed': -1, 'stop_at_error': False}`.  The .update_defaults method is to deal with the fact that the likelihood defaults live in a nested dictionary.  I don't know where else this is done, but other subclasses of `HasDefaults` could do similar.