### PR TITLE
Add 'none' option for min_version

### DIFF
--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -157,7 +157,7 @@ def load_module(name, package=None, path=None, min_version=None,
         component = import_module(name, package=package)
     if path and check_path:
         check_component_path(component, path)
-    if min_version:
+    if min_version and min_version.lower() != 'none':
         check_component_version(component, min_version)
     return component
 


### PR DESCRIPTION
This allows a workaround if, e.g., the desired version of classy is old and doesn't have version access: the $CLASS_REPO_VERSION can be set to the string 'none' and the version check passes.  Might also be generally applicable elsewhere with similar env var patterns.