### PR TITLE
Split camb into two Theory classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - changed use_planck_names to more general use_renames etc.
 - Greatly reduced deepcopy time overhead in loglike evaluation, faster uniform prior and sample collection
 - Global stop_at_error option to stop at error in any component
+- CAMB calculation using transfer functions for speed up with initial power spectrum parameters (even for non-linear lensing)
+- dragging now exploits blocks within slow and fast groups
 
 ### General
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,14 +11,13 @@
 ## Finish implementation of aggregated-by-data-type chi2
 ## Faster Collections for MCMC: numpy cache for merging OnePoint into Collection
 - `_out_update` method would take care of flushing into the Pandas table.
-## Check blocking/dragging when slowest block has all parameters fixed
 ## Option to set speeds dynamically based on actual timing for number of threads used (e.g. at first propose update)
 ## No output to files while burn in makes it hard to see if working OK (default no burn?)
 ## ,, related, how to set intermediate debugging level so see regular short output
 ## dump log info along with each chain file if saving to file (currently in stdout)
 ## check parameter default proposal widths not too large
 ## turn dragging off if only one block or no speeds differ by more than factor 2
-## specify how to calibrate speed factors (2018 defaults looks wrong, TTTEEE slower than TT)
+## specify how to calibrate speed factors (2018 defaults looked wrong, TTTEEE slower than TT)
 ## If non-linear lensing on, model the non-linear correction via limber for faster semi-slow parameters
 ## minimize run with -f does not work. Check resuming.
-## minimize with mpi and initial_point seems to start all runs at the same point??
+## unbounded parameters with flat prior (this would make it safe to rotate the unbounded ones in minimize)

--- a/TODO.md
+++ b/TODO.md
@@ -20,3 +20,4 @@
 ## minimize run with -f does not work. Check resuming.
 ## unbounded parameters with flat prior (this would make it safe to rotate the unbounded ones in minimize)
 ## ordering of helper theories
+## minimize updated yaml will overwrite chain updated yaml?

--- a/TODO.md
+++ b/TODO.md
@@ -21,3 +21,5 @@
 ## unbounded parameters with flat prior (this would make it safe to rotate the unbounded ones in minimize)
 ## ordering of helper theories
 ## minimize updated yaml will overwrite chain updated yaml?
+## Lots of batchjob stuff (hasConvergeBetterThan,wantCheckpointContinue etc) now broken
+## More pythonic alternative to class_options (e.g class or object attributes/properties)

--- a/TODO.md
+++ b/TODO.md
@@ -17,3 +17,6 @@
 ## ,, related, how to set intermediate debugging level so see regular short output
 ## dump log info along with each chain file if saving to file (currently in stdout)
 ## check parameter default proposal widths not too large
+## turn dragging off if only one block or no speeds differ by more than factor 2
+## specify how to calibrate speed factors (2018 defaults looks wrong, TTTEEE slower than TT)
+## If non-linear lensing on, model the non-linear correction via limber for faster semi-slow parameters

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 ## Update example notebook to match example in paper (+ updates)
 ## Make numba a requirement?
-## Update setting for model.overhead
-## Already added get_version(): should add as version trace dump with output files. Where?
 ## Let classes do all defaults combining; allow separate like instantiation + use equivalent to loading in cobaya
 ## Move sampler/plik install into class methods
 ## Support "parameterization" option of theory .yaml to specify parameter yaml variants?

--- a/TODO.md
+++ b/TODO.md
@@ -20,3 +20,5 @@
 ## turn dragging off if only one block or no speeds differ by more than factor 2
 ## specify how to calibrate speed factors (2018 defaults looks wrong, TTTEEE slower than TT)
 ## If non-linear lensing on, model the non-linear correction via limber for faster semi-slow parameters
+## minimize run with -f does not work. Check resuming.
+## minimize with mpi and initial_point seems to start all runs at the same point??

--- a/TODO.md
+++ b/TODO.md
@@ -11,4 +11,9 @@
 ## Finish implementation of aggregated-by-data-type chi2
 ## Faster Collections for MCMC: numpy cache for merging OnePoint into Collection
 - `_out_update` method would take care of flushing into the Pandas table.
-
+## Check blocking/dragging when slowest block has all parameters fixed
+## Option to set speeds dynamically based on actual timing for number of threads used (e.g. at first propose update)
+## No output to files while burn in makes it hard to see if working OK (default no burn?)
+## ,, related, how to set intermediate debugging level so see regular short output
+## dump log info along with each chain file if saving to file (currently in stdout)
+## check parameter default proposal widths not too large

--- a/TODO.md
+++ b/TODO.md
@@ -11,13 +11,12 @@
 ## Finish implementation of aggregated-by-data-type chi2
 ## Faster Collections for MCMC: numpy cache for merging OnePoint into Collection
 - `_out_update` method would take care of flushing into the Pandas table.
-## Option to set speeds dynamically based on actual timing for number of threads used (e.g. at first propose update)
 ## No output to files while burn in makes it hard to see if working OK (default no burn?)
 ## ,, related, how to set intermediate debugging level so see regular short output
 ## dump log info along with each chain file if saving to file (currently in stdout)
 ## check parameter default proposal widths not too large
 ## turn dragging off if only one block or no speeds differ by more than factor 2
-## specify how to calibrate speed factors (2018 defaults looked wrong, TTTEEE slower than TT)
 ## If non-linear lensing on, model the non-linear correction via limber for faster semi-slow parameters
 ## minimize run with -f does not work. Check resuming.
 ## unbounded parameters with flat prior (this would make it safe to rotate the unbounded ones in minimize)
+## ordering of helper theories

--- a/cobaya/bib.py
+++ b/cobaya/bib.py
@@ -54,8 +54,8 @@ def prettyprint_bib(blocks_text):
 
 # Command-line script
 def bib_script():
-    from cobaya.mpi import am_single_or_primary_process
-    if not am_single_or_primary_process():
+    from cobaya.mpi import is_main_process
+    if not is_main_process():
         return
     warn_deprecation()
     # Parse arguments and launch

--- a/cobaya/conventions.py
+++ b/cobaya/conventions.py
@@ -85,10 +85,7 @@ subfolders = {kinds.likelihood: "likelihoods",
               kinds.theory: "theories"}
 
 # Approximate overhead of cobaya per posterior evaluation. Useful for blocking speeds
-# After testing, it's mostly due to evaluating logpdf of scipy.stats 1d pdf's,
-# in particular ~0.1ms per param
-# (faster for most common cases, after manual override of logpdf)
-_overhead_per_param = 5e-6
+_overhead_time = 0.0003
 
 # Line width for console printing
 _line_width = 120

--- a/cobaya/cosmo_input/autoselect_covmat.py
+++ b/cobaya/cosmo_input/autoselect_covmat.py
@@ -11,7 +11,7 @@ import numpy as np
 # Local
 from cobaya.yaml import yaml_load_file, yaml_dump_file
 from cobaya.conventions import _covmats_file, _aliases, _path_install, partag
-from cobaya.input import str_to_list
+from cobaya.tools import str_to_list
 
 # Logger
 import logging
