### PR TITLE
More general input derived parameter dependencies

### DIFF
--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -279,7 +279,7 @@ class LikelihoodCollection(ComponentCollection):
             else:
                 like_class = get_resolved_class(
                     name, kind=kinds.likelihood,
-                    component_path=info.pop(_component_path, None),
+                    component_path=info.get(_component_path, None),
                     class_name=info.get(_class_name))
                 self.add_instance(name, like_class(info, packages_path=packages_path,
                                                    timing=timing, standalone=False,

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -824,14 +824,13 @@ class Model(HasLogger):
             #    Input parameters always assigned to any supporting component.
             unassigned = [p for p in assign if not assign[p]]
             for component in assign_components:
-                if component not in agnostic_likes[io_kind]:
-                    if derived_param:
-                        supports_params = component.get_can_provide_params()
-                    else:
-                        supports_params = component.get_can_support_params()
-                    for p in (unassigned if derived_param else assign):
-                        if p in supports_params and component not in assign[p]:
-                            assign[p] += [component]
+                if derived_param:
+                    supports_params = component.get_can_provide_params()
+                else:
+                    supports_params = component.get_can_support_params()
+                for p in (unassigned if derived_param else assign):
+                    if p in supports_params and component not in assign[p]:
+                        assign[p] += [component]
             # Check that there is only one non-knowledgeable element, and assign
             # unused params
             if len(agnostic_likes[io_kind]) > 1 and not all(assign.values()):

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -832,7 +832,11 @@ class Model(HasLogger):
         # If there are unassigned input params, check later that they are used by
         # *conditional* requirements of a component (and if not raise error)
         self._unassigned_input = set(p for p, assigned in params_assign["input"].items()
-                                     if not assigned)
+                                     if not assigned).difference(
+            chain(*(self.parameterization._input_dependencies[p] for p, assigned in
+                        params_assign["input"].items() if assigned and
+                    p in self.parameterization._input_dependencies)))
+
         # Remove aggregated chi2 that may have been picked up by an agnostic component
         aggr_chi2_names = [_get_chi2_name(t) for t in self.likelihood.all_types]
         for p in aggr_chi2_names:

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -682,14 +682,13 @@ class Model(HasLogger):
         if self._unassigned_input:
             self._unassigned_input.difference_update(*direct_param_dependence.values())
             if self._unassigned_input:
-                unassigned = self._unassigned_input.difference(
-                    self.prior.external_dependence)
+                unassigned = self._unassigned_input - self.prior.external_dependence
                 if unassigned:
                     raise LoggedError(
                         self.log, "Could not find anything to use input parameter(s) %r.",
                         unassigned)
                 else:
-                    self.log.warning("Parameters %s are only used by the prior",
+                    self.log.warning("Parameter(s) %s are only used by the prior",
                                      self._unassigned_input)
         if self.log.getEffectiveLevel() <= logging.DEBUG:
             self.log.debug("Components will be computed in the order:")

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -807,11 +807,15 @@ class Model(HasLogger):
                 # 3. Does it have a general (mixed) list of params? (set from default)
                 # 4. or otherwise required
                 elif getattr(component, _params, None) or required_params:
-                    for p, options in getattr(component, _params, {}).items():
-                        if not hasattr(options, 'get') or \
-                                options.get('derived', derived_param) is derived_param:
-                            if p in assign:
-                                assign[p] += [component]
+                    if getattr(component, _params, None):
+                        for p, options in getattr(component, _params, {}).items():
+                            if not hasattr(options, 'get') or \
+                                    options.get('derived',
+                                                derived_param) is derived_param:
+                                if p in assign:
+                                    assign[p] += [component]
+                    elif component.get_allow_agnostic():
+                        agnostic_likes[io_kind] += [component]
                     if required_params:
                         for p in required_params:
                             if p in assign and component not in assign[p]:
@@ -841,8 +845,7 @@ class Model(HasLogger):
             elif agnostic_likes[io_kind]:  # if there is only one
                 component = agnostic_likes[io_kind][0]
                 for p, assigned in assign.items():
-                    if not assigned or not derived_param and \
-                            p in component.get_requirements():
+                    if not assigned:
                         assign[p] += [component]
 
         # If unit likelihood is present, assign all unassigned inputs to it

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -194,15 +194,14 @@ class Parameterization(HasLogger):
                 list(dropped_but_never_used), partag.drop)
         # input params depend on input and sampled only, never on output/derived
         all_input_arguments = set(chain(*self._input_args.values()))
-        bad_input_dependencies = all_input_arguments.difference(
-            set(self.input_params()).union(set(self.sampled_params())).union(
-                set(self.constant_params())))
+        bad_input_dependencies = \
+            set(all_input_arguments).intersection(set(self._input_funcs))
         if bad_input_dependencies:
             raise LoggedError(
                 self.log,
                 "Input parameters defined as functions can only depend on other "
                 "input parameters that are not defined as functions. "
-                "In particular, an input parameter cannot depend on %r."
+                "In particular, an input parameter cannot depend on %r. "
                 "Use an explicit Theory calculator for more complex dependencies.",
                 list(bad_input_dependencies))
         self._wrapped_input_funcs, self._wrapped_derived_funcs = \

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -343,6 +343,7 @@ import numpy as np
 import numbers
 from types import MethodType
 from typing import Sequence
+from itertools import chain
 
 # Local
 from cobaya.conventions import _prior, partag, _prior_1d_name
@@ -441,10 +442,10 @@ class Prior(HasLogger):
                     opts["argspec"].args)
             params_without_default = opts["argspec"].args[
                                      :(len(opts["argspec"].args) -
-                                       len(opts[
-                                               "argspec"].defaults or []))]
+                                       len(opts["argspec"].defaults or []))]
             if not all((p in opts["params"] or
-                        p in opts["constant_params"])
+                        p in opts["constant_params"] or
+                        p in chain(*parameterization.sampled_input_dependence().values()))
                        for p in params_without_default):
                 raise LoggedError(
                     self.log, "Some of the arguments of the external prior '%s' cannot "

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -440,19 +440,17 @@ class Prior(HasLogger):
                               "are known *fixed* or *sampled* parameters. "
                               "This prior recognizes: %r", name,
                     opts["argspec"].args)
