### PR TITLE
add FIRAS units

### DIFF
--- a/cobaya/likelihoods/_base_classes/_cmblikes.py
+++ b/cobaya/likelihoods/_base_classes/_cmblikes.py
@@ -581,7 +581,7 @@ class _CMBlikes(_DataSetLikelihood):
                     (np.trace(M) - self.nmaps - np.linalg.slogdet(M)[1]))
 
     def logp(self, **data_params):
-        cls = self.provider.get_Cl(ell_factor=True, units="muK2")
+        cls = self.provider.get_Cl(ell_factor=True)
         return self.log_likelihood(cls, **data_params)
 
     def log_likelihood(self, dls, **data_params):

--- a/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
@@ -121,7 +121,7 @@ class _planck_clik_prototype(Likelihood):
 
     def logp(self, **params_values):
         # get Cl's from the theory code
-        cl = self.provider.get_Cl(units="FIRAS")
+        cl = self.provider.get_Cl(units="FIRASmuK2")
         return self.log_likelihood(cl, **params_values)
 
     def log_likelihood(self, cl, **params_values):

--- a/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
+++ b/cobaya/likelihoods/_base_classes/_planck_clik_prototype.py
@@ -121,7 +121,7 @@ class _planck_clik_prototype(Likelihood):
 
     def logp(self, **params_values):
         # get Cl's from the theory code
-        cl = self.provider.get_Cl(units="muK2")
+        cl = self.provider.get_Cl(units="FIRAS")
         return self.log_likelihood(cl, **params_values)
 
     def log_likelihood(self, cl, **params_values):

--- a/cobaya/theories/_cosmo/boltzmannbase.py
+++ b/cobaya/theories/_cosmo/boltzmannbase.py
@@ -214,24 +214,26 @@ class BoltzmannBase(Theory):
         units_factors = {"1": 1,
                          "muK2": T_cmb * 1.e6,
                          "K2": T_cmb,
-                         "FIRAS": 2.7255e6}
+                         "FIRASmuK2": 2.7255e6,
+                         "FIRASK2": 2.7255
+                         }
         try:
             return units_factors[units]
         except KeyError:
             raise LoggedError(self.log, "Units '%s' not recognized. Use one of %s.",
                               units, list(units_factors))
 
-    def get_Cl(self, ell_factor=False, units="FIRAS"):
+    def get_Cl(self, ell_factor=False, units="FIRASmuK2"):
         r"""
         Returns a dictionary of lensed CMB power spectra and the lensing potential ``pp``
         power spectrum.
 
-        Set the units with the keyword ``units=number|'muK2'|'K2'|'FIRAS'``
-        (default: 'FIRAS' gives FIRAS-calibrated microKelvin^2, except for the lensing
+        Set the units with the keyword ``units=number|'muK2'|'K2'|'FIRASmuK2'|'FIRASK2'``
+        (default: 'FIRASmuK2' gives FIRAS-calibrated microKelvin^2, except for the lensing
         potential power spectrum, which is always unitless).
         Note the muK2 and K2 options use the model's CMB temperature; experimental data
         are usually calibrated to the FIRAS measurement which is a fixed temperature.
-        The default FIRAS takes CMB units = 2.7255e6 (to get result in MicroKelvin).
+        The default FIRASmuK2 takes CMB C_l scaled by 2.7255e6^2 (to get result in muK^2).
 
         If ``ell_factor=True`` (default: False), multiplies the spectra by
         :math:`\ell(\ell+1)/(2\pi)` (or by :math:`\ell^2(\ell+1)^2/(2\pi)` in the case of

--- a/cobaya/theories/_cosmo/boltzmannbase.py
+++ b/cobaya/theories/_cosmo/boltzmannbase.py
@@ -210,7 +210,7 @@ class BoltzmannBase(Theory):
                           "as extra arguments: %s. Please, remove one of the definitions "
                           "of each.", common)
 
-    def _unit_factor(self, units, T_cmb):
+    def _cmb_unit_factor(self, units, T_cmb):
         units_factors = {"1": 1,
                          "muK2": T_cmb * 1.e6,
                          "K2": T_cmb,

--- a/cobaya/theories/_cosmo/boltzmannbase.py
+++ b/cobaya/theories/_cosmo/boltzmannbase.py
@@ -210,13 +210,28 @@ class BoltzmannBase(Theory):
                           "as extra arguments: %s. Please, remove one of the definitions "
                           "of each.", common)
 
-    def get_Cl(self, ell_factor=False, units="muK2"):
+    def _unit_factor(self, units, T_cmb):
+        units_factors = {"1": 1,
+                         "muK2": T_cmb * 1.e6,
+                         "K2": T_cmb,
+                         "FIRAS": 2.7255e6}
+        try:
+            return units_factors[units]
+        except KeyError:
+            raise LoggedError(self.log, "Units '%s' not recognized. Use one of %s.",
+                              units, list(units_factors))
+
+    def get_Cl(self, ell_factor=False, units="FIRAS"):
         r"""
         Returns a dictionary of lensed CMB power spectra and the lensing potential ``pp``
         power spectrum.
 