@@ -23,6 +23,7 @@ covmat_folders = ["{%s}/data/planck_supp_data_and_covmats/covmats/" % _path_inst
 
 
 def get_covmat_database(modules, cached=True):
+    from cobaya.mpi import am_single_or_primary_process
     # Get folders with corresponding modules installed
     installed_folders = [folder for folder in covmat_folders
                          if os.path.exists(folder.format(**{_path_install: modules}))]
@@ -51,7 +52,7 @@ def get_covmat_database(modules, cached=True):
             except:
                 continue
             covmat_database[folder].append({"name": filename, "params": params})
-    if cached:
+    if cached and am_single_or_primary_process():
         yaml_dump_file(covmats_database_fullpath, covmat_database, error_if_exists=False)
     return covmat_database
 

--- a/cobaya/cosmo_input/autoselect_covmat.py
+++ b/cobaya/cosmo_input/autoselect_covmat.py
@@ -23,7 +23,6 @@ covmat_folders = ["{%s}/data/planck_supp_data_and_covmats/covmats/" % _path_inst
 
 
 def get_covmat_database(modules, cached=True):
-    from cobaya.mpi import am_single_or_primary_process
     # Get folders with corresponding modules installed
     installed_folders = [folder for folder in covmat_folders
                          if os.path.exists(folder.format(**{_path_install: modules}))]
@@ -52,7 +51,7 @@ def get_covmat_database(modules, cached=True):
             except:
                 continue
             covmat_database[folder].append({"name": filename, "params": params})
-    if cached and am_single_or_primary_process():
+    if cached:
         yaml_dump_file(covmats_database_fullpath, covmat_database, error_if_exists=False)
     return covmat_database
 

--- a/cobaya/cosmo_input/input_database.py
+++ b/cobaya/cosmo_input/input_database.py
@@ -186,7 +186,7 @@ N_eff_std = 3.046
 nu_mass_fac = 94.0708
 matter = odict([
     ["omegab_h2, omegac_h2", {
-        _desc: "Flat prior on Omega*h^2 for barions and cold dark matter",
+        _desc: "Flat prior on Omega*h^2 for baryons and cold dark matter",
         kinds.theory: {_camb: None, _classy: None},
         _params: odict([
             ["omegabh2", odict([

--- a/cobaya/doc.py
+++ b/cobaya/doc.py
@@ -23,8 +23,8 @@ import_odict = "from collections import OrderedDict\n\ninfo = "
 # Command-line script ####################################################################
 
 def doc_script():
-    from cobaya.mpi import am_single_or_primary_process
-    if not am_single_or_primary_process():
+    from cobaya.mpi import is_main_process
+    if not is_main_process():
         return
     warn_deprecation()
     # Parse arguments

--- a/cobaya/grid_tools/__init__.py
+++ b/cobaya/grid_tools/__init__.py
@@ -1,2 +1,5 @@
 from .gridconfig import *
 from .runbatch import *
+from . import jobqueue
+
+jobqueue.set_default_program('cobaya-run', 'COBAYA')

--- a/cobaya/grid_tools/jobqueue.py
+++ b/cobaya/grid_tools/jobqueue.py
@@ -68,7 +68,7 @@ class jobSettings(object):
                     grid_engine = 'OGS'  # Open Grid Scheduler, as on StarCluster
             except:
                 pass
-        self.job_template = getDefaulted('job-template', 'job_script', **kwargs)
+        self.job_template = getDefaulted('job_template', 'job_script', **kwargs)
         if not self.job_template or self.job_template == 'job_script' \
                 and not os.path.exists(self.job_template):
             raise ValueError("You must provide a script template with '--job-template'.")
@@ -85,7 +85,7 @@ class jobSettings(object):
         except:
             cores = 8
         self.cores_per_node = getDefaulted(
-            'cores-per-node', cores, tp=int, template=template, **kwargs)
+            'cores_per_node', cores, tp=int, template=template, **kwargs)
         if cores == 4:
             perNode = 2
         elif cores % 4 == 0:
@@ -95,7 +95,7 @@ class jobSettings(object):
         else:
             perNode = 1
         self.chains_per_node = getDefaulted(
-            'chains-per-node', perNode, tp=int, template=template, **kwargs)
+            'chains_per_node', perNode, tp=int, template=template, **kwargs)
         self.nodes = getDefaulted(
             'nodes', max(1, 4 // perNode), tp=int, template=template, **kwargs)
         self.nchains = self.nodes * self.chains_per_node
@@ -112,7 +112,7 @@ class jobSettings(object):
                       self.runsPerJob, self.nchains, self.nodes, self.chains_per_node,
                       self.omp, self.cores_per_node))
         self.mem_per_node = getDefaulted(
-            'mem-per-node', 63900, tp=int, template=template, **kwargs)
+            'mem_per_node', 63900, tp=int, template=template, **kwargs)
         self.walltime = getDefaulted('walltime', '24:00:00', template=template, **kwargs)
         self.program = getDefaulted('program', default_program, template=template,
                                     **kwargs)
@@ -439,7 +439,7 @@ def getDefaulted(key_name, default=None, tp=str, template=None, ext_env=None, **
     if val is None and template is not None:
         val = extractValue(template, 'DEFAULT_' + key_name)
     if val is None:
-        val = os.environ.get(code_prefix + '_' + key_name.replace('-', '_'), None)
+        val = os.environ.get(code_prefix + '_' + key_name, None)
     if val is None and ext_env:
         val = os.environ.get('ext_env', None)
     if val is None:

--- a/cobaya/grid_tools/runMPI.py
+++ b/cobaya/grid_tools/runMPI.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+from . import jobqueue
+
+
+def run_single():
+    parser = argparse.ArgumentParser(description="Submit a single job to queue")
+
+    parser.add_argument('input_file', nargs='+')
+
+    jobqueue.addArguments(parser)
+
+    args = parser.parse_args()
+
+    ini = [ini.replace('.ini', '') for ini in args.input_file]
+
+    jobqueue.submitJob(os.path.basename(ini[0]), ini, msg=True, **args.__dict__)
+
+
+if __name__ == "__main__":
+    run_single()

--- a/cobaya/grid_tools/runbatch.py
+++ b/cobaya/grid_tools/runbatch.py
@@ -24,10 +24,11 @@ def run():
     Opts.parser.add_argument('--minimize_failed', action='store_true',
                              help='run where minimization previously failed')
     Opts.parser.add_argument('--checkpoint_run', nargs='?', default=None, const=0,
-                             type=float, help=(
-            'run if stopped and not finished; if optional value '
-            'given then only run chains with convergence worse than '
-            'the given value'))
+                             type=float,
+                             help=(
+                                 'run if stopped and not finished; if optional value '
+                                 'given then only run chains with convergence worse than '
+                                 'the given value'))
     Opts.parser.add_argument('--importance_ready', action='store_true',
                              help='where parent chain has converged and stopped')
     Opts.parser.add_argument('--importance_changed', action='store_true',
@@ -96,18 +97,23 @@ def run():
         if ((not args.notexist or isMinimize and not jobItem.chainMinimumExists()
              or not isMinimize and not jobItem.chainExists()) and (
                     not args.minimize_failed or not jobItem.chainMinimumConverged())
-            and (isMinimize or args.notall is None or not jobItem.allChainExists(args.notall))) \
+            and (isMinimize or args.notall is None or not jobItem.allChainExists(
+                    args.notall))) \
                 and (not isMinimize or getattr(jobItem, 'want_minimize', True)):
             if not args.parent_converge or not jobItem.isImportanceJob or jobItem.parent.hasConvergeBetterThan(
                     args.parent_converge):
-                if args.converge == 0 or not jobItem.hasConvergeBetterThan(args.converge, returnNotExist=True):
+                if args.converge == 0 or not jobItem.hasConvergeBetterThan(args.converge,
+                                                                           returnNotExist=True):
                     if args.checkpoint_run is None or jobItem.wantCheckpointContinue(
                             args.checkpoint_run) and jobItem.notRunning():
                         if (not jobItem.isImportanceJob or isMinimize
-                                or (args.importance_ready and jobItem.parent.chainFinished()
-                                    or not args.importance_ready and jobItem.parent.chainExists())
-                                and (not args.importance_changed or jobItem.parentChanged())
-                                and (not args.parent_stopped or jobItem.parent.notRunning())):
+                                or (
+                                        args.importance_ready and jobItem.parent.chainFinished()
+                                        or not args.importance_ready and jobItem.parent.chainExists())
+                                and (
+                                        not args.importance_changed or jobItem.parentChanged())
+                                and (
+                                        not args.parent_stopped or jobItem.parent.notRunning())):
                             if not args.not_queued or notQueued(jobItem.name):
                                 submitJob(jobItem.iniFile(variant))
 

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -15,7 +15,6 @@ from collections import OrderedDict as odict
 from copy import deepcopy
 from importlib import import_module
 import inspect
-from six import string_types
 from itertools import chain
 import pkg_resources
 
@@ -30,7 +29,7 @@ from cobaya.tools import fuzzy_match, deepcopy_where_possible, get_class, get_ki
 from cobaya.yaml import yaml_load_file, yaml_dump
 from cobaya.log import LoggedError
 from cobaya.parameterization import expand_info_param
-from cobaya.mpi import get_mpi_comm, am_single_or_primary_process
+from cobaya.mpi import share_mpi, is_main_process
 
 # Logger
 import logging
@@ -64,12 +63,7 @@ def load_input(input_file):
 
 # MPI wrapper for loading the input info
 def load_input_MPI(input_file):
-    if am_single_or_primary_process():
-        info = load_input(input_file)
-    else:
-        info = None
-    info = get_mpi_comm().bcast(info, root=0)
-    return info
+    return share_mpi(load_input(input_file) if is_main_process() else None)
 
 
 def get_used_modules(*infos):

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -399,9 +399,10 @@ def is_equal_info(info1, info2, strict=True, print_not_log=False, ignore_blocks=
                         block2[k].pop(j, None)
             if recursive_odict_to_dict(block1[k]) != recursive_odict_to_dict(block2[k]):
                 # For clarity, pop common stuff before printing
-                to_pop = [j for j in block1[k] if (
-                        recursive_odict_to_dict(block1[k][j]) ==
-                        recursive_odict_to_dict(block2[k][j]))]
+                to_pop = [j for j in block1[k] if
+                          (j in block2[k] and
+                           recursive_odict_to_dict(block1[k][j]) ==
+                           recursive_odict_to_dict(block2[k][j]))]
                 [(block1[k].pop(j, None), block2[k].pop(j, None)) for j in to_pop]
                 myprint(
                     myname + ": different content of [%s:%s]" % (block_name, k))

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -23,10 +23,9 @@ import pkg_resources
 from cobaya.conventions import _products_path, _path_install, _resume, _force
 from cobaya.conventions import _output_prefix, _debug, _debug_file, _external
 from cobaya.conventions import _params, _prior, kinds, _provides, _requires
-
 from cobaya.conventions import partag, _input_params, _output_params, _module_path
 from cobaya.conventions import _yaml_extensions, _aliases
-from cobaya.tools import recursive_update, recursive_odict_to_dict
+from cobaya.tools import recursive_update, recursive_odict_to_dict, str_to_list
 from cobaya.tools import fuzzy_match, deepcopy_where_possible, get_class, get_kind
 from cobaya.yaml import yaml_load_file, yaml_dump
 from cobaya.log import LoggedError
@@ -115,10 +114,6 @@ def get_default_info(module_or_class, kind=None, fail_if_not_found=False,
                           module_or_class, e)
 
     return default_module_info
-
-
-def str_to_list(x):
-    return [x] if isinstance(x, string_types) else x
 
 
 def update_info(info):
@@ -409,8 +404,8 @@ def is_equal_info(info1, info2, strict=True, print_not_log=False, ignore_blocks=
             if recursive_odict_to_dict(block1[k]) != recursive_odict_to_dict(block2[k]):
                 # For clarity, pop common stuff before printing
                 to_pop = [j for j in block1[k] if (
-                    recursive_odict_to_dict(block1[k][j]) ==
-                    recursive_odict_to_dict(block2[k][j]))]
+                        recursive_odict_to_dict(block1[k][j]) ==
+                        recursive_odict_to_dict(block2[k][j]))]
                 [(block1[k].pop(j, None), block2[k].pop(j, None)) for j in to_pop]
                 myprint(
                     myname + ": different content of [%s:%s]" % (block_name, k))

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -393,8 +393,10 @@ def is_equal_info(info1, info2, strict=True, print_not_log=False, ignore_blocks=
                             set(getattr(cls, "ignore_at_resume", {})))
                     except ImportError:
                         pass
-                # Pop ignored options
-                [(block1[k].pop(j, None), block2[k].pop(j, None)) for j in ignore_k_this]
+                    # Pop ignored options
+                    for j in ignore_k_this:
+                        block1[k].pop(j, None)
+                        block2[k].pop(j, None)
             if recursive_odict_to_dict(block1[k]) != recursive_odict_to_dict(block2[k]):
                 # For clarity, pop common stuff before printing
                 to_pop = [j for j in block1[k] if (

--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -273,8 +273,8 @@ def install_script():
                             help="Install data of the modules.", dest=_code)
     arguments = parser.parse_args()
 
-    from cobaya.mpi import am_single_or_primary_process
-    is_primary_process = am_single_or_primary_process(no_mpi=arguments.no_mpi)
+    from cobaya.mpi import is_main_process
+    is_primary_process = is_main_process(no_mpi=arguments.no_mpi)
 
     # Configure the logger ASAP
     logger_setup(no_mpi=arguments.no_mpi)

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -163,7 +163,7 @@ class LikelihoodExternalFunction(Likelihood):
                 # Print traceback
                 self.log.error("".join(
                     ["-"] * 16 + ["\n\n"] +
-                    list(traceback.format_exception(*sys.exc_info())) | +
+                    list(traceback.format_exception(*sys.exc_info()))  +
                     ["\n"] + ["-"] * 37))
             raise LoggedError(
                 self.log, "The external likelihood '%s' failed at evaluation. "

--- a/cobaya/likelihoods/_base_classes/_DataSetLikelihood.py
+++ b/cobaya/likelihoods/_base_classes/_DataSetLikelihood.py
@@ -20,7 +20,7 @@ class _fast_chi_square(object):
         # delay testing active camb until run time
         try:
             from camb.mathutils import chi_squared as fast_chi_squared
-        except:
+        except ImportError:
             def fast_chi_squared(covinv, x):
                 return covinv.dot(x).dot(x)
 
@@ -29,7 +29,7 @@ class _fast_chi_square(object):
 
 
 class _DataSetLikelihood(_InstallableLikelihood):
-    """A likelihood reading parameters and filenames from a .dataset plain text
+    """A likelihood reading parameters and file names from a .dataset plain text
     .ini file (as CosmoMC)"""
 
     default_dataset_params = {}

--- a/cobaya/likelihoods/planck_2018_highl_plik/EE.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_plik/EE.yaml
@@ -7,6 +7,6 @@ product_id: "151905"
 # Aliases for automatic covariance matrix
 aliases: [plikHM_EE]
 # Speed in evaluations/second
-speed: 7
+speed: 100
 
 params: !defaults [params_calib, params_calib_pol, params_EE]

--- a/cobaya/likelihoods/planck_2018_highl_plik/TE.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_plik/TE.yaml
@@ -7,6 +7,6 @@ product_id: "151905"
 # Aliases for automatic covariance matrix
 aliases: [plikHM_TE]
 # Speed in evaluations/second
-speed: 7
+speed: 100
 
 params: !defaults [params_calib, params_calib_temp, params_calib_pol, params_TE]

--- a/cobaya/likelihoods/planck_2018_highl_plik/TT.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_plik/TT.yaml
@@ -7,7 +7,7 @@ product_id: "151902"
 # Aliases for automatic covariance matrix
 aliases: [plikHM_TT]
 # Speed in evaluations/second
-speed: 7
+speed: 50
 
 params: !defaults [params_calib, params_calib_temp, params_TT]
 

--- a/cobaya/likelihoods/planck_2018_highl_plik/TTTEEE.yaml
+++ b/cobaya/likelihoods/planck_2018_highl_plik/TTTEEE.yaml
@@ -7,7 +7,7 @@ product_id: "151902"
 # Aliases for automatic covariance matrix
 aliases: [plikHM_TTTEEE]
 # Speed in evaluations/second
-speed: 7
+speed: 30
 
 params: !defaults [params_calib, params_calib_temp, params_calib_pol, params_TT, params_TE, params_EE]
 

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -19,7 +19,8 @@ from copy import deepcopy
 
 # Local
 from cobaya.conventions import _debug, _debug_file
-from cobaya.mpi import get_mpi_rank, get_mpi_size, get_mpi_comm, more_than_one_process
+from cobaya.mpi import get_mpi_rank, get_mpi_size, get_mpi_comm, \
+    more_than_one_process, is_main_process
 
 
 class LoggedError(Exception):
@@ -147,3 +148,11 @@ class HasLogger(object):
     def __setstate__(self, d):
         self.__dict__ = d
         self.set_logger()
+
+    def mpi_warning(self, msg, *args, **kwargs):
+        if is_main_process():
+            self.log.warning(msg, *args, **kwargs)
+
+    def mpi_info(self, msg, *args, **kwargs):
+        if is_main_process():
+            self.log.info(msg, *args, **kwargs)

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -75,7 +75,7 @@ def exception_handler(exception_type, exception_instance, trace_back):
     safe_exit()
 
 
-def logger_setup(debug=None, debug_file=None, no_mpi=False):
+def logger_setup(debug=None, debug_file=None):
     """
     Configuring the root logger, for its children to inherit level, format and handlers.
 
@@ -95,8 +95,7 @@ def logger_setup(debug=None, debug_file=None, no_mpi=False):
     class MyFormatter(logging.Formatter):
         def format(self, record):
             fmt = ((" %(asctime)s " if debug else "") +
-                   "[" + ("%d : " % get_mpi_rank() if more_than_one_process(
-                        no_mpi=no_mpi) else "") +
+                   "[" + ("%d : " % get_mpi_rank() if more_than_one_process() else "") +
                    "%(name)s" + "] " +
                    {logging.ERROR: "*ERROR* ",
                     logging.WARNING: "*WARNING* "}.get(record.levelno, "") +

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -972,7 +972,7 @@ class Model(HasLogger):
                 # average for different points
                 times = np.average(get_mpi_comm().allgather(times), axis=0)
             self._measured_speeds = [1 / (1e-7 + time) for time in times]
-            self.mpi_info('Setting measured speeds: %r',
+            self.mpi_info('Setting measured speeds (per sec): %r',
                           {component: float("%.3g" % speed) for component, speed in
                            zip(self.components, self._measured_speeds)})
             if not timing_on:

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -18,7 +18,7 @@ import six
 
 # Local
 from cobaya.conventions import kinds, _prior, _timing, _aliases
-from cobaya.conventions import _params, _overhead_per_param, _provides
+from cobaya.conventions import _params, _overhead_time, _provides
 from cobaya.conventions import _path_install, _debug, _debug_default, _debug_file
 from cobaya.conventions import _input_params, _output_params, _chi2, _separator
 from cobaya.conventions import _input_params_prefix, _output_params_prefix, _requires
@@ -165,7 +165,7 @@ class Model(HasLogger):
         self._measured_speeds = None
 
         # Overhead per likelihood evaluation
-        self.overhead = _overhead_per_param * len(self.parameterization.sampled_params())
+        self.overhead = _overhead_time
 
     def info(self):
         """
@@ -400,7 +400,7 @@ class Model(HasLogger):
                 dict(zip(self.parameterization.sampled_params(), params_values_array)))
         # Notice that we don't use the make_finite in the prior call,
         # to correctly check if we have to compute the likelihood
-        logpriors = self.logpriors(params_values_array, make_finite=False)
+        logpriors = self.prior.logps(params_values_array)
         logpost = sum(logpriors)
         if -np.inf not in logpriors:
             like = self.loglikes(params_values, return_derived=return_derived,

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -79,7 +79,7 @@ def get_mpi_rank():
 
 
 # Aliases for simpler use
-def am_single_or_primary_process(no_mpi=False):
+def is_main_process(no_mpi=False):
     """Returns true if primary process or MPI not available.
 
     Use the no_mpi keyword to avoid checking for MPI via import, 
@@ -110,3 +110,11 @@ def import_MPI(module, target):
     if get_mpi_rank() is not None:
         target_name = target + "_MPI"
     return getattr(import_module(module, package=_package), target_name)
+
+
+def share_mpi(data=None):
+    comm = get_mpi_comm()
+    if comm and more_than_one_process():
+        return comm.bcast(data, root=0)
+    else:
+        return data

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -9,10 +9,7 @@
 # Python 2/3 compatibility
 from __future__ import absolute_import
 from __future__ import division
-
-# Global
 import os
-
 # Local
 from cobaya.conventions import _package
 
@@ -21,6 +18,8 @@ _mpi = -1
 _mpi_size = -1
 _mpi_comm = -1
 _mpi_rank = -1
+
+disabled = os.environ.get('COBAYA_NOMPI', False)
 
 
 def get_mpi():
@@ -31,6 +30,9 @@ def get_mpi():
     """
     global _mpi
     if _mpi == -1:
+        if disabled:
+            _mpi = None
+            return None
         try:
             from mpi4py import MPI
             _mpi = MPI
@@ -95,8 +97,9 @@ def more_than_one_process(no_mpi=False):
     else:
         return False
 
+
 def sync_processes():
-    if get_mpi_size():
+    if get_mpi_size() > 1:
         get_mpi_comm().barrier()
 
 

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -20,7 +20,7 @@ _mpi_comm = -1
 _mpi_rank = -1
 
 
-def set_mpi_disabled(disabled):
+def set_mpi_disabled(disabled=True):
     """
     Disable MPI, e.g. for use on cluster head nodes where mpi4py may be installed
     but not MPI functions will work.

--- a/cobaya/output.py
+++ b/cobaya/output.py
@@ -154,13 +154,12 @@ class Output(HasLogger):
         # We write the new one anyway (maybe updated debug, resuming...)
         for f, info in [(self.file_input, input_info),
                         (self.file_updated, updated_info_trimmed)]:
-            if not info:
-                pass
-            with open(f, "w") as f_out:
-                try:
-                    f_out.write(yaml_dump(info))
-                except OutputError as e:
-                    raise LoggedError(self.log, str(e))
+            if info:
+                with open(f, "w") as f_out:
+                    try:
+                        f_out.write(yaml_dump(info))
+                    except OutputError as e:
+                        raise LoggedError(self.log, str(e))
 
     def prepare_collection(self, name=None, extension=None):
         """

--- a/cobaya/output.py
+++ b/cobaya/output.py
@@ -126,6 +126,9 @@ class Output(HasLogger):
                 # We will test the old info against the dumped+loaded new info.
                 # This is because we can't actually check if python objects do change
                 old_info = self.reload_updated_info()
+                if not old_info:
+                    raise LoggedError(self.log, "No old sample information: %s",
+                                      self.file_updated)
                 new_info = yaml_load(yaml_dump(updated_info_trimmed))
                 ignore_blocks = []
                 from cobaya.sampler import get_sampler_class, Minimizer

--- a/cobaya/output.py
+++ b/cobaya/output.py
@@ -95,7 +95,7 @@ class Output(HasLogger):
                     self.log.info("Overwritten old failed chain files.")
                 else:
                     raise LoggedError(
-                        self.log, "Delete the previous sample manually, automatically "
+                        self.log, "Delete the previous output manually, automatically "
                                   "('-%s', '--%s', '%s: True')" % (
                                       _force[0], _force, _force) +
                                   " or request resuming ('-%s', '--%s', '%s: True')" % (

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -222,8 +222,8 @@ class Parameterization(HasLogger):
         return deepcopy(self._sampled)
 
     def sampled_params_info(self):
-        return odict(
-            (p, deepcopy_where_possible(info)) for p, info in self._infos.items() if p in self._sampled)
+        return odict((p, deepcopy_where_possible(info)) for p, info
+                     in self._infos.items() if p in self._sampled)
 
     def sampled_params_renames(self):
         return deepcopy(self._sampled_renames)
@@ -374,10 +374,11 @@ class Parameterization(HasLogger):
 
         Uses the parameter name if no label has been given.
         """
-        get_label = lambda p, info: (
-            ensure_nolatex(
-                getattr(info, "get", lambda x, y: y)(partag.latex,
-                                                     p.replace("_", r"\ "))))
+
+        def get_label(p, info):
+            return ensure_nolatex(getattr(info, "get", lambda x, y: y)
+                                  (partag.latex, p.replace("_", r"\ ")))
+
         return odict((p, get_label(p, info)) for p, info in self._infos.items())
 
     # Python magic for the "with" statement

--- a/cobaya/post.py
+++ b/cobaya/post.py
@@ -54,7 +54,8 @@ def post(info, sample=None):
             "Post-processing is not yet MPI-able. Doing nothing for rank > 1 processes.")
         return
     # 1. Load existing sample
-    output_in = get_output(output_prefix=info.get(_output_prefix), resume=True)
+    output_in = get_output(output_prefix=info.get(_output_prefix),
+                           resume=True, must_exist=True)
     info_in = load_input(output_in.file_updated) if output_in else deepcopy(info)
     dummy_model_in = DummyModel(info_in[_params], info_in[kinds.likelihood],
                                 info_in.get(_prior, None))

--- a/cobaya/post.py
+++ b/cobaya/post.py
@@ -26,7 +26,7 @@ from cobaya.conventions import _separator_files, _post_add, _post_remove, _post_
 from cobaya.collection import Collection
 from cobaya.log import logger_setup, LoggedError
 from cobaya.input import update_info
-from cobaya.output import get_Output as Output
+from cobaya.output import get_output
 from cobaya.mpi import get_mpi_rank
 from cobaya.tools import progress_bar, recursive_update
 from cobaya.model import Model
@@ -54,7 +54,7 @@ def post(info, sample=None):
             "Post-processing is not yet MPI-able. Doing nothing for rank > 1 processes.")
         return
     # 1. Load existing sample
-    output_in = Output(output_prefix=info.get(_output_prefix), resume=True)
+    output_in = get_output(output_prefix=info.get(_output_prefix), resume=True)
     info_in = load_input(output_in.file_updated) if output_in else deepcopy(info)
     dummy_model_in = DummyModel(info_in[_params], info_in[kinds.likelihood],
                                 info_in.get(_prior, None))
@@ -222,7 +222,7 @@ def post(info, sample=None):
     if out_prefix not in [None, False]:
         out_prefix += _separator_files + _post + _separator_files + info_post[
             _post_suffix]
-    output_out = Output(output_prefix=out_prefix, force_output=info.get(_force))
+    output_out = get_output(output_prefix=out_prefix, force_output=info.get(_force))
     info_out = deepcopy(info)
     info_out[_post] = info_post
     # Updated with input info and extended (updated) add info

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -346,7 +346,6 @@ from __future__ import division
 from collections import OrderedDict as odict
 import numpy as np
 import numbers
-from copy import deepcopy
 from types import MethodType
 
 # Local
@@ -372,7 +371,7 @@ class Prior(HasLogger):
         constant_params_info = parameterization.constant_params()
         sampled_params_info = parameterization.sampled_params_info()
         if not sampled_params_info:
-            self.log.warning("No sampled parameters requested! "
+            self.mpi_warning("No sampled parameters requested! "
                              "This will fail for non-mock samplers.")
         # pdf: a list of independent components
         # in principle, separable: one per parameter
@@ -452,7 +451,7 @@ class Prior(HasLogger):
                     name, list(set(params_without_default)
                                .difference(opts["params"])
                                .difference(opts["constant_params"])))
-            self.log.warning("External prior '%s' loaded. "
+            self.mpi_warning("External prior '%s' loaded. "
                              "Mind that it might not be normalized!", name)
 
     def d(self):
@@ -490,9 +489,9 @@ class Prior(HasLogger):
             bounds = self._bounds.copy()
             infs = list(set(np.argwhere(np.isinf(bounds)).T[0]))
             if infs:
-                self.log.warning("There are unbounded parameters (%r). Prior bounds are "
-                                 "given at %s confidence level. Beware of likelihood "
-                                 "modes at the edge of the prior",
+                self.mpi_warning("There are unbounded parameters (%r). Prior bounds "
+                                 "are given at %s confidence level. Beware of "
+                                 "likelihood modes at the edge of the prior",
                                  [self.params[ix] for ix in infs],
                                  confidence_for_unbounded)
                 bounds[infs] = [
@@ -620,7 +619,7 @@ class Prior(HasLogger):
                           for i, ref_pdf in enumerate(self.ref_pdf)])
         where_no_ref = np.isnan(covmat)
         if np.any(where_no_ref):
-            self.log.warning("Reference pdf not defined or improper for some parameters. "
+            self.mpi_warning("Reference pdf not defined or improper for some parameters. "
                              "Using prior's sigma instead for them.")
             covmat[where_no_ref] = self.covmat(ignore_external=True)[where_no_ref]
         return covmat

--- a/cobaya/run.py
+++ b/cobaya/run.py
@@ -25,8 +25,8 @@ from cobaya.sampler import get_sampler, get_sampler_class, Minimizer
 from cobaya.log import logger_setup
 from cobaya.yaml import yaml_dump
 from cobaya.input import update_info
-from cobaya.mpi import import_MPI, is_main_process
-from cobaya.tools import warn_deprecation, deepcopy_where_possible, recursive_update
+from cobaya.mpi import import_MPI, is_main_process, set_mpi_disabled
+from cobaya.tools import warn_deprecation, recursive_update
 from cobaya.post import post
 
 
@@ -119,7 +119,12 @@ def run_script():
                               help="Overwrites previous output, if it exists "
                                    "(use with care!)")
     parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument("--no-mpi", action='store_true',
+                        help="disable MPI when mpi4py installed but MPI does "
+                             "not actually work")
     args = parser.parse_args()
+    if args.no_mpi:
+        set_mpi_disabled()
     if any((os.path.splitext(f)[0] in ("input", "updated")) for f in args.input_file):
         raise ValueError("'input' and 'updated' are reserved file names. "
                          "Please, use a different one.")

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -165,12 +165,6 @@ class Sampler(CobayaComponent):
                 self.output.folder, self.output.prefix + _progress_extension)
         return None
 
-    def covmat_filename(self):
-        if self.output:
-            return os.path.join(
-                self.output.folder, self.output.prefix + _covmat_extension)
-        return None
-
     def close(self, exception_type, exception_value, traceback):
         """
         Finalizes the sampler, if something needs to be done

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -134,8 +134,7 @@ class Sampler(CobayaComponent):
                     for k, v in checkpoint_info[kinds.sampler][self.get_name()].items():
                         setattr(self, k, v)
                     self.resuming = True
-                    if is_main_process():
-                        self.log.info("Resuming from previous sample!")
+                    self.mpi_info("Resuming from previous sample!")
                 except KeyError:
                     if is_main_process():
                         raise LoggedError(

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -57,7 +57,7 @@ from cobaya.conventions import _covmat_extension, _progress_extension, _module_p
 from cobaya.tools import get_class
 from cobaya.log import LoggedError
 from cobaya.yaml import yaml_load_file
-from cobaya.mpi import am_single_or_primary_process
+from cobaya.mpi import is_main_process
 from cobaya.component import CobayaComponent
 
 
@@ -134,10 +134,10 @@ class Sampler(CobayaComponent):
                     for k, v in checkpoint_info[kinds.sampler][self.get_name()].items():
                         setattr(self, k, v)
                     self.resuming = True
-                    if am_single_or_primary_process():
+                    if is_main_process():
                         self.log.info("Resuming from previous sample!")
                 except KeyError:
-                    if am_single_or_primary_process():
+                    if is_main_process():
                         raise LoggedError(
                             self.log, "Checkpoint file found at '%s' "
                                       "but it corresponds to a different sampler.",

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -606,8 +606,8 @@ class mcmc(CovmatSampler):
                     "The chain has been stuck for %d attempts. Stopping sampling. "
                     "If this has happened often, try improving your "
                     "reference point/distribution. Alternatively (though not advisable) "
-                    "make 'max_tries: np.inf' (or 'max_tries: .inf' in yaml)",
-                    max_tries_now)
+                    "make 'max_tries: np.inf' (or 'max_tries: .inf' in yaml).\n"
+                    "Current point: %s", max_tries_now, self.current_point)
 
     # Functions to check convergence and learn the covariance of the proposal distribution
 

--- a/cobaya/samplers/mcmc/mcmc.yaml
+++ b/cobaya/samplers/mcmc/mcmc.yaml
@@ -1,7 +1,7 @@
 # Default arguments for the Markov Chain Monte Carlo sampler
 # ('Xd' means 'X steps per dimension')
 
-# Number of discarded burn-in samples
+# Number of discarded burn-in samples per dimension
 burn_in: 20d
 # Error criterion: max attempts (= weight-1) before deciding that the chain
 # is stuck and failing. Set to `.inf` to ignore this kind of errors.
@@ -14,7 +14,7 @@ covmat:
 covmat_params:
 # Overall scale of the proposal pdf (increase for longer steps)
 proposal_scale: 2.4
-# Number of steps between convergence checks & proposal learn
+# Number of distinct accepted points between convergence checks & proposal learn
 check_every: 40d
 # Update output file(s) every X accepted samples
 output_every: 20
@@ -40,6 +40,9 @@ Rminus1_cl_level: 0.95
 Rminus1_single_split: 4
 # Exploiting speed hierarchy
 # --------------------------
+# whether to measure actual speeds for your machine/threading at starting rather
+# than using stored values
+measured_speeds: True
 # Method I: Oversampling of each parameters block relative to it speed
 oversample: False  # produces potentially MANY samples
 # Method II: Dragging: simulates jumps on slow params when varying fast ones
@@ -61,10 +64,3 @@ callback_every:  # default: every checkpoint
 # Seeding runs
 # ------------
 seed:  # integer between 0 and 2**32 - 1
-# Checkpointing -- do not modify!
-Rminus1_last: .inf
-converged:
-blocks:
-oversampling_factors:
-i_last_slow_block:
-mpi_size:

--- a/cobaya/samplers/mcmc/mcmc.yaml
+++ b/cobaya/samplers/mcmc/mcmc.yaml
@@ -46,7 +46,7 @@ oversample: False  # produces potentially MANY samples
 # Set to True, or a factor of the time of a jump on the slow block
 drag: False
 # Min and max number of times the fast block is iterated
-drag_limits : [1, 10]
+drag_limits: [1, 10]
 # Manual blocking
 # ---------------
 # To take full advantage of speed-blocking, sort the blocks by ascending speeds

--- a/cobaya/samplers/mcmc/proposal.py
+++ b/cobaya/samplers/mcmc/proposal.py
@@ -50,7 +50,7 @@ class CyclicIndexRandomizer(IndexCycler):
 
 try:
     import numba
-    from np.random import normal
+    from numpy.random import normal
     import warnings
 
 
@@ -177,8 +177,8 @@ class BlockedProposer(HasLogger):
                     "The index given for the last slow block, %d, is not valid: "
                     "there are only %d blocks.",
                     i_last_slow_block, len(parameter_blocks))
-        n_all = sum([len(b) for b in parameter_blocks])
-        n_slow = sum([len(b) for b in parameter_blocks[:1 + i_last_slow_block]])
+        n_all = sum(len(b) for b in parameter_blocks)
+        n_slow = sum(len(b) for b in parameter_blocks[:1 + i_last_slow_block])
         if set(list(chain(*parameter_blocks))) != set(range(n_all)):
             raise LoggedError(self.log,
                               "The blocks do not contain all the parameter indices.")
@@ -258,8 +258,8 @@ class BlockedProposer(HasLogger):
         for iblock, bp in enumerate(self.proposer):
             j_start = self.j_start[iblock]
             j_end = j_start + bp.n
-            self.transform += [sigmas_diag[j_start:, j_start:]
-                                   .dot(L[j_start:, j_start:j_end])]
+            self.transform += [sigmas_diag[j_start:, j_start:].dot(L[j_start:,
+                                                                   j_start:j_end])]
 
     def get_covariance(self):
         return self.propose_matrix.copy()

--- a/cobaya/samplers/mcmc/proposal.py
+++ b/cobaya/samplers/mcmc/proposal.py
@@ -50,6 +50,12 @@ class CyclicIndexRandomizer(IndexCycler):
 
 try:
     import numba
+except ImportError as e:
+    from scipy.stats import special_ortho_group
+
+    random_SO_N = special_ortho_group.rvs
+    numba = None
+else:
     from numpy.random import normal
     import warnings
 
@@ -95,12 +101,6 @@ try:
                 H[:, n:] -= np.outer(tmp, x)
             D[-1] = (-1) ** (dim - 1) * D[:-1].prod()
             H[:, :] = (D * H.T).T
-
-
-except Exception as e:
-    from scipy.stats import special_ortho_group
-
-    random_SO_N = special_ortho_group.rvs
 
 
 class RandDirectionProposer(IndexCycler):
@@ -223,8 +223,8 @@ class BlockedProposer(HasLogger):
         self.get_block_proposal(P, current_iblock_slow)
 
     def get_proposal_fast(self, P):
-        current_iblock_fast = self.iblock_of_j[
-            self.cycler_slow.n + self.cycler_fast.next()]
+        current_iblock_fast = self.iblock_of_j[self.cycler_slow.n
+                                               + self.cycler_fast.next()]
         self.get_block_proposal(P, current_iblock_fast)
 
     def get_block_proposal(self, P, iblock):

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -103,7 +103,6 @@ getdist_ext_ignore_prior = {True: ".bestfit", False: ".minimum"}
 
 class minimize(Minimizer, CovmatSampler):
     def initialize(self):
-        """Prepares the arguments for `scipy.minimize`."""
         self.mpi_info("Initializing")
         self.max_evals = read_dnumber(self.max_evals, self.model.prior.d())
         # Configure target

--- a/cobaya/samplers/minimize/minimize.yaml
+++ b/cobaya/samplers/minimize/minimize.yaml
@@ -21,5 +21,6 @@ override_scipy:
 #  - https://numericalalgorithmsgroup.github.io/pybobyqa/build/html/advanced.html
 override_bobyqa:
   # option: value
-  # Relaxed convergence criterion for numerically-noisiy likelihoods
+  # Relaxed convergence criterion for numerically-noisy likelihoods
   rhoend: 0.05
+covmat: auto

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -226,8 +226,7 @@ class polychord(Sampler):
                 derived)
 
         sync_processes()
-        if is_main_process():
-            self.log.info("Sampling!")
+        self.mpi_info("Sampling!")
         self.pc.run_polychord(logpost, self.nDims, self.nDerived, self.pc_settings,
                               self.pc_prior, self.dumper)
 

--- a/cobaya/theories/_cosmo/boltzmannbase.py
+++ b/cobaya/theories/_cosmo/boltzmannbase.py
@@ -12,11 +12,10 @@ import numpy as np
 from scipy.interpolate import RectBivariateSpline
 from six import string_types
 from itertools import chain
-from collections import deque
 
 # Local
 from cobaya.theory import Theory
-from cobaya.tools import deepcopy_where_possible
+from cobaya.tools import deepcopy_where_possible, str_to_list
 from cobaya.log import LoggedError
 from cobaya.conventions import _requires, _c_km_s
 
@@ -32,9 +31,6 @@ class BoltzmannBase(Theory):
         # Additional input parameters to pass to CAMB, and attributes to set_ manually
         self.extra_args = deepcopy_where_possible(self.extra_args) or {}
         self._needs = None
-
-    def get_requirements(self):
-        return {p: None for p in getattr(self, _requires, [])}
 
     def get_allow_agnostic(self):
         return True

--- a/cobaya/theory.py
+++ b/cobaya/theory.py
@@ -264,6 +264,9 @@ class Theory(CobayaComponent):
     def get_speed(self):
         return self._measured_speed or self.speed
 
+    def set_measured_speed(self, speed):
+        self._measured_speed = speed
+
 
 class TheoryCollection(ComponentCollection):
     """

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division, print_function
 # Global
 import os
 import sys
-from copy import deepcopy, copy
+from copy import deepcopy
 from importlib import import_module
 import six
 import numpy as np  # don't delete: necessary for get_external_function
@@ -599,7 +599,7 @@ def warn_deprecation_python2(logger=None):
 
 def warn_deprecation_version(logger=None):
     msg = """
-    You are using an archived version of Cobaya, which is no loger maintained.
+    You are using an archived version of Cobaya, which is no longer maintained.
     Unless intentionally doing so, please, update asap to the latest version
     (e.g. with ``pip install cobaya --upgrade``).
     """

--- a/docs/sampler_mcmc.rst
+++ b/docs/sampler_mcmc.rst
@@ -183,30 +183,31 @@ Taking advantage of a speed hierarchy
 
 The proposal pdf is *blocked* by speeds, i.e. it allows for efficient sampling of a
 mixture of *fast* and *slow* parameters, such that we can avoid recomputing the slowest
-parts of the likelihood when sampling along the fast directions only. This is often very useful when the likelihoods
+parts of the likelihood calculation when sampling along the fast directions only. This is often very useful when the likelihoods
 have large numbers of nuisance parameters, but recomputing the likelihood for different sets of nuisance parameters is fast.
 
-Two different sampling schemes are available to take additional advantage from a speed
+Two different sampling schemes are available in the ``mcmcm`` sampler to take additional advantage of a speed
 hierarchy:
 
 - **Dragging the fast parameters:** implies a number of intermediate steps when jumping between fast+slow combinations, such that the jump in the fast parameters is optimized with respect to the jump in the slow parameters to explore any possible degeneracy between them. If enabled (``drag: True``), tries to spend the same amount of time doing dragging steps as it takes to compute a jump in the slow direction (make sure your likelihoods ``speed``'s are accurate; see below).
 
 - **Oversampling the fast parameters:** consists simply of taking a larger proportion of steps in the faster directions, useful when exploring their conditional distributions is cheap. If enabled (``oversample: True``), it tries to spend the same amount of time in each block.
 
-In general, the *dragging* method is the recommended one if there are non-trivial degeneracies between fast and slow parameters.
+In general, the *dragging* method is the recommended one if there are non-trivial degeneracies between fast and slow parameters and you have a fairly large speed hierarchy.
 Oversampling can potentially produce very large output files; dragging outputs
 smaller chain files since fast parameters are effectively partially marginalized over internally. For a thorough description of both methods and references, see
 `A. Lewis, "Efficient sampling of fast and slow cosmological parameters" (arXiv:1304.4473) <https://arxiv.org/abs/1304.4473>`_.
 
 The relative speeds can be specified per likelihood/theory, with the option ``speed``,
 preferably in evaluations per second (approximately).
+The speeds can also be measured automatically when you run a chain (with mcmc, ``measured_speeds: True``), allowing for variations with the number of threads used and machine differences.
+This option only tests the speed on one point (per mpi instance), so if your speed varies significantly with where you are in parameter space it may be better ot turn the automatic selection off
+and keep to manually specified average speeds. To measure the average speeds, set ``timing: True`` at the highest level of your input (i.e. not inside any of the blocks), set the ``mcmc`` options ``burn_in: 0`` and ``max_samples`` to a reasonably large number (so that it will be done in a few minutes), and check the output: it should have printed, towards the end, computation times for the likelihood and theory codes in seconds, the *inverse* of which are the speeds.
 
-To measure the speed of your likelihood, set ``timing: True`` at the highest level of your input (i.e. not inside any of the blocks), set the ``mcmc`` options ``burn_in: 0`` and ``max_samples`` to a reasonably large number (so that it will be done in a few minutes), and check the output: it should have printed, towards the end, computation times for the likelihoods and the theory code in seconds, the *inverse* of which are the speeds.
-
-If the speed has not been specified for a likelihood, it is assigned the slowest one in
-the set. If two or more likelihoods with different speeds share a parameter,
+If the speed has not been specified for a component, it is assigned the slowest one in
+the set. If two or more components with different speeds share a parameter,
 said parameter is assigned to a separate block with a speed that takes into account the
-computation time of all the likelihoods it belongs to.
+computation time of all the codes that depends on it.
 
 For example:
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
             'cobaya-bib=cobaya.bib:bib_script',
             'cobaya-grid-create=cobaya.grid_tools:MakeGridScript',
             'cobaya-grid-run=cobaya.grid_tools.runbatch:run',
+            'cobaya-run-job=cobaya.grid_tools.runMPI:run_single',
             'cobaya-cosmo-generator=cobaya.cosmo_input:gui_script',
         ],
     },

--- a/tests/common_sampler.py
+++ b/tests/common_sampler.py
@@ -172,6 +172,7 @@ def body_of_test_speeds(info_sampler={}, manual_blocking=False, modules=None):
         "likelihood": {"like1": {"external": like1, "speed": speed1},
                        "like2": {"external": like2, "speed": speed2}},
         "sampler": info_sampler}
+    info["sampler"][sampler]["measured_speeds"] = False
     if manual_blocking:
         info["sampler"][sampler]["blocking"] = [
             [speed1, ["a_0", "a_1", "a_2"]],

--- a/tests/job_script_SLURM
+++ b/tests/job_script_SLURM
@@ -51,8 +51,8 @@ echo `which python`
 ##RUN: time srun --mpi=pmi2 {PROGRAM} {INI} > ./scripts/{INIBASE}.log 2>&1 ##
 ### defaults for this script
 ##DEFAULT_qsub: qsub ##
-##DEFAULT_cores-per-node: 16 ##
-##DEFAULT_chains-per-node: 4 ##
+##DEFAULT_cores_per_node: 16 ##
+##DEFAULT_chains_per_node: 4 ##
 ##DEFAULT_program: cobaya-run -r ##
 ##DEFAULT_walltime: 8:00:00##
 

--- a/tests/job_script_SLURM
+++ b/tests/job_script_SLURM
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+##SLURM Example for skylake system in Cambridge
+
+#SBATCH -p skylake
+#SBATCH --nodes={NUMNODES}
+#SBATCH --ntasks={NUMTASKS}
+#SBATCH --time={WALLTIME}
+#SBATCH --mail-type=FAIL
+#SBATCH --cpus-per-task={OMP}
+
+cd {ROOTDIR}
+
+. /etc/profile.d/modules.sh                # Leave this line (enables the module command)
+module purge                               # Removes all modules still loaded
+module load rhel7/default-peta4            # REQUIRED - loads the basic environment
+module unload intel/bundles/complib/2017.4
+module load intel/bundles/complib/2019.3    #2017.4 seems to have compiler bugs
+
+
+## assuming using anaconda with env called py37
+module load gcc/7
+eval "$(conda shell.bash hook)"
+conda activate py37
+
+
+export OMP_NUM_THREADS={OMP}
+export I_MPI_PIN=1
+export I_MPI_HYDRA_RMK=slurm
+
+JOBID=$SLURM_JOB_ID
+
+echo -e "JobID: $JOBID\n======"
+echo "Time: `date`"
+echo "Running on master node: `hostname`"
+echo "Current directory: `pwd`"
+
+if [ "$SLURM_JOB_NODELIST" ]; then
+        #! Create a machine file:
+        export NODEFILE=`generate_pbs_nodefile`
+        cat $NODEFILE | uniq > scripts/machine.file.$JOBID
+        echo -e "\nNodes allocated:\n================"
+        echo `cat scripts/machine.file.$JOBID | sed -e 's/\..*$//g'`
+fi
+
+echo `module list`
+echo `which python`
+
+###set things to be used by the python script, which extracts text from here with ##XX: ... ##
+### command to use for each run in the batch
+##RUN: time srun --mpi=pmi2 {PROGRAM} {INI} > ./scripts/{INIBASE}.log 2>&1 ##
+### defaults for this script
+##DEFAULT_qsub: qsub ##
+##DEFAULT_cores-per-node: 16 ##
+##DEFAULT_chains-per-node: 4 ##
+##DEFAULT_program: cobaya-run -r ##
+##DEFAULT_walltime: 8:00:00##
+
+{COMMAND}
+
+wait
+
+
+

--- a/tests/test_cosmo_des_y1.py
+++ b/tests/test_cosmo_des_y1.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from copy import deepcopy
-import pytest
 
 from .test_cosmo_planck_2015 import params_lowTEB_highTTTEEE
 from .common_cosmo import body_of_test

--- a/tests/test_cosmo_multi_theory.py
+++ b/tests/test_cosmo_multi_theory.py
@@ -58,10 +58,10 @@ debug = True
 info = {'likelihood': {'cmb': cmb_likelihood},
         'theory': OrderedDict({
             'camb': {"extra_args": {"lens_potential_accuracy": 1},
-                     "requires": ['YHe', 'ombh2'], "stop_at_error": True},
+                     "requires": ['YHe', 'ombh2']},
             'bbn': {'external': BBN, 'provides': ['YHe']}}),
         'params': camb_params,
-        'debug': debug}
+        'debug': debug, 'stop_at_error': True}
 
 info2 = {'likelihood': {'cmb': {'external': cmb_likelihood}},
          'theory': OrderedDict({

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -30,6 +30,7 @@ def test_mcmc(tmpdir, modules=None):
     S0 = comm.bcast(S0, root=0)
     info_sampler = {"mcmc": {
         # Bad guess for covmat, so big burn in and max_tries
+        # TODO: why * dimension here?
         "max_tries": 1000 * dimension, "burn_in": 100 * dimension,
         # Learn proposal
         # "learn_proposal": True,  # default now!


### PR DESCRIPTION
Allows semi-slow parameters for the initial power spectrum or nonlinear model, generalizing cosmomc's approach to also work when non-linear corrections are needed (by computing time transfer functions, and recalculating nonlinear corrections, bessel integrals and lensed CL when the semi-slow parameters change). This should make cobaya faster than cosmomc, since compute saving should be significant. 

To do this the camb class now dynamically generates a helper transfer function Theory class on which it depends, and assigns initial power/nonlinear parameters to itself and other parameters to the transfer function class.

Not sure how this works with the updated yaml, resuming etc, could do with some help on that. (is resuming/checkpointing with camb in any of the tests?)