-            params_without_default = opts["argspec"].args[
-                                     :(len(opts["argspec"].args) -
+            params_without_default = \
+                opts["argspec"].args[:(len(opts["argspec"].args) -
                                        len(opts["argspec"].defaults or []))]
-            if not all((p in opts["params"] or
-                        p in opts["constant_params"] or
-                        p in chain(*parameterization.sampled_input_dependence().values()))
-                       for p in params_without_default):
+            unknown = set(params_without_default).difference(
+                opts["params"]).difference(opts["constant_params"]).difference(
+                chain(*parameterization.sampled_input_dependence().values()))
+            if unknown:
                 raise LoggedError(
                     self.log, "Some of the arguments of the external prior '%s' cannot "
                               "be found and don't have a default value either: %s",
-                    name, list(set(params_without_default)
-                               .difference(opts["params"])
-                               .difference(opts["constant_params"])))
+                    name, list(unknown))
             self.mpi_warning("External prior '%s' loaded. "
                              "Mind that it might not be normalized!", name)
 

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -142,17 +142,14 @@ b) **As a string,** which will be passed to ``eval()``. The string can be a
 
 .. warning::
 
-   At this moment, external priors can only be functions of **sampled** and **fixed**
-   parameters. This may be extended in the future to dependence on **derived** parameters,
-   probably just for dynamically defined ones, but not for those computed by the theory
-   code, since otherwise the full prior could not be computed **before** the likelihood,
+   External priors can only be functions **sampled** and **fixed**
+   and **derived** parameters that are dynamically defined in terms of other inputs.
+   Derived parameters computed by the theory code cannot be used in in a prior, since
+   otherwise the full prior could not be computed **before** the likelihood,
    preventing us from avoiding computing the likelihood when the prior is null, or
    forcing a *post-call* to the prior.
 