-        Set the units with the keyword ``units='1'|'muK2'|'K2'`` (default: 'muK2',
-        except for the lensing potential power spectrum, which is always unitless).
+        Set the units with the keyword ``units=number|'muK2'|'K2'|'FIRAS'``
+        (default: 'FIRAS' gives FIRAS-calibrated microKelvin^2, except for the lensing
+        potential power spectrum, which is always unitless).
+        Note the muK2 and K2 options use the model's CMB temperature; experimental data
+        are usually calibrated to the FIRAS measurement which is a fixed temperature.
+        The default FIRAS takes CMB units = 2.7255e6 (to get result in MicroKelvin).
 
         If ``ell_factor=True`` (default: False), multiplies the spectra by
         :math:`\ell(\ell+1)/(2\pi)` (or by :math:`\ell^2(\ell+1)^2/(2\pi)` in the case of

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -583,7 +583,7 @@ class camb(BoltzmannBase):
                                             " in the CAMB interface", p)
         return derived
 
-    def get_Cl(self, ell_factor=False, units="FIRAS"):
+    def get_Cl(self, ell_factor=False, units="FIRASmuK2"):
         current_state = self._current_state
         # get C_l^XX from the cosmological code
         try:

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -583,7 +583,7 @@ class camb(BoltzmannBase):
                                             " in the CAMB interface", p)
         return derived
 
-    def get_Cl(self, ell_factor=False, units="muK2"):
+    def get_Cl(self, ell_factor=False, units="FIRAS"):
         current_state = self._current_state
         # get C_l^XX from the cosmological code
         try:
@@ -592,15 +592,7 @@ class camb(BoltzmannBase):
             raise LoggedError(self.log, "No Cl's were computed. Are you sure that you "
                                         "have requested them?")
 
-        temp = current_state['derived_extra']['TCMB']
-        units_factors = {"1": 1,
-                         "muK2": temp * 1.e6,
-                         "K2": temp}
-        try:
-            units_factor = units_factors[units]
-        except KeyError:
-            raise LoggedError(self.log, "Units '%s' not recognized. Use one of %s.",
-                              units, list(units_factors))
+        units_factor = self._unit_factor(units, current_state['derived_extra']['TCMB'])
 
         ls = np.arange(cl_camb.shape[0], dtype=np.int64)
         if not ell_factor:

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -592,7 +592,7 @@ class camb(BoltzmannBase):
             raise LoggedError(self.log, "No Cl's were computed. Are you sure that you "
                                         "have requested them?")
 
-        units_factor = self._unit_factor(units, current_state['derived_extra']['TCMB'])
+        units_factor = self._cmb_unit_factor(units, current_state['derived_extra']['TCMB'])
 
         ls = np.arange(cl_camb.shape[0], dtype=np.int64)
         if not ell_factor:

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -442,7 +442,7 @@ class classy(BoltzmannBase):
         derived_extra = {p: requested_and_extra[p] for p in self.derived_extra}
         return derived, derived_extra
 
-    def get_Cl(self, ell_factor=False, units="muK2"):
+    def get_Cl(self, ell_factor=False, units="FIRAS"):
         try:
             cls = deepcopy(self._current_state["Cl"])
         except:
@@ -452,15 +452,9 @@ class classy(BoltzmannBase):
         # unit conversion and ell_factor
         ells_factor = ((cls["ell"] + 1) * cls["ell"] / (2 * np.pi))[
                       2:] if ell_factor else 1
-        t_cmb = self._current_state['derived_extra']['T_cmb']
-        units_factors = {"1": 1,
-                         "muK2": t_cmb * 1.e6,
-                         "K2": t_cmb}
-        try:
-            units_factor = units_factors[units]
-        except KeyError:
-            raise LoggedError(self.log, "Units '%s' not recognized. Use one of %s.",
-                              units, list(units_factors))
+        units_factor = self._unit_factor(units,
+                                         self._current_state['derived_extra']['T_cmb'])
+
         for cl in cls:
             if cl not in ['pp', 'ell']:
                 cls[cl][2:] *= units_factor ** 2 * ells_factor

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -452,8 +452,8 @@ class classy(BoltzmannBase):
         # unit conversion and ell_factor
         ells_factor = ((cls["ell"] + 1) * cls["ell"] / (2 * np.pi))[
                       2:] if ell_factor else 1
-        units_factor = self._unit_factor(units,
-                                         self._current_state['derived_extra']['T_cmb'])
+        units_factor = self._cmb_unit_factor(units,
+                                             self._current_state['derived_extra']['T_cmb'])
 
         for cl in cls:
             if cl not in ['pp', 'ell']:

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -442,7 +442,7 @@ class classy(BoltzmannBase):
         derived_extra = {p: requested_and_extra[p] for p in self.derived_extra}
         return derived, derived_extra
 
-    def get_Cl(self, ell_factor=False, units="FIRAS"):
+    def get_Cl(self, ell_factor=False, units="FIRASmuK2"):
         try:
             cls = deepcopy(self._current_state["Cl"])
         except:
@@ -452,8 +452,8 @@ class classy(BoltzmannBase):
         # unit conversion and ell_factor
         ells_factor = ((cls["ell"] + 1) * cls["ell"] / (2 * np.pi))[
                       2:] if ell_factor else 1
-        units_factor = self._cmb_unit_factor(units,
-                                             self._current_state['derived_extra']['T_cmb'])
+        units_factor = self._cmb_unit_factor(
+            units, self._current_state['derived_extra']['T_cmb'])
 
         for cl in cls:
             if cl not in ['pp', 'ell']:


### PR DESCRIPTION
Experiments like Planck are usually calibrated to FIRAS not an absolute temperature. This adds FIRAS units option to get C_l result in FIRAS muK^2, which is default for Planck (and hopefully making it easier to directly run varying T_CMB consistently). 