### PR TITLE
Reducing the overhead of MCMC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 3.0.5 – 2021-YY-ZZ
 
+### MCMC
+
+- Overhead reduced by at least 40%, thanks to caching in Collection
+
 ### Minimize
 
 - `PyBOBYQA` updated to 1.2, and quieter by default.

--- a/cobaya/collection.py
+++ b/cobaya/collection.py
@@ -31,12 +31,12 @@ chains.print_load_details = False
 # Default chunk size for enlarging collections more efficiently
 # If a factor is defined (as a fraction !=0), it is used instead
 # (e.g. 0.10 to grow the number of rows by 10%)
-enlargement_size: int = 100
+enlargement_size: int = 500
 enlargement_factor: Optional[int] = None
 
 # Size of fast numpy cache; should be larger than enlargement_size.
 # (used to avoid "setting" in Pandas too often, which is expensive)
-cache_size = 20
+cache_size = 100
 
 
 # Make sure that we don't reach the empty part of the dataframe

--- a/cobaya/collection.py
+++ b/cobaya/collection.py
@@ -30,7 +30,7 @@ chains.print_load_details = False
 
 # Size of fast numpy cache
 # (used to avoid "setting" in Pandas too often, which is expensive)
-_default_cache_size = 100
+_default_cache_size = 200
 
 
 # Make sure that we don't reach the empty part of the dataframe

--- a/cobaya/post.py
+++ b/cobaya/post.py
@@ -384,9 +384,9 @@ def post(info, sample=None):
     #   Prefer to rescale +inf to finite, and ignore final points with -inf.
     #   Remove -inf's (0-weight), and correct indices
     difflogmax = max(collection_in[_minuslogpost] - collection_out[_minuslogpost])