-   **Workaround #1:** If the derived parameter(s) can be computed easily from sampled and
-   fixed parameters, do the computation inside the call to the external prior.
-
-   **Workaround #2:** Define your function as a
+   **Workaround:** Define your function as a
    :ref:`external likelihood <likelihood_external>` instead, since likelihoods do have
    access to derived parameters (for an example, see `this comment
    <https://github.com/CobayaSampler/cobaya/issues/18#issuecomment-447818811>`_).
@@ -216,7 +213,7 @@ parameters:
 + **Sampled** parameters, i.e. those that have a prior, including ``logx`` but not ``x``
   (it does not have a prior: it's fixed by a function). Those are the ones with which the
   **sampler** interacts. Since the likelihood does not understand them, they must be
-  **dropped** with ``drop: True``.
+  **dropped** with ``drop: True`` if you are using any parameter-agnostic components.
 
 + Likelihood **input** parameters: those that will be passed to the likelihood
   (or theory). They are identified by either having a prior and not being **dropped**, or

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -538,7 +538,7 @@ class CovmatSampler(Sampler):
                 "Covariance matrix loaded for params %r",
                 [list(params_infos)[i] for i in indices_sampler])
             missing_params = set(params_infos).difference(
-                set(list(params_infos)[i] for i in indices_sampler))
+                list(params_infos)[i] for i in indices_sampler)
             if missing_params:
                 self.log.info(
                     "Missing proposal covariance for params %r",

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -136,7 +136,8 @@ class mcmc(CovmatSampler):
                 fmt = lambda col: header_fmt.get(col, ((7 + 8) - len(col)) * " " + col)
                 with open(self.progress_filename(), "w",
                           encoding="utf-8") as progress_file:
-                    progress_file.write("# " + " ".join([fmt(col) for col in self.progress.columns]) + "\n")
+                    progress_file.write("# " + " ".join(
+                        [fmt(col) for col in self.progress.columns]) + "\n")
         # Get first point, to be discarded -- not possible to determine its weight
         # Still, we need to compute derived parameters, since, as the proposal "blocked",
         # we may be saving the initial state of some block.
@@ -718,10 +719,10 @@ class mcmc(CovmatSampler):
                 mcsamples = self.collection._sampled_to_getdist_mcsamples(first=use_first)
                 try:
                     bound = np.array([[
-                        mcsamples.confidence(
-                            i, limfrac=self.Rminus1_cl_level / 2., upper=which)
+                        mcsamples.confidence(i, limfrac=self.Rminus1_cl_level / 2.,
+                                             upper=which)
                         for i in range(self.model.prior.d())]
-                                      for which in [False, True]]).T
+                        for which in [False, True]]).T
                     success_bounds = True
                 except:
                     bound = None
@@ -742,8 +743,8 @@ class mcmc(CovmatSampler):
                         np.array(
                             [[mcs.confidence(
                                 i, limfrac=self.Rminus1_cl_level / 2., upper=which)
-                              for i in range(self.model.prior.d())]
-                             for which in [False, True]]).T
+                                for i in range(self.model.prior.d())]
+                                for which in [False, True]]).T
                         for mcs in mcsamples_list]
                     success_bounds = True
                 except:

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -175,6 +175,7 @@ import ctypes
 from copy import deepcopy
 from typing import NamedTuple, Any
 import numpy as np
+from itertools import chain
 # Local
 from cobaya.theories._cosmo import BoltzmannBase
 from cobaya.log import LoggedError
@@ -684,8 +685,7 @@ class camb(BoltzmannBase):
             if mapped in names:
                 names.append(name)
         # remove any parameters explicitly tagged as input requirements
-        return set(names).difference(
-            set(self._transfer_requires).union(set(self.requires)))
+        return set(names).difference(chain(self._transfer_requires,self.requires))
 
     def get_version(self):
         return self.camb.__version__

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -480,7 +480,7 @@ class camb(BoltzmannBase):
     def calculate(self, state, want_derived=True, **params_values_dict):
         try:
             params, results = self.provider.get_CAMB_transfers()
-            if self.collectors:
+            if self.collectors or 'sigma8' in self.derived_extra:
                 if self.external_primordial_pk and self.needs_perts:
                     primordial_pk = self.provider.get_primordial_scalar_pk()
                     if primordial_pk.get('log_regular', True):

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -635,7 +635,7 @@ class camb(BoltzmannBase):
             i_kwarg_z = np.searchsorted(computed_redshifts, np.atleast_1d(z))
         return np.array(self.current_state[quantity], copy=True)[i_kwarg_z]
 
