### PR TITLE
Expose _likelihoods and add option for returning full sampler object from run.run()

### DIFF
--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -289,15 +289,15 @@ class LikelihoodCollection(HasLogger):
         else:
             self.theory = None
         # Initialize individual Likelihoods
-        self._likelihoods = odict()
+        self.likelihoods = odict()
         for name, info in info_likelihood.items():
             # If it has an "external" key, wrap it up. Else, load it up
             if _external in info:
-                self._likelihoods[name] = LikelihoodExternalFunction(
+                self.likelihoods[name] = LikelihoodExternalFunction(
                     name, info, _theory=getattr(self, _theory, None), timing=timing)
             else:
                 like_class = get_class(name, kind=_likelihood)
-                self._likelihoods[name] = like_class(info, modules=modules, timing=timing)
+                self.likelihoods[name] = like_class(info, modules=modules, timing=timing)
         # Assign input/output parameters
         self._assign_params(parameterization, info_likelihood, info_theory)
         # Do the user-defined post-initialisation, and assign the theory code
@@ -321,7 +321,7 @@ class LikelihoodCollection(HasLogger):
         # code forces recomputation of the likelihoods
         for p, ls in self.sampled_like_dependence.items():
             if _theory in ls:
-                self.sampled_like_dependence[p] = ([_theory] + list(self._likelihoods))
+                self.sampled_like_dependence[p] = ([_theory] + list(self.likelihoods))
         # Overhead per likelihood evaluation
         self.overhead = _overhead_per_param * len(parameterization.sampled_params())
 
@@ -329,12 +329,12 @@ class LikelihoodCollection(HasLogger):
     # notice that "get" can get "theory", but the iterator does not!
     def __getitem__(self, key):
         try:
-            return self._likelihoods.__getitem__(key) if key != _theory else self.theory
+            return self.likelihoods.__getitem__(key) if key != _theory else self.theory
         except KeyError:
             raise LoggedError(self.log, "Likelihood '%r' not known", key)
 
     def __iter__(self):
-        return self._likelihoods.__iter__()
+        return self.likelihoods.__iter__()
 
     def logps(self, input_params, _derived=None, cached=True):
         """

--- a/cobaya/run.py
+++ b/cobaya/run.py
@@ -30,7 +30,7 @@ from cobaya.tools import warn_deprecation, deepcopy_where_possible
 from cobaya.post import post
 
 
-def run(info):
+def run(info,return_sampler=False):
     assert hasattr(info, "keys"), (
         "The first argument must be a dictionary with the info needed for the run. "
         "If you were trying to pass the name of an input file instead, "
@@ -89,7 +89,10 @@ def run(info):
     # Restore the original output_prefix: the script has not changed folder!
     if _output_prefix in info:
         updated_info[_output_prefix] = info.get(_output_prefix)
-    return updated_info, sampler.products()
+    if return_sampler:
+        return updated_info, sampler.products(), sampler
+    else:
+        return updated_info, sampler.products()
 
 
 # Command-line script

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -67,7 +67,7 @@ class polychord(Sampler):
         # Prepare arguments and settings
         self.nDims = self.model.prior.d()
         self.nDerived = (len(self.model.parameterization.derived_params()) +
-                         len(self.model.prior) + len(self.model.likelihood._likelihoods))
+                         len(self.model.prior) + len(self.model.likelihood.likelihoods))
         if self.logzero is None:
             self.logzero = np.nan_to_num(-np.inf)
         if self.max_ndead == np.inf:
@@ -173,7 +173,7 @@ class polychord(Sampler):
         self.n_sampled = len(self.model.parameterization.sampled_params())
         self.n_derived = len(self.model.parameterization.derived_params())
         self.n_priors = len(self.model.prior)
-        self.n_likes = len(self.model.likelihood._likelihoods)
+        self.n_likes = len(self.model.likelihood.likelihoods)
         # Done!
         if am_single_or_primary_process():
             self.log.info("Calling PolyChord with arguments:")
@@ -223,9 +223,9 @@ class polychord(Sampler):
             if len(derived) != len(self.model.parameterization.derived_params()):
                 derived = np.full(
                     len(self.model.parameterization.derived_params()), np.nan)
-            if len(loglikes) != len(self.model.likelihood._likelihoods):
+            if len(loglikes) != len(self.model.likelihood.likelihoods):
                 loglikes = np.full(
-                    len(self.model.likelihood._likelihoods), np.nan)
+                    len(self.model.likelihood.likelihoods), np.nan)
             derived = list(derived) + list(logpriors) + list(loglikes)
             return (
                 max(logposterior + self.logvolume, 0.99 * self.pc_settings.logzero), derived)


### PR DESCRIPTION
This addresses issue #72. Note that I've worked off the `sources` branch of CobayaSampler/cobaya.

It changes the `_likelihoods` attribute of `LikelihoodCollection` to `likelihoods` to make it discoverable in tab completion. It also adds an option for cobaya.run.run() to return the full sampler object so that the specific theory functions from a likelihood can be explicitly accessed. e.g. for accessing the BAO likelihood theory functions:

```
model = get_model(info)                                                                                                                                                                       
updated_info, products, sampler = crun(info,return_sampler=True)                                                                                                                              
DM_over_rs = sampler.model.likelihood.likelihoods['bao.sdss_dr12_consensus_bao'].theory_fun(z=0.51,'DM_over_rs')
```



If there are better existing ways to achieve this, I'll close this PR.