### PR TITLE
add get_cobaya_class load path

### DIFF
--- a/cobaya/conventions.py
+++ b/cobaya/conventions.py
@@ -11,7 +11,7 @@ from types import MappingProxyType
 
 # Package name (for importlib)
 # (apparently __package__ is only defined if you import something locally.
-_package = __name__.rpartition('.')[0]
+_cobaya_package = __name__.rpartition('.')[0]
 
 # an immutable empty dict (e.g. for argument defaults)
 empty_dict = MappingProxyType({})

--- a/cobaya/mpi.py
+++ b/cobaya/mpi.py
@@ -8,7 +8,7 @@
 
 import os
 # Local
-from cobaya.conventions import _package
+from cobaya.conventions import _cobaya_package
 
 # Vars to keep track of MPI parameters
 _mpi = None if os.environ.get('COBAYA_NOMPI', False) else -1
@@ -112,7 +112,7 @@ def import_MPI(module, target):
     target_name = target
     if get_mpi_rank() is not None:
         target_name = target + "_MPI"
-    return getattr(import_module(module, package=_package), target_name)
+    return getattr(import_module(module, package=_cobaya_package), target_name)
 
 
 def share_mpi(data=None):

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -64,13 +64,13 @@ from cobaya.input import update_info, is_equal_info, get_preferred_old_values
 from cobaya.output import OutputDummy
 
 
-def get_sampler_class(info_sampler):
+def get_sampler_name_and_class(info_sampler):
     """
     Auxiliary function to retrieve the class of the required sampler.
     """
     check_sane_info_sampler(info_sampler)
     name = list(info_sampler)[0]
-    return get_class(name, kind=kinds.sampler)
+    return name, get_class(name, kind=kinds.sampler)
 
 
 def check_sane_info_sampler(info_sampler):
@@ -144,12 +144,11 @@ def get_sampler(info_sampler, model, output=None, packages_path=None):
             "Input info updated with defaults (dumped to YAML):\n%s",
             yaml_dump(updated_info_sampler))
     # Get sampler class & check resume/force compatibility
-    sampler_class = get_sampler_class(updated_info_sampler)
+    sampler_name, sampler_class = get_sampler_name_and_class(updated_info_sampler)
     check_sampler_info(
         (output.reload_updated_info(use_cache=True) or {}).get(kinds.sampler),
         updated_info_sampler, is_resuming=output.is_resuming())
     # Check if resumable run
-    sampler_name = sampler_class.__name__
     sampler_class.check_force_resume(output, info=updated_info_sampler[sampler_name])
     # Instantiate the sampler
     sampler_instance = sampler_class(updated_info_sampler[sampler_name], model,


### PR DESCRIPTION
Thinking about how e.g. polychord could be made entirely external, and how other external general packages like CCL could support a cobaya class, it may be useful for external python packages to be able to provide a cobaya class without depending on Cobaya or loading it by default. So this adds a `get_cobaya_class() `function support to `get_class`, which could dynamically load the relevant class from the package `main __init_`_ file (i.e. if "polychord" external python package defined this in its `__init__`, it could then be used with exactly the same syntax as now as an internal package).

[Could also be used to e.g. rename internal classes with PEP8 formatting, e.g. MCMC rather than mcmc, loading from `mcmc.__init__ `and overriding `MCMC.get_qualified_class_name` to return "mcmc"; but there are likely complication in other places where the class name is used, e.g. loading the bib/yaml]