-    def get_sigma8_z(self, z):        
+    def get_sigma8_z(self, z):
         return self._get_z_dependent("sigma8_z", z)
 
     def get_fsigma8(self, z):
@@ -815,9 +815,8 @@ class camb(BoltzmannBase):
                           " a very old version without the Python interface.", path)
                 return False
             if not os.path.isfile(os.path.realpath(
-                    os.path.join(path,
-                                 "camb", "cambdll.dll" if (
-                                platform.system() == "Windows") else "camblib.so"))):
+                    os.path.join(path, "camb", "cambdll.dll" if (
+                            platform.system() == "Windows") else "camblib.so"))):
                 log.error("CAMB installation at '%s' appears not to be compiled.", path)
                 return False
         elif not path:

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -408,7 +408,7 @@ class classy(BoltzmannBase):
         # Put all parameters in CLASS nomenclature (self.derived_extra already is)
         requested = [self.translate_param(p) for p in (
             self.output_params if derived_requested else [])]
-        requested_and_extra = dict.fromkeys(set(requested).union(set(self.derived_extra)))
+        requested_and_extra = dict.fromkeys(set(requested).union(self.derived_extra))
         # Parameters with their own getters
         if "rs_drag" in requested_and_extra:
             requested_and_extra["rs_drag"] = self.classy.rs_drag()

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -438,7 +438,7 @@ class classy(BoltzmannBase):
             cls = deepcopy(self.current_state[which_key])
         except:
             raise LoggedError(self.log, "No %s Cl's were computed. Are you sure that you "
-                              "have requested them?", which_error)
+                                        "have requested them?", which_error)
         # unit conversion and ell_factor
         ells_factor = ((cls["ell"] + 1) * cls["ell"] / (2 * np.pi))[
                       2:] if ell_factor else 1
@@ -482,6 +482,11 @@ class classy(BoltzmannBase):
             if mapped in names:
                 names.append(name)
         return names
+
+    def get_can_support_params(self):
+        # non-exhaustive list of supported input parameters that will be assigne do classy
+        # if they are varied
+        return ['H0']
 
     def get_version(self):
         return getattr(self.classy_module, '__version__', None)

--- a/cobaya/theory.py
+++ b/cobaya/theory.py
@@ -222,12 +222,12 @@ class Theory(CobayaComponent):
         (retrieved using current_derived).
         """
         self.log.debug("Got parameters %r", params_values_dict)
-        for p in self._input_params_extra:
+        for p in list(self._input_params_extra):
             try:
                 params_values_dict[p] = self.provider.get_param(p)
             except:
                 # Pop non-parameter (only done during 1st call)
-                self._input_params_extra = self._input_params_extra.difference({p})
+                self._input_params_extra.discard(p)
         state = None
         if cached:
             for _state in self._states:
@@ -287,6 +287,7 @@ class Theory(CobayaComponent):
                          "rename your call.")
         # BEHAVIOUR TO BE REPLACED BY AN ERROR
         return self.current_derived
+
     # END OF DEPRECATION BLOCK
 
     def get_provider(self):

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -837,7 +837,7 @@ def get_translated_params(params_info, params_list):
     """
     translations = {}
     for p, pinfo in params_info.items():
-        renames = {p}.union(set(str_to_list(pinfo.get(partag.renames, []))))
+        renames = {p}.union(str_to_list(pinfo.get(partag.renames, [])))
         try:
             trans = next(r for r in renames if r in params_list)
             translations[p] = trans


### PR DESCRIPTION
Currently things like
```

  xx: 
    value: 12
    drop: True
  xy:
    value: "lambda xx: xx*2"
    drop: True
  x:
    value: "lambda xy, xx: xx*xy"  
```
generate an error that "xy" is not used by any likelihood (assuming it isn't). Ideally we'd support nested dependencies, but I think currently not supported, so  this pull just changes the way the existing nested dependency error is raised. Not sure if that error is supposed to be catching other cases not captured by this.