### PR TITLE
Resuming checks for convergence parameter changes

### DIFF
--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -855,6 +855,11 @@ class mcmc(CovmatSampler):
                         header=False, index=False, formatters=fmts) + "\n")
             self.log.debug("Dumped checkpoint and progress info, and current covmat.")
 
+    def converge_info_changed(self, old_info, new_info):
+        converge_params = ['Rminus1_stop', "Rminus1_cl_stop", "Rminus1_cl_level",
+                           "max_samples"]
+        return any(old_info.get(p) != new_info.get(p) for p in converge_params)
+
     # Finally: returning the computed products ###########################################
 
     def products(self):


### PR DESCRIPTION
Probably we also need to delete the checkpoint file after reading if input parameters changed so that do not get inconsistent result if run fails before new checkpoint with new parameters is written?