### PR TITLE
Make exception more verbose for debugging purposes

### DIFF
--- a/cobaya/component.py
+++ b/cobaya/component.py
@@ -72,7 +72,10 @@ class CobayaComponent(HasLogger, HasDefaults):
             setattr(self, k, value)
         # set attributes from the info (usually from yaml file)
         for k, value in info.items():
-            setattr(self, k, value)
+            try:
+                setattr(self, k, value)
+            except AttributeError:
+                raise AttributeError("Cannot set {} attribute for {}!".format(k, self))
         self.set_logger(name=self._name)
         self.set_timing_on(timing)
         try:


### PR DESCRIPTION
Developing a new likelihood, had a bug, and this AttributeError here didn't give any useful info, so suggesting increased verbosity.