### PR TITLE
Add 'make' to the apt installation list

### DIFF
--- a/docs/cluster_amazon.rst
+++ b/docs/cluster_amazon.rst
@@ -17,7 +17,7 @@ Now install the requisites with
 
 .. code:: bash
 
-   $ sudo apt update && sudo apt install gcc gfortran g++ openmpi-bin openmpi-common libopenmpi-dev libopenblas-base liblapack3 liblapack-dev
+   $ sudo apt update && sudo apt install gcc gfortran g++ openmpi-bin openmpi-common libopenmpi-dev libopenblas-base liblapack3 liblapack-dev make
    $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
    $ bash miniconda.sh -b -p $HOME/miniconda
    $ export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
Trying this for the first time, I found that 'make' is not installed unless requested, which means the cobaya-install of camb & classy wouldn't work without.