-    collection_out.data[_weight] *= np.exp(
+    collection_out._data[_weight] *= np.exp(
         collection_in[_minuslogpost] - collection_out[_minuslogpost] - difflogmax)
-    collection_out.data = (
+    collection_out._data = (
         collection_out.data[collection_out.data.weight > 0].reset_index(drop=True))
     collection_out._n = collection_out.data.last_valid_index() + 1
     # Write!

--- a/cobaya/samplers/evaluate/evaluate.py
+++ b/cobaya/samplers/evaluate/evaluate.py
@@ -31,7 +31,7 @@ class evaluate(Sampler):
                 self.log,
                 "Could not convert the number of samples to an integer: %r", self.N)
         self.one_point = Collection(
-            self.model, self.output, initial_size=self.N, name="1")
+            self.model, self.output, name="1")
         self.log.info("Initialized!")
 
     def _run(self):

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -611,24 +611,15 @@ class mcmc(CovmatSampler):
         learns a new covariance matrix for the proposal distribution from the covariance
         of the last samples.
         """
+        # Compute Rminus1 of means
         if more_than_one_process():
-            # Compute and gather means, covs and CL intervals of last half of chains
+            # Compute and gather means and covs
             use_first = int(self.n() / 2)
             mean = self.collection.mean(first=use_first)
             cov = self.collection.cov(first=use_first)
-            mcsamples = self.collection._sampled_to_getdist_mcsamples(first=use_first)
-            try:
-                bound = np.array([[
-                    mcsamples.confidence(i, limfrac=self.Rminus1_cl_level / 2.,
-                                         upper=which)
-                    for i in range(self.model.prior.d())] for which in [False, True]]).T
-                success_bounds = True
-            except:
-                bound = None
-                success_bounds = False
-            Ns, means, covs, bounds, acceptance_rates = map(
+            Ns, means, covs, acceptance_rates = map(
                 lambda x: np.array(get_mpi_comm().gather(x)),
-                [self.n(), mean, cov, bound, self.acceptance_rate])
+                [self.n(), mean, cov, self.acceptance_rate])
         else:
             # Compute and gather means, covs and CL intervals of last m-1 chain fractions
             m = 1 + self.Rminus1_single_split
@@ -641,25 +632,11 @@ class mcmc(CovmatSampler):
                 covs = np.array(
                     [self.collection.cov(first=i * cut, last=(i + 1) * cut - 1) for i in
                      range(1, m)])
-                mcsamples_list = [
-                    self.collection._sampled_to_getdist_mcsamples(
-                        first=i * cut, last=(i + 1) * cut - 1)
-                    for i in range(1, m)]
             except:
                 self.log.info("Not enough points in chain to check convergence. "
                               "Waiting for next checkpoint.")
                 return
             acceptance_rates = self.acceptance_rate
-            try:
-                bounds = [np.array(
-                    [[mcs.confidence(i, limfrac=self.Rminus1_cl_level / 2., upper=which)
-                      for i in range(self.model.prior.d())] for which in [False, True]]).T
-                          for mcs in mcsamples_list]
-                success_bounds = True
-            except:
-                bounds = None
-                success_bounds = False
-        # Compute convergence diagnostics
         if is_main_process():
             self.progress.at[self.i_learn, "N"] = (
                 sum(Ns) if more_than_one_process() else self.n())
@@ -690,7 +667,8 @@ class mcmc(CovmatSampler):
             np.seterr(**prev_err_state)
             corr_of_means = diagSinvsqrt.dot(cov_of_means).dot(diagSinvsqrt)
             norm_mean_of_covs = diagSinvsqrt.dot(mean_of_covs).dot(diagSinvsqrt)
-            success = False
+            success_means = False
+            converged_means = False
             # Cholesky of (normalized) mean of covs and eigvals of Linv*cov_of_means*L
             try:
                 L = np.linalg.cholesky(norm_mean_of_covs)
@@ -707,7 +685,7 @@ class mcmc(CovmatSampler):
                 np.seterr(all="ignore")
                 try:
                     eigvals = np.linalg.eigvalsh(Linv.dot(corr_of_means).dot(Linv.T))
-                    success = True
+                    success_means = True
                 except np.linalg.LinAlgError:
                     self.log.warning("Could not compute eigenvalues. "
                                      "Skipping learning a new covmat for now.")
@@ -724,39 +702,76 @@ class mcmc(CovmatSampler):
                         (" = sum(%r)" % list(Ns) if more_than_one_process() else ""))
                     # Have we converged in means?
                     # (criterion must be fulfilled twice in a row)
-                    if max(Rminus1, self.Rminus1_last) < self.Rminus1_stop:
-                        # Check the convergence of the bounds of the confidence intervals
-                        # Same as R-1, but with the rms deviation from the mean bound
-                        # in units of the mean standard deviation of the chains
-                        if success_bounds:
-                            Rminus1_cl = (np.std(bounds, axis=0).T /
-                                          np.sqrt(np.diag(mean_of_covs)))
-                            self.log.debug(" - normalized std's of bounds = %r",
-                                           Rminus1_cl)
-                            Rminus1_cl = np.max(Rminus1_cl)
-                            self.progress.at[self.i_learn, "Rminus1_cl"] = Rminus1_cl
-                            self.log.info(
-                                " - Convergence of bounds: R-1 = %f after %d " % (
-                                    Rminus1_cl,
-                                    (sum(Ns) if more_than_one_process() else self.n())) +
-                                "accepted steps" +
-                                (" = sum(%r)" % list(
-                                    Ns) if more_than_one_process() else ""))
-                            if Rminus1_cl < self.Rminus1_cl_stop:
-                                self.converged = True
-                                self.log.info("The run has converged!")
-                            self._Ns = Ns
-                        else:
-                            self.log.info("Computation of the bounds was not possible. "
-                                          "Waiting until the next converge check.")
-                np.seterr(**error_handling)
+                    converged_means = max(Rminus1, self.Rminus1_last) < self.Rminus1_stop
         else:
             mean_of_covs = np.empty((self.model.prior.d(), self.model.prior.d()))
-            success = None
+            success_means = None
+            converged_means = False
             Rminus1 = None
+        success_means = share_mpi(success_means)
+        converged_means = share_mpi(converged_means)
+        # Check the convergence of the bounds of the confidence intervals
+        # Same as R-1, but with the rms deviation from the mean bound
+        # in units of the mean standard deviation of the chains
+        if converged_means:
+            if more_than_one_process():
+                mcsamples = self.collection._sampled_to_getdist_mcsamples(first=use_first)
+                try:
+                    bound = np.array([[
+                        mcsamples.confidence(
+                            i, limfrac=self.Rminus1_cl_level / 2., upper=which)
+                        for i in range(self.model.prior.d())]
+                                      for which in [False, True]]).T
+                    success_bounds = True
+                except:
+                    bound = None
+                    success_bounds = False
+                bounds = np.array(get_mpi_comm().gather(bound))
+            else:
+                try:
+                    mcsamples_list = [
+                        self.collection._sampled_to_getdist_mcsamples(
+                            first=i * cut, last=(i + 1) * cut - 1)
+                        for i in range(1, m)]
+                except:
+                    self.log.info("Not enough points in chain to check c.l. convergence. "
+                                  "Waiting for next checkpoint.")
+                    return
+                try:
+                    bounds = [
+                        np.array(
+                            [[mcs.confidence(
+                                i, limfrac=self.Rminus1_cl_level / 2., upper=which)
+                              for i in range(self.model.prior.d())]
+                             for which in [False, True]]).T
+                        for mcs in mcsamples_list]
+                    success_bounds = True
+                except:
+                    bounds = None
+                    success_bounds = False
+            if is_main_process():
+                if success_bounds:
+                    Rminus1_cl = (np.std(bounds, axis=0).T /
+                                  np.sqrt(np.diag(mean_of_covs)))
+                    self.log.debug(" - normalized std's of bounds = %r", Rminus1_cl)
+                    Rminus1_cl = np.max(Rminus1_cl)
+                    self.progress.at[self.i_learn, "Rminus1_cl"] = Rminus1_cl
+                    self.log.info(
+                        " - Convergence of bounds: R-1 = %f after %d " % (
+                            Rminus1_cl,
+                            (sum(Ns) if more_than_one_process() else self.n())) +
+                        "accepted steps" + (" = sum(%r)" % list(
+                            Ns) if more_than_one_process() else ""))
+                    if Rminus1_cl < self.Rminus1_cl_stop:
+                        self.converged = True
+                        self.log.info("The run has converged!")
+                        self._Ns = Ns
+                else:
+                    self.log.info("Computation of the bounds was not possible. "
+                                  "Waiting until the next converge check.")
+                np.seterr(**error_handling)
         # Broadcast and save the convergence status and the last R-1 of means
-        success = share_mpi(success)
-        if success:
+        if success_means:
             self.Rminus1_last, self.converged = share_mpi(
                 (Rminus1, self.converged) if is_main_process() else None)
             # Do we want to learn a better proposal pdf?
@@ -835,8 +850,8 @@ class mcmc(CovmatSampler):
                     fmts = {"N": lambda x: "{:9d}".format(x)}
                     # TODO: next one is ignored when added to the dict
                     #        "acceptance_rate": lambda x: "{:15.8g}".format(x)}
-                    progress_file.write(
-                        self.progress.tail(1).to_string(header=False, index=False, formatters=fmts) + "\n")
+                    progress_file.write(self.progress.tail(1).to_string(
+                        header=False, index=False, formatters=fmts) + "\n")
             self.log.debug("Dumped checkpoint and progress info, and current covmat.")
 
     # Finally: returning the computed products ###########################################

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -169,8 +169,7 @@ class polychord(Sampler):
                 get_external_function(self.callback_function))
         self.last_point_callback = 0
         # Prepare runtime live and dead points collections
-        self.live = Collection(
-            self.model, None, name="live", initial_size=self.pc_settings.nlive)
+        self.live = Collection(self.model, None, name="live")
         self.dead = Collection(self.model, self.output, name="dead")
         # Done!
         if is_main_process():

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -113,6 +113,7 @@ def _test_overhead_timing(dim=15):
     prof.enable()
     run(info)
     prof.disable()
+    # prof.dump_stats("out.prof")  # to visualize with e.g. snakeviz
     s = StringIO()
     ps = pstats.Stats(prof, stream=s)
     print_n_calls = 10

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -97,7 +97,7 @@ def _make_gaussian_like(nparam):
     return LikeTest
 
 
-def _test_overhead_timing():
+def _test_overhead_timing(dim=15):
     # prints timing for simple Gaussian vanilla mcmc
     import pstats
     from cProfile import Profile
@@ -105,7 +105,7 @@ def _test_overhead_timing():
     # noinspection PyUnresolvedReferences
     from cobaya.samplers.mcmc import proposal  # one-time numba compile out of profiling
 
-    LikeTest = _make_gaussian_like(15)
+    LikeTest = _make_gaussian_like(dim)
     info = {'likelihood': {'like': LikeTest}, 'debug': False, 'sampler': {
         'mcmc': {'max_samples': 1000, 'burn_in': 0, "learn_proposal": False,
                  "Rminus1_stop": 0.0001}}}
@@ -115,9 +115,10 @@ def _test_overhead_timing():
     prof.disable()
     s = StringIO()
     ps = pstats.Stats(prof, stream=s)
+    print_n_calls = 10
     ps.strip_dirs()
     ps.sort_stats('time')
-    ps.print_stats(10)
+    ps.print_stats(print_n_calls)
     ps.sort_stats('cumtime')
-    ps.print_stats(10)
+    ps.print_stats(print_n_calls)
     print(s.getvalue())


### PR DESCRIPTION
- [x] add numpy cache to collection --> now ~3-4x faster than get_proposal (more without numba)
- [x] check_convergence: compute bounds only if Rminus1 bounds test will be performed (affects dim ~< 10) --> 30% faster
- [ ] ...