### PR TITLE
Protect attempted MPI import

### DIFF
--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -70,7 +70,7 @@ def exception_handler(exception_type, exception_instance, trace_back):
     safe_exit()
 
 
-def logger_setup(debug=None, debug_file=None):
+def logger_setup(debug=None, debug_file=None, no_mpi=False):
     """
     Configuring the root logger, for its children to inherit level, format and handlers.
 
@@ -90,7 +90,7 @@ def logger_setup(debug=None, debug_file=None):
     class MyFormatter(logging.Formatter):
         def format(self, record):
             fmt = ((" %(asctime)s " if debug else "") +
-                   "[" + ("%d : " % get_mpi_rank() if more_than_one_process() else "") +
+                   "[" + ("%d : " % get_mpi_rank() if more_than_one_process(no_mpi=no_mpi) else "") +
                    "%(name)s" + "] " +
                    {logging.ERROR: "*ERROR* ",
                     logging.WARNING: "*WARNING* "}.get(record.levelno, "") +

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -77,13 +77,23 @@ def get_mpi_rank():
 
 
 # Aliases for simpler use
-def am_single_or_primary_process():
-    return not bool(get_mpi_rank())
+def am_single_or_primary_process(no_mpi=False):
+    """Returns true if primary process or MPI not available.
+
+    Use the no_mpi keyword to avoid checking for MPI via import, 
+    which can die ungracefully (e.g. on head nodes at NERSC).
+    """
+    if not no_mpi:
+        return not bool(get_mpi_rank())
+    else:
+        return True
 
 
-def more_than_one_process():
-    return bool(max(get_mpi_size(), 1) - 1)
-
+def more_than_one_process(no_mpi=False):
+    if not no_mpi:
+        return bool(max(get_mpi_size(), 1) - 1)
+    else:
+        return False
 
 def sync_processes():
     if get_mpi_size():


### PR DESCRIPTION
On a system where mpi4py is available but disallowed, the command 'from mpi4py import MPI' can cause an ungraceful script abort (e.g., on a head node at NERSC). This circumvents this for the cobaya-install script such that it can be run on a head node at NERSC.  I have tested that cobaya-install now works on head node at NERSC with this update.

As this issue also shows up in setting up the logger, the logger_setup call in the install script needed to be moved until after the arguments are parsed, to allow it to be protected.