### PR TITLE
Better fix for MPI crashing 

### DIFF
--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -273,11 +273,15 @@ def install_script():
                             help="Install data of the modules.", dest=_code)
     arguments = parser.parse_args()
 
+    if arguments.no_mpi:
+        from cobaya.mpi import disable_mpi
+        disable_mpi()
+
     from cobaya.mpi import am_single_or_primary_process
-    is_primary_process = am_single_or_primary_process(no_mpi=arguments.no_mpi)
+    is_primary_process = am_single_or_primary_process()
 
     # Configure the logger ASAP
-    logger_setup(no_mpi=arguments.no_mpi)
+    logger_setup()
     log = logging.getLogger(__name__.split(".")[-1])
 
     if is_primary_process:

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -74,7 +74,7 @@ def exception_handler(exception_type, exception_instance, trace_back):
     safe_exit()
 
 
-def logger_setup(debug=None, debug_file=None, no_mpi=False):
+def logger_setup(debug=None, debug_file=None):
     """
     Configuring the root logger, for its children to inherit level, format and handlers.
 
@@ -94,8 +94,7 @@ def logger_setup(debug=None, debug_file=None, no_mpi=False):
     class MyFormatter(logging.Formatter):
         def format(self, record):
             fmt = ((" %(asctime)s " if debug else "") +
-                   "[" + ("%d : " % get_mpi_rank() if more_than_one_process(
-                        no_mpi=no_mpi) else "") +
+                   "[" + ("%d : " % get_mpi_rank() if more_than_one_process() else "") +
                    "%(name)s" + "] " +
                    {logging.ERROR: "*ERROR* ",
                     logging.WARNING: "*WARNING* "}.get(record.levelno, "") +

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -23,6 +23,26 @@ _mpi_comm = -1
 _mpi_rank = -1
 
 
+def disable_mpi():
+    """Disable checking MPI state, for use on systems where MPI disallowed
+    """
+    global _mpi, _mpi_size, _mpi_comm, _mpi_rank
+    _mpi = None
+    _mpi_size = 0
+    _mpi_comm = None
+    _mpi_rank = None
+
+
+def enable_mpi():
+    """Reset globals to defaults, undoing disable_mpi
+    """
+    global _mpi, _mpi_size, _mpi_comm, _mpi_rank
+    _mpi = -1
+    _mpi_size = -1
+    _mpi_comm = -1
+    _mpi_rank = -1
+
+
 def get_mpi():
     """
     Import and returns the MPI object, or None if not running with MPI.
@@ -77,23 +97,15 @@ def get_mpi_rank():
 
 
 # Aliases for simpler use
-def am_single_or_primary_process(no_mpi=False):
+def am_single_or_primary_process():
     """Returns true if primary process or MPI not available.
-
-    Use the no_mpi keyword to avoid checking for MPI via import, 
-    which can die ungracefully (e.g. on head nodes at NERSC).
     """
-    if not no_mpi:
-        return not bool(get_mpi_rank())
-    else:
-        return True
+    return not bool(get_mpi_rank())
 
 
-def more_than_one_process(no_mpi=False):
-    if not no_mpi:
-        return bool(max(get_mpi_size(), 1) - 1)
-    else:
-        return False
+def more_than_one_process():
+    return bool(max(get_mpi_size(), 1) - 1)
+
 
 def sync_processes():
     if get_mpi_size():


### PR DESCRIPTION
As mentioned in #64 and partially addressed in #65, using cobaya on the head node of a cluster where MPI is disallowed causes python to crash ungracefully.  Since fixing #64, I've run into this issue again trying to use cobaya interactively.  I think this solution is better, as it allows an interactive user to do the following:
```python
from cobaya.mpi import disable_mpi
disable_mpi()
```
and then go on with life.  Followed by (if desired, in some crazy world?)
```python
from cobaya.mpi import enable_mpi
enable_mpi()
```
to restore the globals to their defaults.