### PR TITLE
Fix problem with sigma8

### DIFF
--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -531,6 +531,8 @@ class camb(BoltzmannBase):
                 return derived
         # Specific calls, if general ones fail:
         if p == "sigma8":
+            intermediates.camb_params.Transfer.PK_redshifts = [0]
+            res = self.camb.get_results(intermediates.camb_params)
             return intermediates.results.get_sigma8()[-1]
         try:
             return getattr(intermediates.camb_params, p)


### PR DESCRIPTION
Hello, 

I am trying to run cobaya for BAO, and I noticed that I get a sigma_8 smaller than I would expect given the rest of cosmological parameters. I checked with CosmoMC with the exact same settings, and indeed my sigma_8 in cobaya is low. I believe when using BAO, cobaya was giving me the sigma_8 at the smallest redshift at which I was evaluating BAO. This fix works, but I am sure there is a better and more efficient way of fixing the issue. 

Best, 
Pablo