### PR TITLE
cobaya.typing and constants refactoring

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,13 +6,14 @@
 
 # cosmetic/consistency/speed
 
+## min/max bounds enforced on derived parameters (more generally, "bounds" as well as priors)
 ## make portalocker/numba/dill a requirement?
 ## version attribute should be in all components not just theory (samplers can have versions) [done for samplers; missing: likelihoods]
 ## In the docs "Bases" (and UML diagram) not hyperlinked correctly (not sure how to fix)
 ## dump log info along with each chain file if saving to file (currently in stdout)
 ## PolyChord: check overhead
 ## PolyChord: lower dimension of tests?
-## use TypedDict for all dicts, remove _prior, _... etc constants
+## use TypedDict for all dicts, remove "prior", _... etc constants
 
 # Enhancements/Refactorings
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,6 @@
 ## dump log info along with each chain file if saving to file (currently in stdout)
 ## PolyChord: check overhead
 ## PolyChord: lower dimension of tests?
-## use TypedDict for all dicts, remove "prior", _... etc constants
 
 # Enhancements/Refactorings
 

--- a/cobaya/__init__.py
+++ b/cobaya/__init__.py
@@ -1,5 +1,12 @@
 import sys
 import platform
+from cobaya.likelihood import Likelihood
+from cobaya.theory import Theory
+from cobaya.run import run
+from cobaya.model import get_model
+from cobaya.typing import InputDict, PostDict
+from cobaya.log import LoggedError
+from cobaya.post import post
 
 if sys.version_info < (3, 7):
     if sys.version_info < (3, 6):

--- a/cobaya/bib.py
+++ b/cobaya/bib.py
@@ -14,7 +14,7 @@ import os
 from inspect import cleandoc
 
 # Local
-from cobaya.conventions import _yaml_extensions, kinds, _dump_sort_cosmetic
+from cobaya.conventions import Extension, kinds, dump_sort_cosmetic
 from cobaya.tools import create_banner, warn_deprecation, get_class
 from cobaya.input import load_input, get_used_components
 
@@ -77,8 +77,8 @@ def get_bib_info(*infos):
 
 def prettyprint_bib(descs, bibs):
     # Sort them "optimally"
-    sorted_kinds = [k for k in _dump_sort_cosmetic if k in descs]
-    sorted_kinds += [k for k in descs if k not in _dump_sort_cosmetic]
+    sorted_kinds = [k for k in dump_sort_cosmetic if k in descs]
+    sorted_kinds += [k for k in descs if k not in dump_sort_cosmetic]
     txt = ""
     txt += create_banner(
         "Descriptions", symbol=_default_symbol, length=_default_length) + "\n"
@@ -118,7 +118,7 @@ def bib_script(args=None):
     arguments = parser.parse_args(args)
     # Case of files
     are_yaml = [
-        (os.path.splitext(f)[1] in _yaml_extensions) for f in
+        (os.path.splitext(f)[1] in Extension.yamls) for f in
         arguments.components_or_files]
     if all(are_yaml):
         infos = [load_input(f) for f in arguments.components_or_files]

--- a/cobaya/collection.py
+++ b/cobaya/collection.py
@@ -620,7 +620,7 @@ class OneSamplePoint:
 
 class OnePoint(Collection):
     """Wrapper of :class:`~collection.Collection` to hold a single point,
-    e.g. the current point of an MCMC."""
+    e.g. the best-fit point of a minimization run (not used by default MCMC)."""
 
     def __getitem__(self, columns):
         if isinstance(columns, str):

--- a/cobaya/component.py
+++ b/cobaya/component.py
@@ -94,7 +94,7 @@ class CobayaComponent(HasLogger, HasDefaults):
             if initialize:
                 self.initialize()
         except AttributeError as e:
-            if '"params"' in str(e):
+            if '_params' in str(e):
                 raise LoggedError(self.log, "use 'initialize_with_params' if you need to "
                                             "initialize after input and output parameters"
                                             " are set (%s, %s)", self, e)

--- a/cobaya/component.py
+++ b/cobaya/component.py
@@ -4,7 +4,7 @@ from typing import Optional, Union, List, Any
 
 from cobaya.log import HasLogger, LoggedError
 from cobaya.input import HasDefaults
-from cobaya.conventions import _version, empty_dict, InfoDict
+from cobaya.typing import InfoDict, empty_dict
 from cobaya.tools import resolve_packages_path
 
 
@@ -56,7 +56,7 @@ class CobayaComponent(HasLogger, HasDefaults):
     """
     # The next lists of options apply when comparing existing versus new info at resuming.
     # When defining it for subclasses, redefine append adding this list to new entries.
-    _at_resume_prefer_new = [_version]
+    _at_resume_prefer_new = ["version"]
     _at_resume_prefer_old = []
 
     def __init__(self, info: InfoDict = empty_dict,
@@ -83,8 +83,7 @@ class CobayaComponent(HasLogger, HasDefaults):
                         "in the next version. Please use `packages_path` instead.")
                     # BEHAVIOUR TO BE REPLACED BY ERROR:
                     # set BOTH old and new names, just in case old one is used internally
-                    from cobaya.conventions import _packages_path
-                    setattr(self, _packages_path, value)
+                    setattr(self, "packages_path", value)
                 # END OF DEPRECATION BLOCK
                 setattr(self, k, value)
             except AttributeError:
@@ -95,7 +94,7 @@ class CobayaComponent(HasLogger, HasDefaults):
             if initialize:
                 self.initialize()
         except AttributeError as e:
-            if '_params' in str(e):
+            if '"params"' in str(e):
                 raise LoggedError(self.log, "use 'initialize_with_params' if you need to "
                                             "initialize after input and output parameters"
                                             " are set (%s, %s)", self, e)
@@ -200,7 +199,7 @@ class ComponentCollection(dict, HasLogger):
         """
 
         def format_version(x):
-            return {_version: x} if add_version_field else x
+            return {"version": x} if add_version_field else x
 
         return {component.get_name(): format_version(component.get_version())
                 for component in self.values() if component.has_version()}

--- a/cobaya/conventions.py
+++ b/cobaya/conventions.py
@@ -6,140 +6,120 @@
 :Author: Jesus Torrado
 
 """
-from collections import namedtuple
-from types import MappingProxyType
-from typing import Dict, Any, Optional, Union, Sequence
-import numpy as np
-
-try:
-    from numpy.typing import ArrayLike
-except ImportError:
-    ArrayLike = Union[Sequence, np.ndarray]
-OptionalArrayLike = Optional[ArrayLike]
-ArrayOrFloat = Union[float, ArrayLike]
-# type for Cobaya input parameter dictionaries (as from yaml)
-InfoDict = Dict[str, Any]
-# specific cases (typing to be refined in future using TypedDict)
-InputDict = InfoDict
-ParamDict = Optional[InfoDict]
-ParamsDict = Dict[str, ParamDict]
-LikeDict = Optional[InfoDict]
-LikesDict = Dict[str, LikeDict]
-TheoryDict = Optional[InfoDict]
-TheoriesDict = Dict[str, TheoryDict]
-PriorDict = InfoDict
-PriorsDict = Dict[str, PriorDict]
-SamplerDict = InfoDict
-SamplersDict = Dict[str, SamplerDict]
-ParamValuesDict = Dict[str, Optional[float]]
 
 # Package name (for importlib)
 # (apparently __package__ is only defined if you import something locally.
-_cobaya_package = __name__.rpartition('.')[0]
+cobaya_package = __name__.rpartition('.')[0]
 
-# an immutable empty dict (e.g. for argument defaults)
-empty_dict = MappingProxyType({})
 
-# Names for block and fields in the input
-_prior = "prior"
-_post = "post"
-_post_add = "add"
-_post_remove = "remove"
-_post_suffix = "suffix"
-_params = "params"
-_auto_params = "auto_params"
-_input_params = "input_params"
-_output_params = "output_params"
-_input_params_prefix = "input_params_prefix"
-_output_params_prefix = "output_params_prefix"
-_debug = "debug"
-_debug_default = False
-_debug_file = "debug_file"
-_output_prefix = "output"
-_packages_path = "packages_path"
-_external = "external"
-_class_name = "class"
-_provides = "provides"
-_requires = "requires"
-_resume = "resume"
-_resume_default = False
-_timing = "timing"
-_force = "force"
-_test_run = "test"
-_component_path = "python_path"
-_aliases = "aliases"
-_version = "version"
+def get_version():
+    from cobaya import __version__
+    return __version__
 
-ParTags = namedtuple('ParTags', ("prior", "ref", "proposal", "value", "dist", "drop",
-                                 "derived", "latex", "renames", "min", "max"))
-partag = ParTags(*ParTags._fields)
 
-ComponentKinds = namedtuple('ComponentKinds', ("sampler", "theory", "likelihood"))
-kinds = ComponentKinds(*ComponentKinds._fields)
+debug_default = False
+resume_default = False
+
+kinds = ("sampler", "theory", "likelihood")
 
 # Reserved attributes for component classes with defaults.
 # These are ignored by HasDefaults.get_class_options()
-reserved_attributes = {_input_params, _output_params, "install_options", "bibtex_file"}
+reserved_attributes = {"input_params", "output_params", "install_options", "bibtex_file"}
 
 # Conventional order for yaml dumping (purely cosmetic)
-_dump_sort_cosmetic = [
-    kinds.theory, kinds.likelihood, _prior, _params, kinds.sampler, _post]
+dump_sort_cosmetic = ["theory", "likelihood", "prior", "params", "sampler", "post"]
 
 # Separator for
 # fields in parameter names and files
 # Its manual inclusion in a string anywhere else (e.g. a parameter name) should be avoided
-_separator = "__"
-_separator_files = "."
+derived_par_name_separator = "__"
+separator_files = "."
+
 
 # Names for the samples' fields internally and in the output
-_weight = "weight"  # sample weight
-_minuslogpost = "minuslogpost"  # log-posterior, or in general the total log-probability
-_minuslogprior = "minuslogprior"  # log-prior
-_chi2 = "chi2"  # chi^2 = -2 * loglik
-_get_chi2_name = lambda p: _chi2 + _separator + str(p)
-_undo_chi2_name = lambda p: p[len(_chi2 + _separator):]
-_get_chi2_label = lambda p: r"\chi^2_\mathrm{" + str(p).replace("_", r"\ ") + r"}"
-_prior_1d_name = "0"
+class OutPar:
+    weight = "weight"  # sample weight
+    # log-posterior, or in general the total log-probability
+    minuslogpost = "minuslogpost"
+    minuslogprior = "minuslogprior"  # log-prior
+    chi2 = "chi2"  # chi^2 = -2 * loglike (not always normalized to be useful)
+
+
+prior_1d_name = "0"
+
+
+def get_chi2_name(p):
+    return OutPar.chi2 + derived_par_name_separator + str(p)
+
+
+def undo_chi2_name(p):
+    return p[len(OutPar.chi2 + derived_par_name_separator):]
+
+
+def get_chi2_label(p):
+    return r"\chi^2_\mathrm{" + str(p).replace("_", r"\ ") + r"}"
+
+
+def get_minuslogpior_name(piname):
+    return OutPar.minuslogprior + derived_par_name_separator + piname
+
+
+def minuslogprior_names(prior):
+    return [get_minuslogpior_name(piname) for piname in prior]
+
+
+def chi2_names(likes):
+    return [get_chi2_name(likname) for likname in likes]
+
 
 # Output files
-_input_suffix = "input"
-_updated_suffix = "updated"
-_yaml_extensions = ".yaml", ".yml"
-_dill_extension = ".dill_pickle"
-_checkpoint_extension = ".checkpoint"
-_progress_extension = ".progress"
-_covmat_extension = ".covmat"
-_evidence_extension = ".logZ"
+
+class FileSuffix:
+    input = "input"
+    updated = "updated"
+
+
+class Extension:
+    yaml = ".yaml"
+    yamls = ".yaml", ".yml"
+    dill = ".dill_pickle"
+    checkpoint = ".checkpoint"
+    progress = ".progress"
+    covmat = ".covmat"
+    evidence = ".logZ"
+
 
 # Installation and container definitions
-_packages_path_arg = _packages_path
-_packages_path_arg_posix = _packages_path_arg.replace("_", "-")
-_packages_path_env = "COBAYA_PACKAGES_PATH"
-_packages_path_config_file = "config.yaml"
-_packages_path_containers = "/cobaya_packages"
-_code = "code"
-_data = "data"
-_install_skip_env = "COBAYA_INSTALL_SKIP"
-_test_skip_env = "COBAYA_TEST_SKIP"
-_covmats_file = "covmats_database.pkl"
-_products_path = "/products"
-_requirements_file = "requirements.yaml"
-_help_file = "readme.md"
+packages_path_arg = "packages_path"
+packages_path_arg_posix = packages_path_arg.replace("_", "-")
+packages_path_env = "COBAYA_PACKAGES_PATH"
+packages_path_config_file = "config.yaml"
+packages_path_containers = "/cobaya_packages"
+
+install_skip_env = "COBAYA_INSTALL_SKIP"
+test_skip_env = "COBAYA_TEST_SKIP"
+
+products_path = "/products"
+
+data_path = "data"
+code_path = "code"
 
 # Internal package structure
-subfolders = {kinds.likelihood: "likelihoods",
-              kinds.sampler: "samplers",
-              kinds.theory: "theories"}
+subfolders = {"likelihood": "likelihoods",
+              "sampler": "samplers",
+              "theory": "theories"}
 
 # Approximate overhead of cobaya per posterior evaluation. Useful for blocking speeds
-_overhead_time = 0.0003
+overhead_time = 0.0003
 
 # Line width for console printing
-_line_width = 120
+line_width = 120
+
 
 # Physical constants
 # ------------------
 # Light speed
-_c_km_s = 299792.458  # speed of light
-_h_J_s = 6.626070040e-34  # Planck's constant
-_kB_J_K = 1.38064852e-23  # Boltzmann constant
+class Const:
+    c_km_s = 299792.458  # speed of light
+    h_J_s = 6.626070040e-34  # Planck's constant
+    kB_J_K = 1.38064852e-23  # Boltzmann constant

--- a/cobaya/cosmo_input/convert_cosmomc.py
+++ b/cobaya/cosmo_input/convert_cosmomc.py
@@ -71,7 +71,7 @@ def cosmomc_root_to_cobaya_info_dict(root: str, derived_to_input=()) -> InputDic
                 if param in d:
                     mean, std = (float(v.strip()) for v in value.split())
                     if not names.parWithName(param).isDerived:
-                        info['prior'][param + '"prior"'] = \
+                        info['prior'][param + '_prior'] = \
                             "lambda %s: stats.norm.logpdf(%s, loc=%g, scale=%g)" % (
                                 param, param, mean, std)
 

--- a/cobaya/cosmo_input/convert_cosmomc.py
+++ b/cobaya/cosmo_input/convert_cosmomc.py
@@ -1,10 +1,10 @@
 import os
 from getdist import IniFile, ParamNames
 from getdist.parampriors import ParamBounds
-from cobaya.conventions import InfoDict
+from cobaya.typing import InputDict, ParamsDict
 
 
-def cosmomc_root_to_cobaya_info_dict(root: str, derived_to_input=()) -> InfoDict:
+def cosmomc_root_to_cobaya_info_dict(root: str, derived_to_input=()) -> InputDict:
     """
     Given the root name of existing cosmomc chain files, tries to construct a Cobaya
     input parameter dictionary with roughly equivalent settings. The output
@@ -28,8 +28,8 @@ def cosmomc_root_to_cobaya_info_dict(root: str, derived_to_input=()) -> InfoDict
         ranges = ParamBounds(root + '.ranges')
     else:
         ranges = None
-    d: InfoDict = {}
-    info: InfoDict = {'params': d}
+    d: ParamsDict = {}
+    info: InputDict = {'params': d}
     for par, name in zip(names.names, names.list()):
         if name.startswith('chi2_') and not name.startswith('chi2__'):
             if name == 'chi2_prior':
@@ -71,7 +71,7 @@ def cosmomc_root_to_cobaya_info_dict(root: str, derived_to_input=()) -> InfoDict
                 if param in d:
                     mean, std = (float(v.strip()) for v in value.split())
                     if not names.parWithName(param).isDerived:
-                        info['prior'][param + '_prior'] = \
+                        info['prior'][param + '"prior"'] = \
                             "lambda %s: stats.norm.logpdf(%s, loc=%g, scale=%g)" % (
                                 param, param, mean, std)
 

--- a/cobaya/cosmo_input/create_input.py
+++ b/cobaya/cosmo_input/create_input.py
@@ -4,7 +4,6 @@ from typing import MutableMapping, Mapping
 
 # Local
 from cobaya.input import get_default_info, merge_info
-from cobaya.conventions import kinds, partag, _params
 from cobaya.parameterization import reduce_info_param
 from . import input_database
 
@@ -12,7 +11,7 @@ from . import input_database
 def translate(p, info=None, dictionary=None):
     dictionary = dictionary or {}
     # Ignore if dropped
-    if not (info if isinstance(info, Mapping) else {}).get(partag.drop, False):
+    if not (info if isinstance(info, Mapping) else {}).get("drop", False):
         p = dictionary.get(p, p)
     # Try to modify lambda parameters too!
     if isinstance(info, str):
@@ -24,13 +23,13 @@ def translate(p, info=None, dictionary=None):
             arguments_t = [translate(pi, dictionary=dictionary)[0] for pi in arguments]
             for pi, pit in zip(arguments, arguments_t):
                 info = info.replace(pi, pit)
-    if ((isinstance(info, MutableMapping) and partag.derived in info and
-         isinstance(info[partag.derived], str))):
-        info[partag.derived] = translate(p, info[partag.derived],
-                                         dictionary=dictionary)[1]
-    elif (isinstance(info, MutableMapping) and partag.value in info and
-          isinstance(info[partag.value], str)):
-        info[partag.value] = translate(p, info[partag.value], dictionary=dictionary)[1]
+    if ((isinstance(info, MutableMapping) and "derived" in info and
+         isinstance(info["derived"], str))):
+        info["derived"] = translate(p, info["derived"],
+                                    dictionary=dictionary)[1]
+    elif (isinstance(info, MutableMapping) and "value" in info and
+          isinstance(info["value"], str)):
+        info["value"] = translate(p, info["value"], dictionary=dictionary)[1]
     return p, info
 
 
@@ -53,73 +52,73 @@ def create_input(**kwargs):
             infos[k] = {}
         try:
             infos[k] = deepcopy(
-                getattr(input_database, k)[kwargs.get(k, input_database._none)])
+                getattr(input_database, k)[kwargs.get(k, input_database.none)])
         except KeyError:
             raise ValueError("Unknown value '%s' for '%s'" %
-                             (kwargs.get(k, input_database._none), k))
-    theory_requested = kwargs.get(kinds.theory)
+                             (kwargs.get(k, input_database.none), k))
+    theory_requested = kwargs.get("theory")
     for i, (field, info) in enumerate(infos.items()):
         if not info:
             continue
-        error_msg = info.pop(input_database._error_msg, None)
+        error_msg = info.pop(input_database.error_msg, None)
         try:
-            info[kinds.theory] = {theory_requested: info[kinds.theory][theory_requested]}
+            info["theory"] = {theory_requested: info["theory"][theory_requested]}
         except KeyError:
             return ("There is no preset for\n'%s'" % (
-                info.get(input_database._desc, field)) +
+                info.get("desc", field)) +
                     "with theory code '%s'." % theory_requested +
                     ("\n--> " + error_msg if error_msg else
                      "\nThis does not mean that you cannot use this model with that "
                      "theory code; just that we have not implemented this yet."))
         # Add non-translatable parameters (in info["theory"][classy|camb][params])
-        if _params not in info:
-            info[_params] = {}
-        info[_params].update(
-            (info[kinds.theory][theory_requested] or {}).pop(_params, {}))
+        if "params" not in info:
+            info["params"] = {}
+        info["params"].update(
+            (info["theory"][theory_requested] or {}).pop("params", {}))
         # Remove the *derived* parameters mentioned by the likelihoods that
         # are already *sampled* by some part of the model
-        if field.startswith("like_") and _params in info:
+        if field.startswith("like_") and "params" in info:
             remove_derived = []
-            for p in info[_params]:
-                if any((p in info_part[_params])
-                        for info_part in list(infos.values())[:i]):
+            for p in info["params"]:
+                if any((p in info_part["params"])
+                       for info_part in list(infos.values())[:i]):
                     remove_derived += [p]
             for p in remove_derived:
-                info[_params].pop(p)
+                info["params"].pop(p)
     # Prepare sampler info
-    info_sampler = deepcopy(input_database.sampler.get(kwargs.get(kinds.sampler), {}))
+    info_sampler = deepcopy(input_database.sampler.get(kwargs.get("sampler"), {}))
     if info_sampler:
-        sampler_name = list(info_sampler[kinds.sampler])[0]
-        info_sampler[kinds.sampler][sampler_name] = info_sampler[kinds.sampler][
-                                                        sampler_name] or {}
+        sampler_name = list(info_sampler["sampler"])[0]
+        info_sampler["sampler"][sampler_name] = info_sampler["sampler"][
+                                                    sampler_name] or {}
         # Add recommended options for samplers
         for info in infos.values():
-            this_info_sampler = info.pop(kinds.sampler, {})
+            this_info_sampler = info.pop("sampler", {})
             if sampler_name in this_info_sampler:
-                info_sampler[kinds.sampler][sampler_name].update(
+                info_sampler["sampler"][sampler_name].update(
                     this_info_sampler[sampler_name])
     # Reorder, to have the *parameters* shown in the correct order, and *merge*
     all_infos = [info_sampler] + [infos[k]
                                   for k in kwargs_likes[::-1] + kwargs_params[::-1]]
-    comments = [info.pop(input_database._comment, None) for info in all_infos]
+    comments = [info.pop("comment", None) for info in all_infos]
     comments = [c for c in comments if c]
-    [info.pop(input_database._desc, None) for info in all_infos]
+    [info.pop("desc", None) for info in all_infos]
     merged = merge_info(*all_infos)
     # Simplify parameter infos
-    for p, info in merged[_params].items():
-        merged[_params][p] = reduce_info_param(info)
+    for p, info in merged["params"].items():
+        merged["params"][p] = reduce_info_param(info)
     # Translate from Planck param names
     planck_to_theo = \
-        get_default_info(theory_requested, kinds.theory)[partag.renames]
+        get_default_info(theory_requested, "theory")["renames"]
     if kwargs.get("planck_names", False):
-        merged[kinds.theory][theory_requested] = merged[kinds.theory][
-                                                     theory_requested] or {}
-        merged[kinds.theory][theory_requested]["use_renames"] = True
+        merged["theory"][theory_requested] = merged["theory"][
+                                                 theory_requested] or {}
+        merged["theory"][theory_requested]["use_renames"] = True
     else:
         merged_params_translated = dict([
             translate(p, info, planck_to_theo)
-            for p, info in merged[_params].items()])
-        merged[_params] = merged_params_translated
+            for p, info in merged["params"].items()])
+        merged["params"] = merged_params_translated
     if get_comments and comments:
-        merged[input_database._comment] = comments
+        merged["comment"] = comments
     return merged

--- a/cobaya/cosmo_input/gui.py
+++ b/cobaya/cosmo_input/gui.py
@@ -11,14 +11,14 @@ import io
 # Local
 from cobaya.yaml import yaml_dump
 from cobaya.cosmo_input import input_database
-from cobaya.cosmo_input.input_database import  _combo_dict_text
+from cobaya.cosmo_input.input_database import _combo_dict_text
 from cobaya.cosmo_input.autoselect_covmat import get_best_covmat, covmat_folders
 from cobaya.cosmo_input.create_input import create_input
 from cobaya.bib import prettyprint_bib, get_bib_info, get_bib_component
 from cobaya.tools import warn_deprecation, get_available_internal_class_names, \
     cov_to_std_and_corr, resolve_packages_path, sort_cosmetic
 from cobaya.input import get_default_info
-from cobaya.conventions import subfolders, kinds, _packages_path_env, _packages_path
+from cobaya.conventions import subfolders, kinds, packages_path_env
 
 # per-platform settings for correct high-DPI scaling
 if platform.system() == "Linux":
@@ -48,12 +48,12 @@ except ImportError:
 # Quit with C-c
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-# Color map for correlatins
+# Color map for correlations
 cmap_corr = cmap.get_cmap("coolwarm_r")
 
 
 def text(key, contents):
-    desc = (contents or {}).get(input_database._desc)
+    desc = (contents or {}).get("desc")
     return desc or key
 
 
@@ -216,7 +216,7 @@ class MainWindow(QWidget):
     def refresh_preset(self):
         preset = list(getattr(input_database, "preset"))[
             self.combos["preset"].currentIndex()]
-        if preset is input_database._none:
+        if preset is input_database.none:
             return
         info = create_input(
             get_comments=True,
@@ -225,7 +225,7 @@ class MainWindow(QWidget):
         self.refresh_display(info)
         # Update combo boxes to reflect the preset values, without triggering update
         for k, v in input_database.preset[preset].items():
-            if k in [input_database._desc]:
+            if k in ["desc"]:
                 continue
             self.combos[k].blockSignals(True)
             self.combos[k].setCurrentIndex(
@@ -236,7 +236,7 @@ class MainWindow(QWidget):
     def refresh_display(self, info):
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
-            comments = info.pop(input_database._comment, None)
+            comments = info.pop("comment", None)
             comments_text = "\n# " + "\n# ".join(comments)
         except (TypeError,  # No comments
                 AttributeError):  # Failed to generate info (returned str instead)
@@ -250,8 +250,8 @@ class MainWindow(QWidget):
             self.covmat_text.setText(
                 "\nIn order to find a covariance matrix, you need to define an external "
                 "packages installation path, e.g. via the env variable %r.\n" %
-                _packages_path_env)
-        elif any(not os.path.isdir(d.format(**{_packages_path: packages_path}))
+                packages_path_env)
+        elif any(not os.path.isdir(d.format(**{"packages_path": packages_path}))
                  for d in covmat_folders):
             self.covmat_text.setText(
                 "\nThe external cosmological packages appear not to be installed where "

--- a/cobaya/cosmo_input/input_database.py
+++ b/cobaya/cosmo_input/input_database.py
@@ -9,483 +9,415 @@
 
 # Global
 from copy import deepcopy
+from cobaya.typing import InfoDict
 
-# Local
-from cobaya.conventions import kinds, partag as p, _params, InfoDict
-
-_camb = "camb"
-_classy = "classy"
-_desc = "desc"
-_comment = "note"
-_extra_args = "extra_args"
-_error_msg = "error_msg"
-_none = "(None)"
+none = "(None)"
+error_msg = "error_msg"
 
 # Theory codes
-theory: InfoDict = {_camb: None, _classy: None}
+theory: InfoDict = {"camb": None, "classy": None}
 
 # Primordial perturbations
-primordial: InfoDict = dict([
-    ("SFSR", {
-        _desc: "Adiabatic scalar perturbations, power law spectrum",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["logA", dict([
-                (p.prior, dict([("min", 1.61), ("max", 3.91)])),
-                (p.ref, dict([(p.dist, "norm"), ("loc", 3.05), ("scale", 0.001)])),
-                (p.proposal, 0.001), (p.latex, r"\log(10^{10} A_\mathrm{s})"),
-                (p.drop, True)])],
-            ("As", dict([
-                (p.value, "lambda logA: 1e-10*np.exp(logA)"),
-                (p.latex, r"A_\mathrm{s}")])),
-            ("ns", dict([
-                (p.prior, dict([("min", 0.8), ("max", 1.2)])),
-                (p.ref, dict([(p.dist, "norm"), ("loc", 0.965), ("scale", 0.004)])),
-                (p.proposal, 0.002), (p.latex, r"n_\mathrm{s}")]))])})])
-primordial.update(dict([
-    ["SFSR_DESpriors", {
-        _desc: "Adiabatic scalar perturbations, power law + running spectrum "
-               "-- DESpriors",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["As_1e9", dict([
-                [p.prior, dict([["min", 0.5], ["max", 5]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 2.1], ["scale", 0.5]])],
-                [p.proposal, 0.25], [p.latex, r"10^9 A_\mathrm{s})"],
-                [p.drop, True], [p.renames, "A"]])],
-            ["As", dict([
-                [p.value, "lambda As_1e9: 1e-9 * As_1e9"],
-                [p.latex, r"A_\mathrm{s}"]])],
-            ["ns", primordial["SFSR"][_params]["ns"]]])}]]))
-primordial.update(dict([
-    ["SFSR_run", {
-        _desc: "Adiabatic scalar perturbations, power law + running spectrum",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict(
-            (list(primordial["SFSR"][_params].items()) +
-             [["nrun", dict([
-                 [p.prior, dict([["min", -1], ["max", 1]])],
-                 [p.ref,
-                  dict([[p.dist, "norm"], ["loc", 0], ["scale", 0.005]])],
-                 [p.proposal, 0.001], [p.latex, r"n_\mathrm{run}"]])]]))}]]))
-primordial.update(dict([
-    ["SFSR_runrun", {
-        _desc: "Adiabatic scalar perturbations, power law + 2nd-order running spectrum",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict(
-            (list(primordial["SFSR_run"][_params].items()) +
-             [["nrunrun", dict([
-                 [p.prior, dict([["min", -1], ["max", 1]])],
-                 [p.ref,
-                  dict([[p.dist, "norm"], ["loc", 0], ["scale", 0.002]])],
-                 [p.proposal, 0.001],
-                 [p.latex, r"n_\mathrm{run,run}"]])]]))}]]))
-primordial.update(dict([
-    ["SFSR_t", {
-        _desc: "Adiabatic scalar+tensor perturbations, "
-               "power law spectrum (inflation consistency)",
-        kinds.theory: {_camb: {_extra_args: {"nt": None}},
-                       _classy: {_extra_args: {"n_t": "scc", "alpha_t": "scc"}}},
-        _params: dict(
-            (list(primordial["SFSR"][_params].items()) +
-             [["r", dict([
-                 [p.prior, dict([["min", 0], ["max", 3]])],
-                 [p.ref,
-                  dict([[p.dist, "norm"], ["loc", 0], ["scale", 0.03]])],
-                 [p.proposal, 0.03], [p.latex, r"r_{0.05}"]])]]))}]]))
-primordial.update(dict([
-    ["SFSR_t_nrun", {
-        _desc: "Adiabatic scalar+tensor perturbations, "
-               "power law + running spectrum (inflation consistency)",
-        kinds.theory: {_camb:
-                           {_extra_args: primordial["SFSR_t"][kinds.theory][_camb][
-                               _extra_args]},
-                       _classy:
-                           {_extra_args: primordial["SFSR_t"][kinds.theory][_classy][
-                               _extra_args]}},
-        _params: dict(
-            (list(primordial["SFSR_run"][_params].items()) +
-             list(primordial["SFSR_t"][_params].items())))}]]))
+primordial = {
+    'SFSR': {'desc': 'Adiabatic scalar perturbations, power law spectrum',
+             'theory': theory,
+             'params': {
+                 'logA': {'prior': {'min': 1.61, 'max': 3.91},
+                          'ref': {'dist': 'norm', 'loc': 3.05, 'scale': 0.001},
+                          'proposal': 0.001, 'latex': '\\log(10^{10} A_\\mathrm{s})',
+                          'drop': True},
+                 'As': {'value': 'lambda logA: 1e-10*np.exp(logA)',
+                        'latex': 'A_\\mathrm{s}'},
+                 'ns': {'prior': {'min': 0.8, 'max': 1.2},
+                        'ref': {'dist': 'norm', 'loc': 0.965, 'scale': 0.004},
+                        'proposal': 0.002, 'latex': 'n_\\mathrm{s}'}}},
+    'SFSR_DESpriors': {
+        'desc': 'Adiabatic scalar perturbations, '
+                'power law + running spectrum -- DESpriors',
+        'theory': theory,
+        'params': {
+            'As_1e9': {'prior': {'min': 0.5, 'max': 5},
+                       'ref': {'dist': 'norm', 'loc': 2.1, 'scale': 0.5},
+                       'proposal': 0.25, 'latex': '10^9 A_\\mathrm{s})', 'drop': True,
+                       'renames': 'A'},
+            'As': {'value': 'lambda As_1e9: 1e-9 * As_1e9', 'latex': 'A_\\mathrm{s}'},
+            'ns': {'prior': {'min': 0.8, 'max': 1.2},
+                   'ref': {'dist': 'norm', 'loc': 0.965, 'scale': 0.004},
+                   'proposal': 0.002, 'latex': 'n_\\mathrm{s}'}}},
+    'SFSR_run':
+        {'desc': 'Adiabatic scalar perturbations, power law + running spectrum',
+         'theory': theory,
+         'params': {
+             'logA': {'prior': {'min': 1.61, 'max': 3.91},
+                      'ref': {'dist': 'norm', 'loc': 3.05, 'scale': 0.001},
+                      'proposal': 0.001, 'latex': '\\log(10^{10} A_\\mathrm{s})',
+                      'drop': True},
+             'As': {'value': 'lambda logA: 1e-10*np.exp(logA)', 'latex': 'A_\\mathrm{s}'},
+             'ns': {'prior': {'min': 0.8, 'max': 1.2},
+                    'ref': {'dist': 'norm', 'loc': 0.965, 'scale': 0.004},
+                    'proposal': 0.002, 'latex': 'n_\\mathrm{s}'},
+             'nrun': {'prior': {'min': -1, 'max': 1},
+                      'ref': {'dist': 'norm', 'loc': 0, 'scale': 0.005},
+                      'proposal': 0.001,
+                      'latex': 'n_\\mathrm{run}'}}},
+    'SFSR_runrun': {
+        'desc': 'Adiabatic scalar perturbations, power law + 2nd-order running spectrum',
+        'theory': theory,
+        'params': {
+            'logA': {'prior': {'min': 1.61, 'max': 3.91},
+                     'ref': {'dist': 'norm', 'loc': 3.05, 'scale': 0.001},
+                     'proposal': 0.001, 'latex': '\\log(10^{10} A_\\mathrm{s})',
+                     'drop': True},
+            'As': {'value': 'lambda logA: 1e-10*np.exp(logA)', 'latex': 'A_\\mathrm{s}'},
+            'ns': {'prior': {'min': 0.8, 'max': 1.2},
+                   'ref': {'dist': 'norm', 'loc': 0.965, 'scale': 0.004},
+                   'proposal': 0.002, 'latex': 'n_\\mathrm{s}'},
+            'nrun': {'prior': {'min': -1, 'max': 1},
+                     'ref': {'dist': 'norm', 'loc': 0, 'scale': 0.005}, 'proposal': 0.001,
+                     'latex': 'n_\\mathrm{run}'},
+            'nrunrun': {'prior': {'min': -1, 'max': 1},
+                        'ref': {'dist': 'norm', 'loc': 0, 'scale': 0.002},
+                        'proposal': 0.001, 'latex': 'n_\\mathrm{run,run}'}}},
+    'SFSR_t': {
+        'desc': 'Adiabatic scalar+tensor perturbations, power law spectrum '
+                '(inflation consistency)',
+        'theory': {'camb': {'extra_args': {'nt': None}},
+                   'classy': {'extra_args': {'n_t': 'scc', 'alpha_t': 'scc'}}},
+        'params': {'logA': {'prior': {'min': 1.61, 'max': 3.91},
+                            'ref': {'dist': 'norm', 'loc': 3.05, 'scale': 0.001},
+                            'proposal': 0.001, 'latex': '\\log(10^{10} A_\\mathrm{s})',
+                            'drop': True},
+                   'As': {'value': 'lambda logA: 1e-10*np.exp(logA)',
+                          'latex': 'A_\\mathrm{s}'},
+                   'ns': {'prior': {'min': 0.8, 'max': 1.2},
+                          'ref': {'dist': 'norm', 'loc': 0.965, 'scale': 0.004},
+                          'proposal': 0.002, 'latex': 'n_\\mathrm{s}'},
+                   'r': {'prior': {'min': 0, 'max': 3},
+                         'ref': {'dist': 'norm', 'loc': 0, 'scale': 0.03},
+                         'proposal': 0.03, 'latex': 'r_{0.05}'}}}, 'SFSR_t_nrun': {
+        'desc': 'Adiabatic scalar+tensor perturbations, power law + running '
+                'spectrum (inflation consistency)',
+        'theory': {'camb': {'extra_args': {'nt': None}},
+                   'classy': {'extra_args': {'n_t': 'scc', 'alpha_t': 'scc'}}},
+        'params': {'logA': {'prior': {'min': 1.61, 'max': 3.91},
+                            'ref': {'dist': 'norm', 'loc': 3.05, 'scale': 0.001},
+                            'proposal': 0.001, 'latex': '\\log(10^{10} A_\\mathrm{s})',
+                            'drop': True},
+                   'As': {'value': 'lambda logA: 1e-10*np.exp(logA)',
+                          'latex': 'A_\\mathrm{s}'},
+                   'ns': {'prior': {'min': 0.8, 'max': 1.2},
+                          'ref': {'dist': 'norm', 'loc': 0.965, 'scale': 0.004},
+                          'proposal': 0.002, 'latex': 'n_\\mathrm{s}'},
+                   'nrun': {'prior': {'min': -1, 'max': 1},
+                            'ref': {'dist': 'norm', 'loc': 0, 'scale': 0.005},
+                            'proposal': 0.001, 'latex': 'n_\\mathrm{run}'},
+                   'r': {'prior': {'min': 0, 'max': 3},
+                         'ref': {'dist': 'norm', 'loc': 0, 'scale': 0.03},
+                         'proposal': 0.03, 'latex': 'r_{0.05}'}}}}
 
 # Geometry
-geometry: InfoDict = dict([
-    ["flat", {
-        _desc: "Flat FLRW universe",
-        kinds.theory: {_camb: None, _classy: None}}],
-    ["omegak", {
-        _desc: "FLRW model with varying curvature (prior on Omega_k)",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["omegak", dict([
-                [p.prior, dict([["min", -0.3], ["max", 0.3]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", -0.009], ["scale", 0.001]])],
-                [p.proposal, 0.001], [p.latex, r"\Omega_k"]])]])}], ])
+geometry = {
+    'flat': {'desc': 'Flat FLRW universe',
+             'theory': theory},
+    'omegak': {'desc': 'FLRW model with varying curvature (prior on Omega_k)',
+               'theory': theory,
+               'params': {'omegak': {'prior': {'min': -0.3, 'max': 0.3},
+                                     'ref': {'dist': 'norm', 'loc': -0.009,
+                                             'scale': 0.001},
+                                     'proposal': 0.001, 'latex': '\\Omega_k'}}}}
 
 # Hubble parameter constraints
 H0_min, H0_max = 20, 100
-hubble: InfoDict = dict([
-    ["H", {
-        _desc: "Hubble parameter",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["H0", dict([
-                [p.prior, dict([["min", H0_min], ["max", H0_max]])],
-                [p.ref, dict([[p.dist, "norm"], ["loc", 67], ["scale", 2]])],
-                [p.proposal, 2], [p.latex, r"H_0"]])]])}],
-    ["H_DESpriors", {
-        _desc: "Hubble parameter (reduced range for DES and lensing-only constraints)",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["H0", dict([
-                [p.prior, dict([["min", 55], ["max", 91]])],
-                [p.ref, dict([[p.dist, "norm"], ["loc", 67], ["scale", 2]])],
-                [p.proposal, 2], [p.latex, r"H_0"]])]])}],
-    ["sound_horizon_last_scattering", {
-        _desc: "Angular size of the sound horizon at last scattering "
-               "(approximate, if using CAMB)",
-        kinds.theory: {
-            _camb: {
-                _params: dict([
-                    ["theta_MC_100", dict([
-                        [p.prior, dict([["min", 0.5], ["max", 10]])],
-                        [p.ref,
-                         dict([[p.dist, "norm"], ["loc", 1.04109],
-                               ["scale", 0.0004]])],
-                        [p.proposal, 0.0002],
-                        [p.latex, r"100\theta_\mathrm{MC}"],
-                        [p.drop, True], [p.renames, "theta"]])],
-                    ["cosmomc_theta", dict([
-                        [p.value, "lambda theta_MC_100: 1.e-2*theta_MC_100"],
-                        [p.derived, False]])],
-                    ["H0", {p.latex: r"H_0", "min": H0_min, "max": H0_max}]]),
-                _extra_args: dict([["theta_H0_range", [H0_min, H0_max]]])},
-            _classy: {
-                _params: dict([
-                    ["theta_s_1e2", dict([
-                        [p.prior, dict([["min", 0.5], ["max", 10]])],
-                        [p.ref, dict([
-                            [p.dist, "norm"], ["loc", 1.0416], ["scale", 0.0004]])],
-                        [p.proposal, 0.0002],
-                        [p.latex, r"100\theta_\mathrm{s}"],
-                        [p.drop, True]])],
-                    ["100*theta_s", dict([
-                        [p.value, "lambda theta_s_1e2: theta_s_1e2"],
-                        [p.derived, False]])],
-                    ["H0", {p.latex: r"H_0"}]])}}}]])
+
+hubble = {
+    'H': {'desc': 'Hubble parameter',
+          'theory': theory,
+          'params': {'H0': {'prior': {'min': H0_min, 'max': H0_max},
+                            'ref': {'dist': 'norm', 'loc': 67, 'scale': 2}, 'proposal': 2,
+                            'latex': 'H_0'}}},
+    'H_DESpriors': {
+        'desc': 'Hubble parameter (reduced range for DES and lensing-only constraints)',
+        'theory': theory,
+        'params': {
+            'H0': {'prior': {'min': 55, 'max': 91},
+                   'ref': {'dist': 'norm', 'loc': 67, 'scale': 2}, 'proposal': 2,
+                   'latex': 'H_0'}}},
+    'sound_horizon_last_scattering': {
+        'desc': 'Angular size of the sound horizon at last scattering '
+                '(approximate, if using CAMB)',
+        'theory': {'camb':
+                       {'params':
+                            {'theta_MC_100': {'prior': {'min': 0.5, 'max': 10},
+                                              'ref': {'dist': 'norm',
+                                                      'loc': 1.04109,
+                                                      'scale': 0.0004},
+                                              'proposal': 0.0002,
+                                              'latex': '100\\theta_\\mathrm{MC}',
+                                              'drop': True, 'renames': 'theta'},
+                             'cosmomc_theta': {
+                                 'value': 'lambda theta_MC_100: 1.e-2*theta_MC_100',
+                                 'derived': False},
+                             'H0': {'latex': 'H_0', 'min': H0_min, 'max': H0_max}},
+                        'extra_args': {'theta_H0_range': [H0_min, H0_max]}},
+                   'classy': {
+                       'params': {
+                           'theta_s_1e2': {'prior': {'min': 0.5, 'max': 10},
+                                           'ref': {'dist': 'norm', 'loc': 1.0416,
+                                                   'scale': 0.0004},
+                                           'proposal': 0.0002,
+                                           'latex': '100\\theta_\\mathrm{s}',
+                                           'drop': True}, '100*theta_s': {
+                               'value': 'lambda theta_s_1e2: theta_s_1e2',
+                               'derived': False},
+                           'H0': {'latex': 'H_0'}}}}}}
 
 # Matter sector (minus light species)
 N_eff_std = 3.046
 nu_mass_fac = 94.0708
-matter: InfoDict = dict([
-    ["omegab_h2, omegac_h2", {
-        _desc: "Flat prior on Omega*h^2 for baryons and cold dark matter",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["omegabh2", dict([
-                [p.prior, dict([["min", 0.005], ["max", 0.1]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 0.0224], ["scale", 0.0001]])],
-                [p.proposal, 0.0001], [p.latex, r"\Omega_\mathrm{b} h^2"]])],
-            ["omegach2", dict([
-                [p.prior, dict([["min", 0.001], ["max", 0.99]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 0.120], ["scale", 0.001]])],
-                [p.proposal, 0.0005], [p.latex, r"\Omega_\mathrm{c} h^2"]])],
-            ["omegam", {p.latex: r"\Omega_\mathrm{m}"}]])}],
-    ["Omegab, Omegam", {
-        _desc: "Flat prior on Omega for baryons and total matter",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["omegab", dict([
-                [p.prior, dict([["min", 0.03], ["max", 0.07]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 0.0495], ["scale", 0.004]])],
-                [p.proposal, 0.004], [p.latex, r"\Omega_\mathrm{b}"],
-                [p.drop, True]])],
-            ["omegam", dict([
-                [p.prior, dict([["min", 0.1], ["max", 0.9]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 0.316], ["scale", 0.02]])],
-                [p.proposal, 0.02], [p.latex, r"\Omega_\mathrm{m}"],
-                [p.drop, True]])],
-            ["omegabh2", dict([
-                [p.value, "lambda omegab, H0: omegab*(H0/100)**2"],
-                [p.latex, r"\Omega_\mathrm{b} h^2"]])],
-            ["omegach2", dict([
-                [p.value, ("lambda omegam, omegab, mnu, H0: "
-                           "(omegam-omegab)*(H0/100)**2-(mnu*(%g/3)**0.75)/%g" % (
-                               N_eff_std, nu_mass_fac))],
-                [p.latex, r"\Omega_\mathrm{c} h^2"]])]
-        ])}]])
+matter: InfoDict = {
+    'omegab_h2, omegac_h2': {
+        'desc': 'Flat prior on Omega*h^2 for baryons and cold dark matter',
+        'theory': theory,
+        'params': {
+            'omegabh2': {'prior': {'min': 0.005, 'max': 0.1},
+                         'ref': {'dist': 'norm', 'loc': 0.0224, 'scale': 0.0001},
+                         'proposal': 0.0001, 'latex': '\\Omega_\\mathrm{b} h^2'},
+            'omegach2': {'prior': {'min': 0.001, 'max': 0.99},
+                         'ref': {'dist': 'norm', 'loc': 0.12, 'scale': 0.001},
+                         'proposal': 0.0005, 'latex': '\\Omega_\\mathrm{c} h^2'},
+            'omegam': {'latex': '\\Omega_\\mathrm{m}'}}},
+    'Omegab, Omegam':
+        {'desc': 'Flat prior on Omega for baryons and total matter',
+         'theory': theory,
+         'params': {
+             'omegab':
+                 {'prior': {'min': 0.03, 'max': 0.07},
+                  'ref': {'dist': 'norm', 'loc': 0.0495, 'scale': 0.004},
+                  'proposal': 0.004, 'latex': '\\Omega_\\mathrm{b}',
+                  'drop': True},
+             'omegam': {'prior': {'min': 0.1, 'max': 0.9},
+                        'ref': {'dist': 'norm',
+                                'loc': 0.316,
+                                'scale': 0.02},
+                        'proposal': 0.02,
+                        'latex': '\\Omega_\\mathrm{m}',
+                        'drop': True},
+             'omegabh2':
+                 {'value': 'lambda omegab, H0: omegab*(H0/100)**2',
+                  'latex': '\\Omega_\\mathrm{b} h^2'},
+             'omegach2': {
+                 'value': "lambda omegam, omegab, mnu, H0: (omegam-omegab)*(H0/100)**2"
+                          "-(mnu*(%g/3)**0.75)/%g" % (N_eff_std, nu_mass_fac),
+                 'latex': '\\Omega_\\mathrm{c} h^2'}}}}
+
 for m in matter.values():
-    m[_params]["omegamh2"] = dict([
-        [p.derived, "lambda omegam, H0: omegam*(H0/100)**2"],
-        [p.latex, r"\Omega_\mathrm{m} h^2"]])
+    m["params"]["omegamh2"] = {"derived": "lambda omegam, H0: omegam*(H0/100)**2",
+                               "latex": r"\Omega_\mathrm{m} h^2"}
 
 # Neutrinos and other extra matter
-neutrinos: InfoDict = dict([
-    ["one_heavy_planck", {
-        _desc: "Two massless nu and one with m=0.06. Neff=3.046",
-        kinds.theory: {
-            _camb: {_extra_args: {"num_massive_neutrinos": 1, "nnu": 3.046},
-                    _params: dict([["mnu", 0.06]])},
-            _classy: {_extra_args: {"N_ncdm": 1, "N_ur": 2.0328},
-                      _params: dict([
-                          ["m_ncdm", {p.value: 0.06, p.renames: "mnu"}]])}}}],
-    ["varying_mnu", {
-        _desc: "Varying total mass of 3 degenerate nu's, with N_eff=3.046",
-        kinds.theory: {
-            _camb: {_extra_args: {"num_massive_neutrinos": 3, "nnu": 3.046},
-                    _params: dict([
-                        ["mnu", dict([
-                            [p.prior, dict([["min", 0], ["max", 5]])],
-                            [p.ref, dict([
-                                [p.dist, "norm"], ["loc", 0.02], ["scale", 0.1]])],
-                            [p.proposal, 0.03], [p.latex, r"\sum m_\nu"]])]])},
-            _classy: {_extra_args: {"N_ncdm": 1, "deg_ncdm": 3, "N_ur": 0.00641},
-                      _params: dict([
-                          ["m_ncdm", dict([
-                              [p.prior, dict([["min", 0], ["max", 1.667]])],
-                              [p.ref, dict([
-                                  [p.dist, "norm"], ["loc", 0.0067],
-                                  ["scale", 0.033]])],
-                              [p.proposal, 0.01], [p.latex, r"m_\nu"]])],
-                          ["mnu", dict([[p.derived, "lambda m_ncdm: 3 * m_ncdm"],
-                                        [p.latex, r"\sum m_\nu"]])]])}}}],
-    ["varying_Neff", {
-        _desc: "Varying Neff with two massless nu and one with m=0.06",
-        kinds.theory: {
-            _camb: {_extra_args: {"num_massive_neutrinos": 1},
-                    _params: dict([
-                        ["mnu", 0.06],
-                        ["nnu", dict([
-                            [p.prior, dict([["min", 0.05], ["max", 10]])],
-                            [p.ref, dict([
-                                [p.dist, "norm"], ["loc", 3.046], ["scale", 0.05]])],
-                            [p.proposal, 0.05],
-                            [p.latex, r"N_\mathrm{eff}"]])]])},
-            _classy: {_extra_args: {"N_ncdm": 1},
-                      _params: dict([
-                          ["m_ncdm",
-                           dict([[p.value, 0.06], [p.renames, "mnu"]])],
-                          ["N_ur", dict([
-                              [p.prior, dict([["min", 0.0001], ["max", 9]])],
-                              [p.ref, dict([
-                                  [p.dist, "norm"], ["loc", 2.0328],
-                                  ["scale", 0.05]])],
-                              [p.proposal, 0.05],
-                              [p.latex, r"N_\mathrm{ur}"]])],
-                          ["nnu", dict([
-                              [p.derived, "lambda Neff: Neff"],
-                              [p.latex, r"N_\mathrm{eff}"]])]])}}}]])
-neutrinos.update(dict([
-    ["varying_mnu_Neff", {
-        _desc: "Varying Neff and total mass of 3 degenerate nu's",
-        kinds.theory: {
-            _camb: {
-                _extra_args: {"num_massive_neutrinos": 3},
-                _params: dict([
-                    ["mnu", deepcopy(
-                        neutrinos["varying_mnu"][kinds.theory]["camb"][_params]["mnu"])],
-                    ["nnu", deepcopy(
-                        neutrinos["varying_Neff"][kinds.theory]["camb"][_params][
-                            "nnu"])]])},
-            #            _classy: {
-            #                _extra_args: {"N_ncdm": 1, "deg_ncdm": 3},
-            #                _params: dict([
-            #                    ["m_ncdm", deepcopy(
-            #                        neutrinos["varying_mnu"][_theory]["classy"][_params]["m_ncdm"])],
-            #                    ["mnu", deepcopy(
-            #                        neutrinos["varying_mnu"][_theory]["classy"][_params]["mnu"])],
-            #                    ["N_ur", deepcopy(
-            #                        neutrinos["varying_Neff"][_theory]["classy"][_params]["N_ur"])],
-            #                    ["nnu", deepcopy(
-            #                        neutrinos["varying_Neff"][_theory]["classy"][_params]["nnu"])]
-            #                ])}
-        }}]]))
-# neutrinos["varying_mnu_Neff"][_theory][_classy][_params]["N_ur"][p.ref]["loc"] = 0.00641
-
-#    # ["varying_Neff+1sterile", {
-#    #     _desc: "Varying Neff plus 1 sterile neutrino (SM nu's with m=0,0,0.06)",
-#    #     _theory: {
-#    #         _camb: {_extra_args: dict(
-#    #             list(neutrinos["varying_Neff"][_theory][_camb][_extra_args].items()) +
-#    #             [["accuracy_level", 1.2]])}},
-#    #     _params: dict([
-#    #         ["nnu", dict([
-#    #             [p.prior, dict([["min", 3.046], ["max", 10]])],
-#    #             [p.ref, dict([[p.dist, "norm"], ["loc", 3.046], ["scale", 0.05]])],
-#    #             [p.proposal, 0.05], [p.latex, r"N_\mathrm{eff}"]])],
-#    #         ["meffsterile", dict([
-#    #             [p.prior, dict([["min", 0], ["max", 3]])#,
-#    #             [p.ref, dict([[p.dist, "norm"], ["loc", 0.1], ["scale", 0.1]])],
-#    #             [p.proposal, 0.03],
-#    #             [p.latex, r"m_{\nu,\mathrm{sterile}}^\mathrm{eff}"]])]])}]
-
+neutrinos: InfoDict = {
+    'one_heavy_planck':
+        {'desc': 'Two massless nu and one with m=0.06. Neff=3.046',
+         'theory': {
+             'camb': {
+                 'extra_args': {'num_massive_neutrinos': 1, 'nnu': 3.046},
+                 'params': {'mnu': 0.06}},
+             'classy': {
+                 'extra_args': {'N_ncdm': 1, 'N_ur': 2.0328},
+                 'params': {'m_ncdm': {'value': 0.06, 'renames': 'mnu'}}}}},
+    'varying_mnu':
+        {'desc': "Varying total mass of 3 degenerate nu's, with N_eff=3.046",
+         'theory': {
+             'camb': {
+                 'extra_args': {'num_massive_neutrinos': 3, 'nnu': 3.046},
+                 'params': {'mnu': {'prior': {'min': 0, 'max': 5},
+                                    'ref': {'dist': 'norm', 'loc': 0.02, 'scale': 0.1},
+                                    'proposal': 0.03,
+                                    'latex': '\\sum m_\\nu'}}},
+             'classy': {
+                 'extra_args': {'N_ncdm': 1, 'deg_ncdm': 3, 'N_ur': 0.00641},
+                 'params':
+                     {'m_ncdm': {'prior': {'min': 0, 'max': 1.667},
+                                 'ref': {'dist': 'norm', 'loc': 0.0067, 'scale': 0.033},
+                                 'proposal': 0.01, 'latex': 'm_\\nu'},
+                      'mnu': {'derived': 'lambda m_ncdm: 3 * m_ncdm',
+                              'latex': '\\sum m_\\nu'}}}}},
+    'varying_Neff':
+        {'desc': 'Varying Neff with two massless nu and one with m=0.06',
+         'theory': {
+             'camb': {
+                 'extra_args': {'num_massive_neutrinos': 1},
+                 'params': {
+                     'mnu': 0.06,
+                     'nnu': {
+                         'prior': {'min': 0.05, 'max': 10},
+                         'ref': {'dist': 'norm', 'loc': 3.046, 'scale': 0.05},
+                         'proposal': 0.05,
+                         'latex': 'N_\\mathrm{eff}'}}},
+             'classy':
+                 {'extra_args': {'N_ncdm': 1},
+                  'params': {
+                      'm_ncdm': {'value': 0.06, 'renames': 'mnu'},
+                      'N_ur': {'prior': {'min': 0.0001, 'max': 9},
+                               'ref': {'dist': 'norm', 'loc': 2.0328,
+                                       'scale': 0.05}, 'proposal': 0.05,
+                               'latex': 'N_\\mathrm{ur}'},
+                      'nnu': {'derived': 'lambda Neff: Neff',
+                              'latex': 'N_\\mathrm{eff}'}}}}},
+    'varying_mnu_Neff':
+        {'desc': "Varying Neff and total mass of 3 degenerate nu's",
+         'theory':
+             {'camb': {
+                 'extra_args': {'num_massive_neutrinos': 3},
+                 'params': {
+                     'mnu': {'prior': {'min': 0, 'max': 5},
+                             'ref': {'dist': 'norm', 'loc': 0.02, 'scale': 0.1},
+                             'proposal': 0.03,
+                             'latex': '\\sum m_\\nu'},
+                     'nnu': {
+                         'prior': {'min': 0.05, 'max': 10},
+                         'ref': {'dist': 'norm', 'loc': 3.046, 'scale': 0.05},
+                         'proposal': 0.05,
+                         'latex': 'N_\\mathrm{eff}'}}}}}}
 # Dark Energy
-dark_energy: InfoDict = dict([
-    ["lambda", {
-        _desc: "Cosmological constant (w=-1)",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["omegal", {p.latex: r"\Omega_\Lambda"}]])}],
-    ["de_w", {
-        _desc: "Varying constant eq of state",
-        kinds.theory: {_camb: None,
-                       _classy: {_params: {"Omega_Lambda": 0}}},
-        _params: dict([
-            ["w", dict([
-                [p.prior, dict([["min", -3], ["max", -0.333]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", -0.99], ["scale", 0.02]])],
-                [p.proposal, 0.02], [p.latex, r"w_\mathrm{DE}"]])]])}],
-    ["de_w_wa", {
-        _desc: "Varying constant eq of state with w(a) = w0 + (1-a) wa",
-        kinds.theory: {_camb: {_extra_args: {'dark_energy_model': 'ppf'}},
-                       _classy: {_params: {"Omega_Lambda": 0}}},
-        _params: dict([
-            ["w", dict([
-                [p.prior, dict([["min", -3], ["max", 1]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", -0.99], ["scale", 0.02]])],
-                [p.proposal, 0.02], [p.latex, r"w_{0,\mathrm{DE}}"]])],
-            ["wa", dict([
-                [p.prior, dict([["min", -3], ["max", 2]])],
-                [p.ref, dict([[p.dist, "norm"], ["loc", 0], ["scale", 0.05]])],
-                [p.proposal, 0.05], [p.latex, r"w_{a,\mathrm{DE}}"]])]])}]])
+dark_energy: InfoDict = \
+    {'lambda':
+         {'desc': 'Cosmological constant (w=-1)',
+          'theory': theory,
+          'params': {'omegal': {'latex': '\\Omega_\\Lambda'}}},
+     'de_w':
+         {'desc': 'Varying constant eq of state',
+          'theory': {'camb': None, 'classy': {'params': {'Omega_Lambda': 0}}},
+          'params': {
+              'w': {'prior': {'min': -3, 'max': -0.333},
+                    'ref': {'dist': 'norm', 'loc': -0.99, 'scale': 0.02},
+                    'proposal': 0.02,
+                    'latex': 'w_\\mathrm{DE}'}}},
+     'de_w_wa':
+         {'desc': 'Varying constant eq of state with w(a) = w0 + (1-a) wa',
+          'theory': {'camb': {'extra_args': {'dark_energy_model': 'ppf'}},
+                     'classy': {'params': {'Omega_Lambda': 0}}},
+          'params': {
+              'w': {'prior': {'min': -3, 'max': 1},
+                    'ref': {'dist': 'norm', 'loc': -0.99, 'scale': 0.02},
+                    'proposal': 0.02,
+                    'latex': 'w_{0,\\mathrm{DE}}'},
+              'wa': {'prior': {'min': -3, 'max': 2},
+                     'ref': {'dist': 'norm', 'loc': 0, 'scale': 0.05},
+                     'proposal': 0.05,
+                     'latex': 'w_{a,\\mathrm{DE}}'}}}}
 
 # BBN
-bbn_derived_camb: InfoDict = dict([
-    ["YpBBN", dict([[p.latex, r"Y_P^\mathrm{BBN}"]])],
-    ["DHBBN", dict([[p.derived, r"lambda DH: 10**5*DH"],
-                    [p.latex, r"10^5 \mathrm{D}/\mathrm{H}"]])]])
-bbn = dict([
-    ["consistency", {
-        _desc: "Primordial Helium fraction inferred from BBN consistency",
-        kinds.theory: {_camb: {_params: bbn_derived_camb},
-                       _classy: None},
-        _params: dict([
-            ["yheused", {p.latex: r"Y_\mathrm{P}"}]])}],
-    ["YHe_des_y1", {
-        _desc: "Fixed Y_P = 0.245341 (used in DES Y1)",
-        kinds.theory: {_camb: None,
-                       _classy: None},
-        _params: dict([
-            ["yhe", 0.245341]])}],
-    ["YHe", {
-        _desc: "Varying primordial Helium fraction",
-        kinds.theory: {_camb: None,
-                       _classy: None},
-        _params: dict([
-            ["yhe", dict([
-                [p.prior, dict([["min", 0.1], ["max", 0.5]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 0.237], ["scale", 0.006]])],
-                [p.proposal, 0.006], [p.latex, r"Y_\mathrm{P}"]])]])}], ])
+bbn_derived_camb: InfoDict = {'YpBBN': {'latex': 'Y_P^\\mathrm{BBN}'},
+                              'DHBBN': {'derived': 'lambda DH: 10**5*DH',
+                                        'latex': '10^5 \\mathrm{D}/\\mathrm{H}'}}
+bbn = {'consistency':
+           {'desc': 'Primordial Helium fraction inferred from BBN consistency',
+            'theory': {
+                'camb': {'params': bbn_derived_camb},
+                'classy': None},
+            'params': {'yheused': {'latex': 'Y_\\mathrm{P}'}}},
+       'YHe_des_y1':
+           {'desc': 'Fixed Y_P = 0.245341 (used in DES Y1)',
+            'theory': theory,
+            'params': {'yhe': 0.245341}},
+       'YHe':
+           {'desc': 'Varying primordial Helium fraction',
+            'theory': theory,
+            'params': {
+                'yhe': {'prior': {'min': 0.1, 'max': 0.5},
+                        'ref': {'dist': 'norm', 'loc': 0.237, 'scale': 0.006},
+                        'proposal': 0.006, 'latex': 'Y_\\mathrm{P}'}}}}
 
 # Reionization
-reionization: InfoDict = dict([
-    ["std", {
-        _desc: "Standard reio, lasting delta_z=0.5",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["tau", dict([
-                [p.prior, dict([["min", 0.01], ["max", 0.8]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 0.055], ["scale", 0.006]])],
-                [p.proposal, 0.003], [p.latex, r"\tau_\mathrm{reio}"]])],
-            ["zrei", {p.latex: r"z_\mathrm{re}"}]])}],
-    ["gauss_prior", {
-        _desc: "Standard reio, lasting delta_z=0.5, gaussian prior around tau=0.07",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([
-            ["tau", dict([
-                [p.prior,
-                 dict([[p.dist, "norm"], ["loc", 0.07], ["scale", 0.02]])],
-                [p.ref,
-                 dict([[p.dist, "norm"], ["loc", 0.07], ["scale", 0.01]])],
-                [p.proposal, 0.005], [p.latex, r"\tau_\mathrm{reio}"]])],
-            ["zrei", {p.latex: r"z_\mathrm{re}"}]])}],
-    ["irrelevant", {
-        _desc: "Irrelevant (NB: only valid for non-CMB or CMB-marged datasets!)",
-        kinds.theory: {_camb: None, _classy: None},
-        _params: dict([])}], ])
+reionization = {
+    'std': {
+        'desc': 'Standard reio, lasting delta_z=0.5',
+        'theory': theory,
+        'params': {
+            'tau': {'prior': {'min': 0.01, 'max': 0.8},
+                    'ref': {'dist': 'norm', 'loc': 0.055, 'scale': 0.006},
+                    'proposal': 0.003,
+                    'latex': '\\tau_\\mathrm{reio}'},
+            'zrei': {'latex': 'z_\\mathrm{re}'}}},
+    'gauss_prior': {
+        'desc': 'Standard reio, lasting delta_z=0.5, gaussian prior around tau=0.07',
+        'theory': theory,
+        'params': {
+            'tau': {'prior': {'dist': 'norm', 'loc': 0.07, 'scale': 0.02},
+                    'ref': {'dist': 'norm', 'loc': 0.07, 'scale': 0.01},
+                    'proposal': 0.005,
+                    'latex': '\\tau_\\mathrm{reio}'},
+            'zrei': {'latex': 'z_\\mathrm{re}'}}},
+    'irrelevant': {
+        'desc': 'Irrelevant (NB: only valid for non-CMB or CMB-marged datasets!)',
+        'theory': theory,
+        'params': {}}}
 
 # EXPERIMENTS ############################################################################
-base_precision: InfoDict = {_camb: {"halofit_version": "mead"},
-                            _classy: {"non linear": "hmcode", "hmcode_min_k_max": 20}}
+base_precision: InfoDict = {"camb": {"halofit_version": "mead"},
+                            "classy": {"non linear": "hmcode", "hmcode_min_k_max": 20}}
 cmb_precision = deepcopy(base_precision)
-cmb_precision[_camb].update({"bbn_predictor": "PArthENoPE_880.2_standard.dat",
-                             "lens_potential_accuracy": 1})
+cmb_precision["camb"].update({"bbn_predictor": "PArthENoPE_880.2_standard.dat",
+                              "lens_potential_accuracy": 1})
 cmb_sampler_recommended: InfoDict = {"mcmc": {
     "drag": True, "oversample_power": 0.4, "proposal_scale": 1.9}}
 
-like_cmb: InfoDict = dict([
-    [_none, {}],
-    ["planck_2018", {
-        _desc: "Planck 2018 (Polarized CMB + lensing)",
-        _comment: None,
-        kinds.sampler: cmb_sampler_recommended,
-        kinds.theory: {theo: {_extra_args: cmb_precision[theo]}
-                       for theo in [_camb, _classy]},
-        kinds.likelihood: dict([
-            ["planck_2018_lowl.TT", None],
-            ["planck_2018_lowl.EE", None],
-            ["planck_2018_highl_plik.TTTEEE", None],
-            ["planck_2018_lensing.clik", None]])}],
-    ["planck_2018_bk15", {
-        _desc: "Planck 2018 (Polarized CMB + lensing) + Bicep/Keck-Array 2015",
-        kinds.sampler: cmb_sampler_recommended,
-        kinds.theory: {theo: {_extra_args: cmb_precision[theo]}
-                       for theo in [_camb, _classy]},
-        kinds.likelihood: dict([
-            ["planck_2018_lowl.TT", None],
-            ["planck_2018_lowl.EE", None],
-            ["planck_2018_highl_plik.TTTEEE", None],
-            ["planck_2018_lensing.clik", None],
-            ["bicep_keck_2015", None]])}],
-    ["planck_2018_CMBmarged_lensing", {
-        _desc: "Planck 2018 CMB-marginalized lensing",
-        kinds.sampler: cmb_sampler_recommended,
-        kinds.theory: {theo: {_extra_args: cmb_precision[theo]}
-                       for theo in [_camb, _classy]},
-        kinds.likelihood: dict([
-            ["planck_2018_lensing.CMBMarged", None]])}],
-])
-like_cmb["planck_2018_bk15"][_comment] = like_cmb["planck_2018"][_comment]
+like_cmb: InfoDict = {
+    none: {},
+    "planck_2018": {
+        "desc": "Planck 2018 (Polarized CMB + lensing)",
+        "note": None,
+        "sampler": cmb_sampler_recommended,
+        "theory": {theo: {"extra_args": cmb_precision[theo]}
+                   for theo in ["camb", "classy"]},
+        "likelihood": {
+            "planck_2018_lowl.TT": None,
+            "planck_2018_lowl.EE": None,
+            "planck_2018_highl_plik.TTTEEE": None,
+            "planck_2018_lensing.clik": None}},
+    "planck_2018_bk15": {
+        "desc": "Planck 2018 (Polarized CMB + lensing) + Bicep/Keck-Array 2015",
+        "sampler": cmb_sampler_recommended,
+        "theory": {theo: {"extra_args": cmb_precision[theo]}
+                   for theo in ["camb", "classy"]},
+        "likelihood": {
+            "planck_2018_lowl.TT": None,
+            "planck_2018_lowl.EE": None,
+            "planck_2018_highl_plik.TTTEEE": None,
+            "planck_2018_lensing.clik": None,
+            "bicep_keck_2015": None}},
+    "planck_2018_CMBmarged_lensing": {
+        "desc": "Planck 2018 CMB-marginalized lensing",
+        "sampler": cmb_sampler_recommended,
+        "theory": {theo: {"extra_args": cmb_precision[theo]}
+                   for theo in ["camb", "classy"]},
+        "likelihood": {"planck_2018_lensing.CMBMarged": None}}}
+
+like_cmb["planck_2018_bk15"]["note"] = like_cmb["planck_2018"]["note"]
 # Add common CMB derived parameters
+derived_params = {'sigma8': {'latex': '\\sigma_8'},
+                  's8h5': {'derived': 'lambda sigma8, H0: sigma8*(H0*1e-2)**(-0.5)',
+                           'latex': '\\sigma_8/h^{0.5}'},
+                  's8omegamp5': {'derived': 'lambda sigma8, omegam: sigma8*omegam**0.5',
+                                 'latex': '\\sigma_8 \\Omega_\\mathrm{m}^{0.5}'},
+                  's8omegamp25': {'derived': 'lambda sigma8, omegam: sigma8*omegam**0.25',
+                                  'latex': '\\sigma_8 \\Omega_\\mathrm{m}^{0.25}'},
+                  'A': {'derived': 'lambda As: 1e9*As', 'latex': '10^9 A_\\mathrm{s}'},
+                  'clamp': {'derived': 'lambda As, tau: 1e9*As*np.exp(-2*tau)',
+                            'latex': '10^9 A_\\mathrm{s} e^{-2\\tau}'},
+                  'age': {'latex': '{\\rm{Age}}/\\mathrm{Gyr}'},
+                  'rdrag': {'latex': 'r_\\mathrm{drag}'}}
 for name, m in like_cmb.items():
     # Don't add the derived parameter to the no-CMB case!
     if not m:
         continue
-    if _params not in m:
-        m[_params] = dict()
-    m[_params].update(dict([
-        ["sigma8", {p.latex: r"\sigma_8"}],
-        ["s8h5", dict([
-            [p.derived, "lambda sigma8, H0: sigma8*(H0*1e-2)**(-0.5)"],
-            [p.latex, r"\sigma_8/h^{0.5}"]])],
-        ["s8omegamp5", dict([
-            [p.derived, "lambda sigma8, omegam: sigma8*omegam**0.5"],
-            [p.latex, r"\sigma_8 \Omega_\mathrm{m}^{0.5}"]])],
-        ["s8omegamp25", dict([
-            [p.derived, "lambda sigma8, omegam: sigma8*omegam**0.25"],
-            [p.latex, r"\sigma_8 \Omega_\mathrm{m}^{0.25}"]])],
-        ["A", dict([
-            [p.derived, "lambda As: 1e9*As"],
-            [p.latex, r"10^9 A_\mathrm{s}"]])],
-        ["clamp", dict([
-            [p.derived, "lambda As, tau: 1e9*As*np.exp(-2*tau)"],
-            [p.latex, r"10^9 A_\mathrm{s} e^{-2\tau}"]])],
-        ["age", dict([
-            [p.latex, r"{\rm{Age}}/\mathrm{Gyr}"]])],
-        ["rdrag", dict([
-            [p.latex, r"r_\mathrm{drag}"]])]]))
+    if "params" not in m:
+        m["params"] = dict()
+    m["params"].update(derived_params)
     if "cmbmarged" in name.lower():
-        m[_params].pop("A")
-        m[_params].pop("clamp")
+        m["params"].pop("A")
+        m["params"].pop("clamp")
 # Some more, in case we want to add them at some point, described in
 # https://wiki.cosmos.esa.int/planckpla2015/images/b/b9/Parameter_tag_definitions_2015.pdf
 #    "zstar":       {"latex": r"z_*"},
@@ -500,77 +432,70 @@ for name, m in like_cmb.items():
 #    "thetaeq":     {"latex": r"100\theta_\mathrm{eq}"},
 #    "thetarseq":   {"latex": r"100\theta_\mathrm{s,eq}"},
 
-like_bao: InfoDict = dict([
-    [_none, {}],
-    ["BAO_planck_2018", {
-        _desc: "Baryon acoustic oscillation data from DR12, MGS and 6DF",
-        kinds.theory: {_camb: None, _classy: None},
-        kinds.likelihood: dict([
-            ["bao.sixdf_2011_bao", None],
-            ["bao.sdss_dr7_mgs", None],
-            ["bao.sdss_dr12_consensus_bao", None]])}],
-])
+like_bao = {none: {},
+            'BAO_planck_2018': {
+                'desc': 'Baryon acoustic oscillation data from DR12, MGS and 6DF',
+                'theory': theory,
+                'likelihood': {'bao.sixdf_2011_bao': None, 'bao.sdss_dr7_mgs': None,
+                               'bao.sdss_dr12_consensus_bao': None}}}
 
-like_des: InfoDict = dict([
-    [_none, {}],
-    ["des_y1_clustering", {
-        _desc: "Galaxy clustering from DES Y1",
-        kinds.theory: {theo: {_extra_args: base_precision[theo]}
-                       for theo in [_camb, _classy]},
-        kinds.likelihood: dict([
-            ["des_y1.clustering", None]])}],
-    ["des_y1_galaxy_galaxy", {
-        _desc: "Galaxy-galaxy lensing from DES Y1",
-        kinds.theory: {theo: {_extra_args: base_precision[theo]}
-                       for theo in [_camb, _classy]},
-        kinds.likelihood: dict([
-            ["des_y1.galaxy_galaxy", None]])}],
-    ["des_y1_shear", {
-        _desc: "Cosmic shear data from DES Y1",
-        kinds.theory: {theo: {_extra_args: base_precision[theo]}
-                       for theo in [_camb, _classy]},
-        kinds.likelihood: dict([
-            ["des_y1.shear", None]])}],
-    ["des_y1_joint", {
-        _desc: "Combination of galaxy clustering and weak lensing data from DES Y1",
-        kinds.theory: {theo: {_extra_args: base_precision[theo]}
-                       for theo in [_camb, _classy]},
-        kinds.likelihood: dict([
-            ["des_y1.joint", None]])}],
-])
+like_des: InfoDict = \
+    {none: {},
+     "des_y1_clustering": {
+         "desc": "Galaxy clustering from DES Y1",
+         "theory": {theo: {"extra_args": base_precision[theo]}
+                    for theo in ["camb", "classy"]},
+         "likelihood": {"des_y1.clustering": None}},
+     "des_y1_galaxy_galaxy": {
+         "desc": "Galaxy-galaxy lensing from DES Y1",
+         "theory": {theo: {"extra_args": base_precision[theo]}
+                    for theo in ["camb", "classy"]},
+         "likelihood": {"des_y1.galaxy_galaxy": None}},
+     "des_y1_shear": {
+         "desc": "Cosmic shear data from DES Y1",
+         "theory": {theo: {"extra_args": base_precision[theo]}
+                    for theo in ["camb", "classy"]},
+         "likelihood": {"des_y1.shear": None}},
+     "des_y1_joint": {
+         "desc": "Combination of galaxy clustering and weak lensing data from DES Y1",
+         "theory": {theo: {"extra_args": base_precision[theo]}
+                    for theo in ["camb", "classy"]},
+         "likelihood": {"des_y1.joint": None}}}
 
-like_sn: InfoDict = dict([
-    [_none, {}],
-    ["Pantheon", {
-        _desc: "Supernovae data from the Pantheon sample",
-        kinds.theory: {_camb: None, _classy: None},
-        kinds.likelihood: dict([
-            ["sn.pantheon", None]])}],
-])
+like_sn: InfoDict = {none: {},
+                     "Pantheon": {
+                         "desc": "Supernovae data from the Pantheon sample",
+                         "theory": theory,
+                         "likelihood": {"sn.pantheon": None}}}
 
-like_H0: InfoDict = dict([
-    [_none, {}],
-    ["Riess2018a", {
-        _desc: "Local H0 measurement from Riess et al. 2018a (used in Planck 2018)",
-        kinds.theory: {_camb: None, _classy: None},
-        kinds.likelihood: dict([
-            ["H0.riess2018a", None]])}],
-    ["Riess201903", {
-        _desc: "Local H0 measurement from Riess et al. 2019",
-        kinds.theory: {_camb: None, _classy: None},
-        kinds.likelihood: dict([
-            ["H0.riess201903", None]])}],
-])
+like_H0: InfoDict = \
+    {none: {},
+     "Riess2018a": {
+         "desc": "Local H0 measurement from Riess et al. 2018a (used in Planck 2018)",
+         "theory": theory,
+         "likelihood": {"H0.riess2018a": None}},
+     "Riess201903": {
+         "desc": "Local H0 measurement from Riess et al. 2019",
+         "theory": theory,
+         "likelihood": {"H0.riess201903": None}},
+     "Riess2020": {
+         "desc": "Local H0 measurement from Riess et al. 2020",
+         "theory": theory,
+         "likelihood": {"H0.riess2020": None}},
+     "Freedman2020": {
+         "desc": "Local H0 measurement from Freedman et al. 2020",
+         "theory": theory,
+         "likelihood": {"H0.freedman2020": None}}}
 
 # SAMPLERS ###############################################################################
 
-sampler: InfoDict = dict([
-    ["MCMC", {
-        _desc: "MCMC sampler with covmat learning",
-        kinds.sampler: {"mcmc": {"covmat": "auto"}}}],
-    ["PolyChord", {
-        _desc: "Nested sampler, affine invariant and multi-modal",
-        kinds.sampler: {"polychord": None}}], ])
+sampler: InfoDict = {
+    "MCMC":
+        {"desc": "MCMC sampler with covmat learning",
+         "sampler": {"mcmc": {"covmat": "auto"}}},
+    "PolyChord": {
+        "desc": "Nested sampler, affine invariant and multi-modal",
+        "sampler": {"polychord": None}}}
 
 # PRESETS ################################################################################
 
@@ -586,61 +511,61 @@ planck_base_model = {
 default_sampler = {"sampler": "MCMC"}
 
 preset: InfoDict = dict([
-    [_none, {_desc: "(No preset chosen)"}],
+    [none, {"desc": "(No preset chosen)"}],
     # Pure CMB #######################################################
     ["planck_2018_camb", {
-        _desc: "Planck 2018 with CAMB",
-        "theory": _camb,
+        "desc": "Planck 2018 with CAMB",
+        "theory": "camb",
         "like_cmb": "planck_2018"}],
     ["planck_2018_classy", {
-        _desc: "Planck 2018 with CLASS",
-        "theory": _classy,
+        "desc": "Planck 2018 with CLASS",
+        "theory": "classy",
         "like_cmb": "planck_2018"}],
     ["planck_2018_bicep_camb", {
-        _desc: "Planck 2018 + BK15 (with tensor modes) with CAMB",
-        "theory": _camb,
+        "desc": "Planck 2018 + BK15 (with tensor modes) with CAMB",
+        "theory": "camb",
         "primordial": "SFSR_t",
         "like_cmb": "planck_2018_bk15"}],
     ["planck_2018_bicep_classy", {
-        _desc: "Planck 2018 + BK15 (with tensor modes) with CLASS",
-        "theory": _classy,
+        "desc": "Planck 2018 + BK15 (with tensor modes) with CLASS",
+        "theory": "classy",
         "primordial": "SFSR_t",
         "like_cmb": "planck_2018_bk15"}],
     # CMB+BAO ######################################################
     ["planck_2018_BAO_camb", {
-        _desc: "Planck 2018 + BAO with CAMB",
-        "theory": _camb,
+        "desc": "Planck 2018 + BAO with CAMB",
+        "theory": "camb",
         "like_cmb": "planck_2018",
         "like_bao": "BAO_planck_2018"}],
     ["planck_2018_BAO_classy", {
-        _desc: "Planck 2018 + BAO with CLASS",
-        "theory": _classy,
+        "desc": "Planck 2018 + BAO with CLASS",
+        "theory": "classy",
         "like_cmb": "planck_2018",
         "like_bao": "BAO_planck_2018"}],
     # CMB+BAO+SN ###################################################
     ["planck_2018_BAO_SN_camb", {
-        _desc: "Planck 2018 + BAO + SN with CAMB",
-        "theory": _camb,
+        "desc": "Planck 2018 + BAO + SN with CAMB",
+        "theory": "camb",
         "like_cmb": "planck_2018",
         "like_bao": "BAO_planck_2018",
         "like_sn": "Pantheon"}],
     ["planck_2018_BAO_SN_classy", {
-        _desc: "Planck 2018 + BAO + SN with CLASS",
-        "theory": _classy,
+        "desc": "Planck 2018 + BAO + SN with CLASS",
+        "theory": "classy",
         "like_cmb": "planck_2018",
         "like_bao": "BAO_planck_2018",
         "like_sn": "Pantheon"}],
     # CMB+DES+BAO+SN ###################################################
     ["planck_2018_DES_BAO_SN_camb", {
-        _desc: "Planck 2018 + DESjoint + BAO + SN with CAMB",
-        "theory": _camb,
+        "desc": "Planck 2018 + DESjoint + BAO + SN with CAMB",
+        "theory": "camb",
         "like_cmb": "planck_2018",
         "like_bao": "BAO_planck_2018",
         "like_des": "des_y1_joint",
         "like_sn": "Pantheon"}],
     ["planck_2018_DES_BAO_SN_classy", {
-        _desc: "Planck 2018 + DESjoint + BAO + SN with CLASS",
-        "theory": _classy,
+        "desc": "Planck 2018 + DESjoint + BAO + SN with CLASS",
+        "theory": "classy",
         "like_cmb": "planck_2018",
         "like_bao": "BAO_planck_2018",
         "like_des": "des_y1_joint",
@@ -654,19 +579,18 @@ for pre in preset.values():
     pre.update(default_sampler)
 
 # Lensing-only ###################################################
-preset.update(dict([
-    [_none, {_desc: "(No preset chosen)"}],
-    ["planck_2018_DES_lensingonly_camb", {
-        _desc: "Planck 2018 + DES Y1 lensing-only with CAMB",
-        "theory": _camb,
+preset.update({
+    none: {"desc": "(No preset chosen)"},
+    "planck_2018_DES_lensingonly_camb": {
+        "desc": "Planck 2018 + DES Y1 lensing-only with CAMB",
+        "theory": "camb",
         "like_cmb": "planck_2018_CMBmarged_lensing",
-        "like_des": "des_y1_shear"}],
-    ["planck_2018_DES_lensingonly_classy", {
-        _desc: "Planck 2018 + DES Y1 lensing-only with CLASS",
-        "theory": _classy,
+        "like_des": "des_y1_shear"},
+    "planck_2018_DES_lensingonly_classy": {
+        "desc": "Planck 2018 + DES Y1 lensing-only with CLASS",
+        "theory": "classy",
         "like_cmb": "planck_2018_CMBmarged_lensing",
-        "like_des": "des_y1_shear"}],
-]))
+        "like_des": "des_y1_shear"}})
 
 lensingonly_model = {
     "primordial": "SFSR_DESpriors",
@@ -684,12 +608,12 @@ for name, pre in preset.items():
         pre.update(
             {field: value for field, value in lensingonly_model.items() if
              field not in pre})
-        pre.update(default_sampler)
+    pre.update(default_sampler)
 
 # BASIC INSTALLATION #####################################################################
 install_basic: InfoDict = {
-    kinds.theory: {_camb: None, _classy: None},
-    kinds.likelihood: {
+    "theory": theory,
+    "likelihood": {
         "planck_2018_lowl.TT": None,
         "planck_2018_lensing.native": None,
         "bicep_keck_2015": None,
@@ -698,12 +622,12 @@ install_basic: InfoDict = {
         "des_y1.joint": None}}
 
 install_tests = deepcopy(install_basic)
-install_tests[kinds.likelihood].update({"planck_2015_lowl": None,
-                                        "planck_2018_highl_plik.TT_unbinned": None,
-                                        "planck_2018_highl_plik.TT_lite_native": None,
-                                        "planck_2018_highl_CamSpec.TT": None,
-                                        "planck_2018_highl_CamSpec.TT_native": None,
-                                        })
+install_tests["likelihood"].update({"planck_2015_lowl": None,
+                                    "planck_2018_highl_plik.TT_unbinned": None,
+                                    "planck_2018_highl_plik.TT_lite_native": None,
+                                    "planck_2018_highl_CamSpec.TT": None,
+                                    "planck_2018_highl_CamSpec.TT_native": None,
+                                    })
 
 # CONTENTS FOR COMBO-BOXED IN A GUI ######################################################
 

--- a/cobaya/grid_tools/batchjob.py
+++ b/cobaya/grid_tools/batchjob.py
@@ -315,7 +315,7 @@ class JobItem(PropertiesItem):
 
     def matchesDatatag(self, tagList):
         if self.datatag in tagList or self.normed_data in tagList: return True
-        return self.datatag.replace('_post', '') in [tag.replace('_post', '') for tag in
+        return self.datatag.replace('"post"', '') in [tag.replace('"post"', '') for tag in
                                                      tagList]
 
     def hasParam(self, name):
@@ -559,7 +559,7 @@ class BatchJob(PropertiesItem):
         return None
 
     def normalizeDataTag(self, tag):
-        return "_".join(sorted(tag.replace('_post', '').split('_')))
+        return "_".join(sorted(tag.replace('"post"', '').split('_')))
 
     def resolveName(self, paramtag, datatag, wantSubItems=True, wantImportance=True,
                     raiseError=True, base='base',

--- a/cobaya/grid_tools/batchjob.py
+++ b/cobaya/grid_tools/batchjob.py
@@ -315,7 +315,7 @@ class JobItem(PropertiesItem):
 
     def matchesDatatag(self, tagList):
         if self.datatag in tagList or self.normed_data in tagList: return True
-        return self.datatag.replace('"post"', '') in [tag.replace('"post"', '') for tag in
+        return self.datatag.replace('_post', '') in [tag.replace('_post', '') for tag in
                                                      tagList]
 
     def hasParam(self, name):
@@ -559,7 +559,7 @@ class BatchJob(PropertiesItem):
         return None
 
     def normalizeDataTag(self, tag):
-        return "_".join(sorted(tag.replace('"post"', '').split('_')))
+        return "_".join(sorted(tag.replace('_post', '').split('_')))
 
     def resolveName(self, paramtag, datatag, wantSubItems=True, wantImportance=True,
                     raiseError=True, base='base',

--- a/cobaya/grid_tools/jobqueue.py
+++ b/cobaya/grid_tools/jobqueue.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from distutils import spawn
 
-from cobaya.conventions import _yaml_extensions
+from cobaya.conventions import Extension
 from .conventions import _script_folder, _script_ext, _log_folder, _jobid_ext
 
 code_prefix = 'COSMOMC'
@@ -54,6 +54,9 @@ def checkArguments(**kwargs):
 
 
 class jobSettings:
+    names: list
+    jobId: str
+
     def __init__(self, jobName, msg=False, **kwargs):
         self.jobName = jobName
         grid_engine = 'PBS'
@@ -284,7 +287,7 @@ def submitJob(jobName, inputFiles, sequential=False, msg=False, **kwargs):
     if isinstance(inputFiles, str):
         inputFiles = [inputFiles]
     inputFiles = [
-        (os.path.splitext(p)[0] if os.path.splitext(p)[1] in _yaml_extensions else p)
+        (os.path.splitext(p)[0] if os.path.splitext(p)[1] in Extension.yamls else p)
         for p in inputFiles]
     j.runsPerJob = (len(inputFiles), 1)[sequential]
     # adjust omp for the actual number
@@ -350,7 +353,7 @@ def submitJob(jobName, inputFiles, sequential=False, msg=False, **kwargs):
             else:
                 j.inputFiles = inputFiles
                 if 'Your job ' in res:
-                    m = re.search('Your job (\d*) ', res)
+                    m = re.search(r'Your job (\d*) ', res)
                     res = m.group(1)
                 j.jobId = res
                 j.subTime = time.time()

--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -239,7 +239,7 @@ def download_file(url, path, no_progress_bars=False, decompress=False, logger=No
             logger.info('Downloaded filename %s', filename)
         except Exception as e:
             logger.error(
-                "Error downloading file '%s' to folder '%s': %s", filename, tmp_path, e)
+                "Error downloading %s' to folder '%s': %s", url, tmp_path, e)
             return False
         logger.debug('Got: %s', filename)
         if not decompress:

--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -25,10 +25,9 @@ from cobaya.log import logger_setup, LoggedError, NoLogging
 from cobaya.tools import create_banner, warn_deprecation, get_resolved_class, \
     write_packages_path_in_config_file, get_config_path, get_kind
 from cobaya.input import get_used_components
-from cobaya.conventions import _component_path, _code, _data, _external, _force, \
-    _packages_path, _packages_path_arg, _packages_path_env, _yaml_extensions, _debug, \
-    _install_skip_env, _packages_path_arg_posix, _packages_path_config_file, _test_run, \
-    _class_name
+from cobaya.conventions import code_path, data_path, packages_path_arg, \
+    packages_path_env, Extension, install_skip_env, packages_path_arg_posix, \
+    packages_path_config_file
 from cobaya.mpi import set_mpi_disabled
 from cobaya.tools import resolve_packages_path
 
@@ -45,9 +44,9 @@ class NotInstalledError(LoggedError):
     """
 
 
-# noinspection PyUnresolvedReferences
 def install(*infos, **kwargs):
-    debug = kwargs.get(_debug)
+    debug = kwargs.get("debug")
+    # noinspection PyUnresolvedReferences
     if not log.root.handlers:
         logger_setup()
     path = kwargs.get("path")
@@ -58,12 +57,12 @@ def install(*infos, **kwargs):
             log, "No 'path' argument given, and none could be found in input infos "
                  "(as %r), the %r env variable or the config file. "
                  "Maybe specify one via a command line argument '-%s [...]'?",
-            _packages_path, _packages_path_env, _packages_path_arg[0])
+            "packages_path", packages_path_env, packages_path_arg[0])
     abspath = os.path.abspath(path)
     log.info("Installing external packages at '%s'", abspath)
     kwargs_install = {"force": kwargs.get("force", False),
                       "no_progress_bars": kwargs.get("no_progress_bars")}
-    for what in (_code, _data):
+    for what in (code_path, data_path):
         kwargs_install[what] = kwargs.get(what, True)
         spath = os.path.join(abspath, what)
         if kwargs_install[what] and not os.path.exists(spath):
@@ -77,7 +76,7 @@ def install(*infos, **kwargs):
     # NB: if passed with quotes as `--skip "a b"`, it's interpreted as a single key
     skip_keywords_arg = set(chain(*[word.split() for word in skip_keywords_arg]))
     skip_keywords_env = set(
-        os.environ.get(_install_skip_env, "").replace(",", " ").lower().split())
+        os.environ.get(install_skip_env, "").replace(",", " ").lower().split())
     skip_keywords = skip_keywords_arg.union(skip_keywords_env)
     used_components, components_infos = get_used_components(*infos, return_infos=True)
     for kind, components in used_components.items():
@@ -89,16 +88,16 @@ def install(*infos, **kwargs):
             if _skip_helper(component.lower(), skip_keywords, skip_keywords_env, log):
                 continue
             info = components_infos[component]
-            if isinstance(info, str) or _external in info:
+            if isinstance(info, str) or "external" in info:
                 log.warning("Component '%s' is a custom function. "
                             "Nothing to do.", component)
                 continue
             try:
-                class_name = (info or {}).get(_class_name)
+                class_name = (info or {}).get("class")
                 if class_name:
                     log.info("Class to be installed for this component: %r", class_name)
                 imported_class = get_resolved_class(
-                    component, kind=kind, component_path=info.pop(_component_path, None),
+                    component, kind=kind, component_path=info.pop("python_path", None),
                     class_name=class_name)
             except ImportError as excpt:
                 log.error("Component '%s' not recognized. [%s].", component, excpt)
@@ -131,7 +130,7 @@ def install(*infos, **kwargs):
                     has_been_installed = is_installed(path=install_path, **kwargs_install)
             if has_been_installed:
                 log.info("External dependencies for this component already installed.")
-                if kwargs.get(_test_run, False):
+                if kwargs.get("test", False):
                     continue
                 if kwargs_install["force"] and not kwargs.get("skip_global"):
                     log.info("Forcing re-installation, as requested.")
@@ -144,7 +143,7 @@ def install(*infos, **kwargs):
                     log.info(
                         "(If you expected this to be already installed, re-run "
                         "`cobaya-install` with --debug to get more verbose output.)")
-                if kwargs.get(_test_run, False):
+                if kwargs.get("test", False):
                     continue
                 log.info("Installing...")
             try:
@@ -194,17 +193,17 @@ def install(*infos, **kwargs):
             bullet + bullet.join(failed_components))
     log.info("All requested components' dependencies correctly installed.")
     # Set the installation path in the global config file
-    if not kwargs.get("no_set_global", False) and not kwargs.get(_test_run, False):
+    if not kwargs.get("no_set_global", False) and not kwargs.get("test", False):
         write_packages_path_in_config_file(abspath)
         log.info("The installation path has been written into the global config file: %s",
-                 os.path.join(get_config_path(), _packages_path_config_file))
+                 os.path.join(get_config_path(), packages_path_config_file))
 
 
 def _skip_helper(name, skip_keywords, skip_keywords_env, logger):
     try:
         this_skip_keyword = next(s for s in skip_keywords
                                  if s.lower() in name.lower())
-        env_msg = (" in env var %r" % _install_skip_env
+        env_msg = (" in env var %r" % install_skip_env
                    if this_skip_keyword in skip_keywords_env else "")
         logger.info("Skipping %r as per skip keyword %r" + env_msg,
                     name, this_skip_keyword)
@@ -336,13 +335,13 @@ def install_script(args=None):
                         help="One or more input files or component names "
                              "(or simply 'cosmo' to install all the requisites for basic"
                              " cosmological runs)")
-    parser.add_argument("-" + _packages_path_arg[0], "--" + _packages_path_arg_posix,
+    parser.add_argument("-" + packages_path_arg[0], "--" + packages_path_arg_posix,
                         action="store", required=False,
                         metavar="/packages/path", default=None,
                         help="Desired path where to install external packages. "
                              "Optional if one has been set globally or as an env variable"
                              " (run with '--show_%s' to check)." %
-                             _packages_path_arg_posix)
+                             packages_path_arg_posix)
     # MARKED FOR DEPRECATION IN v3.0
     modules = "modules"
     parser.add_argument("-" + modules[0], "--" + modules,
@@ -350,20 +349,20 @@ def install_script(args=None):
                         metavar="/packages/path", default=None,
                         help="To be deprecated! "
                              "Alias for %s, which should be used instead." %
-                             _packages_path_arg_posix)
+                             packages_path_arg_posix)
     # END OF DEPRECATION BLOCK -- CONTINUES BELOW!
     output_show_packages_path = resolve_packages_path()
-    if output_show_packages_path and os.environ.get(_packages_path_env):
-        output_show_packages_path += " (from env variable %r)" % _packages_path_env
+    if output_show_packages_path and os.environ.get(packages_path_env):
+        output_show_packages_path += " (from env variable %r)" % packages_path_env
     elif output_show_packages_path:
         output_show_packages_path += " (from config file)"
     else:
         output_show_packages_path = "(Not currently set.)"
-    parser.add_argument("--show-" + _packages_path_arg_posix, action="version",
+    parser.add_argument("--show-" + packages_path_arg_posix, action="version",
                         version=output_show_packages_path,
                         help="Prints default external packages installation folder "
                              "and exits.")
-    parser.add_argument("-" + _force[0], "--" + _force, action="store_true",
+    parser.add_argument("-" + "force"[0], "--" + "force", action="store_true",
                         default=False,
                         help="Force re-installation of apparently installed packages.")
     parser.add_argument("--skip", action="store", nargs="*",
@@ -372,7 +371,7 @@ def install_script(args=None):
                              "installation.")
     parser.add_argument("--no-progress-bars", action="store_true", default=False,
                         help="No progress bars shown. Shorter logs (used in Travis).")
-    parser.add_argument("--%s" % _test_run, action="store_true", default=False,
+    parser.add_argument("--%s" % "test", action="store_true", default=False,
                         help="Just check whether components are installed.")
     # MARKED FOR DEPRECATION IN v3.0
     parser.add_argument("--just-check", action="store_true", default=False,
@@ -382,13 +381,13 @@ def install_script(args=None):
                         help="Do not store the installation path for later runs.")
     parser.add_argument("--skip-global", action="store_true", default=False,
                         help="Skip installation of already-available Python modules.")
-    parser.add_argument("-" + _debug[0], "--" + _debug, action="store_true",
+    parser.add_argument("-" + "debug"[0], "--" + "debug", action="store_true",
                         help="Produce verbose debug output.")
     group_just = parser.add_mutually_exclusive_group(required=False)
     group_just.add_argument("-C", "--just-code", action="store_false", default=True,
-                            help="Install code of the components.", dest=_data)
+                            help="Install code of the components.", dest=data_path)
     group_just.add_argument("-D", "--just-data", action="store_false", default=True,
-                            help="Install data of the components.", dest=_code)
+                            help="Install data of the components.", dest=code_path)
     arguments = parser.parse_args(args)
     # Configure the logger ASAP
     logger_setup()
@@ -404,7 +403,7 @@ def install_script(args=None):
             logger.info("Installing *tested* cosmological packages.")
             from cobaya.cosmo_input import install_tests
             infos += [install_tests]
-        elif os.path.splitext(f)[1].lower() in _yaml_extensions:
+        elif os.path.splitext(f)[1].lower() in Extension.yamls:
             from cobaya.input import load_input
             infos += [load_input(f)]
         else:
@@ -422,24 +421,24 @@ def install_script(args=None):
         deprecation_warnings.append(
             "*DEPRECATION*: -m/--modules will be deprecated in favor of "
             "-%s/--%s in the next version. Please, use that one instead." %
-            (_packages_path_arg[0], _packages_path_arg_posix))
+            (packages_path_arg[0], packages_path_arg_posix))
         # BEHAVIOUR TO BE REPLACED BY ERROR:
-        if getattr(arguments, _packages_path_arg) is None:
-            setattr(arguments, _packages_path_arg, getattr(arguments, modules))
+        if getattr(arguments, packages_path_arg) is None:
+            setattr(arguments, packages_path_arg, getattr(arguments, modules))
     # END OF DEPRECATION BLOCK
     # MARKED FOR DEPRECATION IN v3.0
     if arguments.just_check is True:
         deprecation_warnings.append(
             "*DEPRECATION*: --just-check will be deprecated in favor of "
-            "--%s in the next version. Please, use that one instead." % _test_run)
+            "--%s in the next version. Please, use that one instead." % "test")
     # BEHAVIOUR TO BE REPLACED BY ERROR:
-    setattr(arguments, _test_run, getattr(arguments, _test_run) or arguments.just_check)
+    setattr(arguments, "test", getattr(arguments, "test") or arguments.just_check)
     # END OF DEPRECATION BLOCK
     # Launch installer
-    install(*infos, path=getattr(arguments, _packages_path_arg),
+    install(*infos, path=getattr(arguments, packages_path_arg),
             **{arg: getattr(arguments, arg)
-               for arg in ["force", _code, _data, "no_progress_bars", _test_run,
-                           "no_set_global", "skip", "skip_global", _debug]})
+               for arg in ["force", code_path, data_path, "no_progress_bars", "test",
+                           "no_set_global", "skip", "skip_global", "debug"]})
     # MARKED FOR DEPRECATION IN v3.0
     for warning_msg in deprecation_warnings:
         logger.warning(warning_msg)

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -137,7 +137,7 @@ class Likelihood(Theory, LikelihoodInterface):
     def wait(self):
         if self.delay:
             self.log.debug("Sleeping for %f seconds.", self.delay)
-        sleep(self.delay)
+            sleep(self.delay)
 
 
 class AbsorbUnusedParamsLikelihood(Likelihood):

--- a/cobaya/likelihoods/H0/riess2018a.yaml
+++ b/cobaya/likelihoods/H0/riess2018a.yaml
@@ -6,6 +6,6 @@
 H0_mean: 73.45
 H0_std: 1.66
 # Aliases for automatic covariance matrix
-aliases: [Riess18]
+aliases: [ Riess18 ]
 # Speed in evaluations/second
 speed: 4500

--- a/cobaya/likelihoods/base_classes/DataSetLikelihood.py
+++ b/cobaya/likelihoods/base_classes/DataSetLikelihood.py
@@ -10,7 +10,6 @@ import os
 from getdist import IniFile
 
 # Local
-from cobaya.conventions import _packages_path
 from cobaya.log import LoggedError
 from cobaya.install import NotInstalledError
 from .InstallableLikelihood import InstallableLikelihood
@@ -54,7 +53,7 @@ class DataSetLikelihood(InstallableLikelihood):
             if not self.path:
                 raise LoggedError(self.log, "No path given for %s. Set the likelihood "
                                             "property 'path' or the common property '%s'."
-                                  , self.dataset_file, _packages_path)
+                                  , self.dataset_file, "packages_path")
 
             data_file = os.path.normpath(os.path.join(self.path, self.dataset_file))
         if not os.path.exists(data_file):

--- a/cobaya/likelihoods/base_classes/bao.py
+++ b/cobaya/likelihoods/base_classes/bao.py
@@ -128,7 +128,7 @@ from typing import Optional, Sequence
 
 # Local
 from cobaya.log import LoggedError
-from cobaya.conventions import _packages_path, _c_km_s
+from cobaya.conventions import Const
 from cobaya.likelihoods.base_classes import InstallableLikelihood
 
 
@@ -153,7 +153,7 @@ class BAO(InstallableLikelihood):
         if not getattr(self, "path", None) and not getattr(self, "packages_path", None):
             raise LoggedError(
                 self.log, "No path given to BAO data. Set the likelihood property "
-                          "'path' or the common property '%s'.", _packages_path)
+                          "'path' or the common property '%s'.", "packages_path")
         # If no path specified, use the external packages path
         data_file_path = os.path.normpath(getattr(self, "path", None) or
                                           os.path.join(self.packages_path, "data"))
@@ -281,12 +281,13 @@ class BAO(InstallableLikelihood):
         if observable == "DV_over_rs":
             return np.cbrt(
                 ((1 + z) * self.provider.get_angular_diameter_distance(z)) ** 2 *
-                _c_km_s * z / self.provider.get_Hubble(z, units="km/s/Mpc")) / self.rs()
+                Const.c_km_s * z / self.provider.get_Hubble(z,
+                                                            units="km/s/Mpc")) / self.rs()
         # Idem, inverse
         elif observable == "rs_over_DV":
             return np.cbrt(
                 ((1 + z) * self.provider.get_angular_diameter_distance(z)) ** 2 *
-                _c_km_s * z / self.provider.get_Hubble(z, units="km/s/Mpc")) ** (
+                Const.c_km_s * z / self.provider.get_Hubble(z, units="km/s/Mpc")) ** (
                        -1) * self.rs()
         # Comoving angular diameter distance, over sound horizon radius
         elif observable == "DM_over_rs":
@@ -306,7 +307,7 @@ class BAO(InstallableLikelihood):
         # Anisotropy (Alcock-Paczynski) parameter
         elif observable == "F_AP":
             return ((1 + z) * self.provider.get_angular_diameter_distance(z) *
-                    self.provider.get_Hubble(z, units="km/s/Mpc")) / _c_km_s
+                    self.provider.get_Hubble(z, units="km/s/Mpc")) / Const.c_km_s
 
     def rs(self):
         return self.provider.get_param("rdrag") * self.rs_rescale

--- a/cobaya/likelihoods/base_classes/des.py
+++ b/cobaya/likelihoods/base_classes/des.py
@@ -54,7 +54,7 @@ import copy
 # Local
 from cobaya.likelihoods.base_classes import DataSetLikelihood
 from cobaya.log import LoggedError
-from cobaya.conventions import _c_km_s
+from cobaya.conventions import Const
 
 # DES data types
 def_DES_types = ['xip', 'xim', 'gammat', 'wtheta']
@@ -419,7 +419,7 @@ class DES(DataSetLikelihood):
             ((chis[1] + chis[0]) / 2, (chis[2:] - chis[:-2]) / 2, (chis[-1] - chis[-2])))
         D_growth = PKdelta.P(self.zs, 0.001)
         D_growth = np.sqrt(D_growth / PKdelta.P(0, 0.001))
-        c = _c_km_s * 1e3  # m/s
+        c = Const.c_km_s * 1e3  # m/s
 
         if any(t in self.used_types for t in ["gammat", "wtheta"]):
             qgal = []

--- a/cobaya/likelihoods/base_classes/planck_clik.py
+++ b/cobaya/likelihoods/base_classes/planck_clik.py
@@ -16,7 +16,6 @@ from typing import Any
 # Local
 from cobaya.likelihood import Likelihood
 from cobaya.log import LoggedError
-from cobaya.conventions import _packages_path, kinds
 from cobaya.input import get_default_info
 from cobaya.install import pip_install, download_file, NotInstalledError
 from cobaya.tools import are_different_params_lists, create_banner, load_module
@@ -52,7 +51,7 @@ class PlanckClik(Likelihood):
             raise LoggedError(
                 self.log, "No path given to the Planck likelihood. Set the "
                           "likelihood property 'path' or the common property "
-                          "'%s'.", _packages_path)
+                          "'%s'.", "packages_path")
         clik: Any = is_installed_clik(path=self.path_clik, allow_global=allow_global)
         if not clik:
             raise NotInstalledError(
@@ -361,7 +360,7 @@ def install_clik(path, no_progress_bars=False):
 
 def get_product_id_and_clik_file(name):
     """Gets the PLA product info from the defaults file."""
-    defaults = get_default_info(name, kinds.likelihood)
+    defaults = get_default_info(name, "likelihood")
     return defaults.get("product_id"), defaults.get("clik_file")
 
 

--- a/cobaya/likelihoods/bicep_keck_2015/__init__.py
+++ b/cobaya/likelihoods/bicep_keck_2015/__init__.py
@@ -73,10 +73,10 @@ import numpy as np
 
 # Local
 from cobaya.likelihoods.base_classes import CMBlikes
-from cobaya.conventions import _h_J_s, _kB_J_K
+from cobaya.conventions import Const
 
 # Physical constants
-Ghz_Kelvin = _h_J_s / _kB_J_K * 1e9
+Ghz_Kelvin = Const.h_J_s / Const.kB_J_K * 1e9
 T_CMB_K = 2.7255  # fiducial CMB temperature
 
 

--- a/cobaya/likelihoods/bicep_keck_2015/bicep_keck_2015.yaml
+++ b/cobaya/likelihoods/bicep_keck_2015/bicep_keck_2015.yaml
@@ -72,7 +72,7 @@ params:
       scale: 0.01
     proposal: 0.01
     latex: \alpha_{B,\mathrm{dust}}
-  # sync spatial power specturm power law index
+  # sync spatial power spectrum power law index
   BBalphasync:
     prior:
       min: -1.0

--- a/cobaya/likelihoods/gaussian_mixture/gaussian_mixture.py
+++ b/cobaya/likelihoods/gaussian_mixture/gaussian_mixture.py
@@ -14,8 +14,7 @@ from scipy.special import logsumexp
 from cobaya.likelihood import Likelihood
 from cobaya.log import LoggedError
 from cobaya.mpi import share_mpi, is_main_process
-from cobaya.conventions import kinds, _params, ArrayLike, ArrayOrFloat
-from cobaya.conventions import _input_params_prefix, _output_params_prefix
+from cobaya.typing import ArrayLike, ArrayOrFloat, InputDict
 
 derived_suffix = "_derived"
 
@@ -215,10 +214,10 @@ def info_random_gaussian_mixture(
     if mpi_aware:
         mean, cov = share_mpi((mean, cov))
     dimension = len(ranges)
-    info = {kinds.likelihood: {"gaussian_mixture": {
-        "means": mean, "covs": cov, _input_params_prefix: input_params_prefix,
-        _output_params_prefix: output_params_prefix, "derived": derived}}}
-    info[_params] = dict(
+    info: InputDict = {"likelihood": {"gaussian_mixture": {
+        "means": mean, "covs": cov, "input_params_prefix": input_params_prefix,
+        "output_params_prefix": output_params_prefix, "derived": derived}}}
+    info["params"] = dict(
         # sampled
         [(input_params_prefix + "_%d" % i,
           {"prior": {"min": ranges[i][0], "max": ranges[i][1]},
@@ -226,6 +225,6 @@ def info_random_gaussian_mixture(
          for i in range(dimension)] +
         # derived
         ([[output_params_prefix + "_%d" % i,
-           {"min": -3, "max": 3, "latex": r"\beta_{%i}" % i}]
+           {"latex": r"\beta_{%i}" % i}]
           for i in range(dimension * n_modes)] if derived else []))
     return info

--- a/cobaya/likelihoods/gaussian_mixture/gaussian_mixture.py
+++ b/cobaya/likelihoods/gaussian_mixture/gaussian_mixture.py
@@ -128,7 +128,11 @@ class gaussian_mixture(Likelihood):
                     (p, v) for p, v in
                     zip(list(self.output_params)[i * n:(i + 1) * n], standard))
         # Compute the likelihood and return
-        return logsumexp([gauss.logpdf(x) for gauss in self.gaussians], b=self.weights)
+        if len(self.gaussians) == 1:
+            return self.gaussians[0].logpdf(x)
+        else:
+            return logsumexp([gauss.logpdf(x) for gauss in self.gaussians],
+                             b=self.weights)
 
 
 # Scripts to generate random means and covariances #######################################

--- a/cobaya/likelihoods/gaussian_mixture/gaussian_mixture.yaml
+++ b/cobaya/likelihoods/gaussian_mixture/gaussian_mixture.yaml
@@ -8,7 +8,7 @@ weights:
 # Prefix of parameters names
 input_params_prefix: ""
 output_params_prefix: ""
-# Use derived standarized parameters for each component
+# Use derived standardized parameters for each component
 derived: False
 # Delay in likelihood evaluation
 delay: 0  # seconds

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -14,7 +14,6 @@ from copy import deepcopy
 import functools
 
 # Local
-from cobaya.conventions import _debug, _debug_file
 from cobaya import mpi
 
 
@@ -112,7 +111,7 @@ def exception_handler(exception_type, exception_instance, trace_back):
             "If you cannot solve it yourself and need to report it, "
             "include the debug output,\n"
             "which you can send it to a file setting '%s:[some_file_name]'.",
-            _debug, _debug_file)
+            "debug", "debug_file")
     # Exit all MPI processes
     if want_abort:
         mpi.abort_if_mpi()

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -342,7 +342,8 @@ from types import MethodType
 from typing import Sequence, NamedTuple, Callable, Optional, Mapping
 
 # Local
-from cobaya.conventions import _prior, partag, _prior_1d_name, PriorsDict
+from cobaya.conventions import prior_1d_name
+from cobaya.typing import PriorsDict
 from cobaya.tools import get_external_function, get_scipy_1d_pdf, read_dnumber
 from cobaya.tools import _fast_norm_logpdf, getfullargspec
 from cobaya.log import LoggedError, HasLogger
@@ -382,17 +383,17 @@ class Prior(HasLogger):
         self._bounds = np.zeros((len(sampled_params_info), 2))
         for i, p in enumerate(sampled_params_info):
             self.params += [p]
-            prior = sampled_params_info[p].get(_prior)
+            prior = sampled_params_info[p].get("prior")
             self.pdf += [get_scipy_1d_pdf({p: prior})]
             fast_logpdf = fast_logpdfs.get(self.pdf[-1].dist.name)
             if fast_logpdf:
                 self.pdf[-1].logpdf = MethodType(fast_logpdf, self.pdf[-1])
             # Get the reference (1d) pdf
-            ref = sampled_params_info[p].get(partag.ref)
+            ref = sampled_params_info[p].get("ref")
             # Cases: number, pdf (something, but not a number), nothing
             if isinstance(ref, Sequence) and len(ref) == 2 and all(
                     isinstance(n, numbers.Number) for n in ref):
-                ref = {partag.dist: "norm", "loc": ref[0], "scale": ref[1]}
+                ref = {"dist": "norm", "loc": ref[0], "scale": ref[1]}
             if isinstance(ref, numbers.Real):
                 self.ref_pdf += [float(ref)]
             elif isinstance(ref, Mapping):
@@ -429,9 +430,9 @@ class Prior(HasLogger):
         self.external = {}
         self.external_dependence = set()
         for name in (info_prior if info_prior else {}):
-            if name == _prior_1d_name:
+            if name == prior_1d_name:
                 raise LoggedError(self.log, "The name '%s' is a reserved prior name. "
-                                            "Please use a different one.", _prior_1d_name)
+                                            "Please use a different one.", prior_1d_name)
             self.log.debug(
                 "Loading external prior '%s' from: '%s'", name, info_prior[name])
             logp = get_external_function(info_prior[name], name=name)
@@ -468,7 +469,7 @@ class Prior(HasLogger):
     # Not very useful, except for getting the prior names as list(self)
     # Created for consistency with likelihoods
     def __iter__(self):
-        return (p for p in [_prior_1d_name] + list(self.external))
+        return (p for p in [prior_1d_name] + list(self.external))
 
     def __len__(self):
         return 1 + len(self.external)

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -52,7 +52,7 @@ from itertools import chain
 
 # Local
 from cobaya.conventions import Extension
-from cobaya.typing import InfoDict, SamplersDict
+from cobaya.typing import InfoDict, SamplersDict, SamplerDict
 from cobaya.tools import get_class, deepcopy_where_possible, find_with_regexp
 from cobaya.tools import recursive_update, str_to_list
 from cobaya.model import Model
@@ -124,8 +124,7 @@ def check_sampler_info(info_old: Optional[SamplersDict] = None,
                 logger_sampler, "Found old Sampler information which is not compatible "
                                 "with the new one. Delete the previous output manually, "
                                 "or automatically with either "
-                                "'-%s', '--%s', '%s: True'" % (
-                                "force"[0], "force", "force"))
+                                "'-f', '--force', 'force: True'")
 
 
 def get_sampler(info_sampler: SamplersDict, model: Model, output: Optional[Output] = None,
@@ -220,7 +219,7 @@ class Sampler(CobayaComponent):
         return self._output
 
     # Private methods: just ignore them:
-    def __init__(self, info_sampler: SamplersDict, model: Model,
+    def __init__(self, info_sampler: SamplerDict, model: Model,
                  output=Optional[Output], packages_path: Optional[str] = None,
                  name: Optional[str] = None):
         """

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -91,14 +91,14 @@ from copy import deepcopy
 
 # Local
 from cobaya.sampler import Minimizer
-from cobaya.conventions import _undo_chi2_name
+from cobaya.conventions import undo_chi2_name
 from cobaya.collection import OnePoint, Collection
 from cobaya.log import LoggedError
 from cobaya.tools import read_dnumber, recursive_update
 from cobaya.sampler import CovmatSampler
 from cobaya import mpi
 
-# Handling scpiy vs BOBYQA
+# Handling scipy vs BOBYQA
 evals_attr = {"scipy": "fun", "bobyqa": "f"}
 
 # Conventions conventions
@@ -385,7 +385,7 @@ class minimize(Minimizer, CovmatSampler):
             [[p, params[p]] for p in self.model.parameterization.derived_params()])
         if hasattr(params, 'chi2_names'):
             labels.update({p: r'\chi^2_{\rm %s}' % (
-                _undo_chi2_name(p).replace("_", r"\ "))
+                undo_chi2_name(p).replace("_", r"\ "))
                            for p in params.chi2_names})
             add_section([[chi2, params[chi2]] for chi2 in params.chi2_names])
         return "\n".join(lines)

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -163,8 +163,9 @@ class minimize(Minimizer, CovmatSampler):
         # TODO: if ignore_prior, one should use *like* covariance (this is *post*)
         covmat = self._load_covmat(prefer_load_old=self.output)[0]
         # scale by conditional parameter widths (since not using correlation structure)
+        rhobeg = 1
         scales = np.minimum(1 / np.sqrt(np.diag(np.linalg.inv(covmat))),
-                            (self._bounds[:, 1] - self._bounds[:, 0]) / 3)
+                            (self._bounds[:, 1] - self._bounds[:, 0]) / 3 / rhobeg)
         # Cov and affine transformation
         # Transform to space where initial point is at centre, and cov is normalised
         # Cannot do rotation, as supported minimization routines assume bounds aligned
@@ -185,6 +186,7 @@ class minimize(Minimizer, CovmatSampler):
                 "bounds": np.array(list(zip(*bounds))),
                 "seek_global_minimum": (True if mpi.size() else False),
                 "maxfun": int(self.max_evals),
+                "rhobeg": rhobeg,
                 "do_logging": (self.log.getEffectiveLevel() == logging.DEBUG)}
             self.kwargs = recursive_update(
                 deepcopy(self.kwargs), self.override_bobyqa or {})

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -184,7 +184,7 @@ class minimize(Minimizer, CovmatSampler):
                 "objfun": (lambda x: -self.logp_transf(x)),
                 "x0": initial_point,
                 "bounds": np.array(list(zip(*bounds))),
-                "seek_global_minimum": (True if mpi.size() else False),
+                "seek_global_minimum": not mpi.more_than_one_process(),
                 "maxfun": int(self.max_evals),
                 "rhobeg": rhobeg,
                 "do_logging": (self.log.getEffectiveLevel() == logging.DEBUG)}

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -26,7 +26,7 @@ from cobaya.collection import Collection
 from cobaya.log import LoggedError
 from cobaya.install import download_github_release, NotInstalledError
 from cobaya.yaml import yaml_dump_file
-from cobaya.conventions import _separator, _evidence_extension, _packages_path_arg
+from cobaya.conventions import derived_par_name_separator, packages_path_arg, Extension
 
 
 class polychord(Sampler):
@@ -63,7 +63,7 @@ class polychord(Sampler):
             raise NotInstalledError(
                 self.log, "Could not find PolyChord. Check error message above. "
                           "To install it, run 'cobaya-install polychord --%s "
-                          "[packages_path]'", _packages_path_arg)
+                          "[packages_path]'", packages_path_arg)
         # Prepare arguments and settings
         from pypolychord.settings import PolyChordSettings
         self.n_sampled = len(self.model.parameterization.sampled_params())
@@ -259,11 +259,11 @@ class polychord(Sampler):
                 f_paramnames.write("%s*\t%s\n" % (p, labels.get(p, "")))
             for p in self.model.prior:
                 f_paramnames.write("%s*\t%s\n" % (
-                    "logprior" + _separator + p,
+                    "logprior" + derived_par_name_separator + p,
                     r"\pi_\mathrm{" + p.replace("_", r"\ ") + r"}"))
             for p in self.model.likelihood:
                 f_paramnames.write("%s*\t%s\n" % (
-                    "loglike" + _separator + p,
+                    "loglike" + derived_par_name_separator + p,
                     r"\log\mathcal{L}_\mathrm{" + p.replace("_", r"\ ") + r"}"))
 
     def save_sample(self, fname, name):
@@ -327,6 +327,7 @@ class polychord(Sampler):
                         self.output.folder = self.clusters_folder
                     sample = self.save_sample(f, str(i))
                     if self.output:
+                        # noinspection PyUnboundLocalVariable
                         self.output.folder = old_folder
                     self.clusters[i] = {"sample": sample}
             # Prepare the evidence(s) and write to file
@@ -357,7 +358,7 @@ class polychord(Sampler):
                             logZ=self.clusters[i]["logZ"],
                             logZstd=self.clusters[i]["logZstd"])
                 fname = os.path.join(self.output.folder,
-                                     self.output.prefix + _evidence_extension)
+                                     self.output.prefix + Extension.evidence)
                 yaml_dump_file(fname, out_evidences, comment="log-evidence",
                                error_if_exists=False)
         # TODO: try to broadcast the collections
@@ -414,7 +415,7 @@ class polychord(Sampler):
             # Main sample
             (output.collection_regexp(name=None), None),
             # Evidence
-            (re.compile(re.escape(output.prefix + _evidence_extension)), None),
+            (re.compile(re.escape(output.prefix + Extension.evidence)), None),
             # Clusters
             (None, cls.get_clusters_dir(output))
         ]
@@ -465,6 +466,7 @@ class polychord(Sampler):
         if path and not kwargs.get("allow_global"):
             if is_main_process():
                 log.info("Importing *local* PolyChord from '%s'.", path)
+            # noinspection PyTypeChecker
             if not os.path.exists(path):
                 if is_main_process():
                     log.error("The given folder does not exist: '%s'", path)

--- a/cobaya/theories/_cosmo/boltzmannbase.py
+++ b/cobaya/theories/_cosmo/boltzmannbase.py
@@ -14,9 +14,10 @@ from typing import Mapping, Iterable
 from cobaya.theory import Theory
 from cobaya.tools import deepcopy_where_possible
 from cobaya.log import LoggedError, abstract
-from cobaya.conventions import _c_km_s, empty_dict
+from cobaya.conventions import Const
+from cobaya.typing import empty_dict
 
-H_units_conv_factor = {"1/Mpc": 1, "km/s/Mpc": _c_km_s}
+H_units_conv_factor = {"1/Mpc": 1, "km/s/Mpc": Const.c_km_s}
 
 
 class BoltzmannBase(Theory):
@@ -426,8 +427,8 @@ class BoltzmannBase(Theory):
 
         ``params_info`` should contain preferably the slow parameters only.
         """
-        from cobaya.cosmo_input import _get_best_covmat
-        return _get_best_covmat(self.packages_path, params_info, likes_info)
+        from cobaya.cosmo_input import get_best_covmat
+        return get_best_covmat(self.packages_path, params_info, likes_info)
 
 
 class PowerSpectrumInterpolator(RectBivariateSpline):

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -183,7 +183,7 @@ from cobaya.install import download_github_release, check_gcc_version, NotInstal
 from cobaya.tools import getfullargspec, get_class_methods, get_properties, load_module, \
     VersionCheckError, str_to_list
 from cobaya.theory import HelperTheory
-from cobaya.conventions import _requires, OptionalArrayLike
+from cobaya.typing import OptionalArrayLike
 
 
 # Result collector
@@ -255,7 +255,7 @@ class camb(BoltzmannBase):
 
         self.nonlin_args, self.nonlin_params = self._extract_params(nonlin.set_params)
 
-        self.requires = str_to_list(getattr(self, _requires, []))
+        self.requires = str_to_list(getattr(self, "requires", []))
         self._transfer_requires = [p for p in self.requires if
                                    p not in self.get_can_support_params()]
         self.requires = [p for p in self.requires if p not in self._transfer_requires]
@@ -676,6 +676,7 @@ class camb(BoltzmannBase):
         params_derived = list(get_class_methods(self.camb.CAMBparams))
         params_derived.remove("custom_source_names")
         fields = []
+        # noinspection PyProtectedMember
         for f, tp in self.camb.CAMBparams._fields_:
             if tp is ctypes.c_double and 'max_eta_k' not in f \
                     and f not in ['Alens', 'num_nu_massless']:
@@ -780,7 +781,7 @@ class camb(BoltzmannBase):
         self._camb_transfers = CambTransfers(self, 'camb.transfers',
                                              dict(stop_at_error=self.stop_at_error),
                                              timing=self.timer)
-        setattr(self._camb_transfers, _requires, self._transfer_requires)
+        setattr(self._camb_transfers, "requires", self._transfer_requires)
         return {'camb.transfers': self._camb_transfers}
 
     def get_speed(self):

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -20,7 +20,7 @@ from importlib import import_module
 from copy import deepcopy
 from packaging import version
 from itertools import permutations
-from typing import Mapping, Sequence, Any, List
+from typing import Mapping, Sequence, Any, List, TypeVar
 from numbers import Number
 from types import ModuleType
 from inspect import cleandoc, getfullargspec
@@ -33,10 +33,8 @@ with warnings.catch_warnings():
     from fuzzywuzzy import process as fuzzy_process
 
 # Local
-from cobaya import __obsolete__
-from cobaya.conventions import _cobaya_package, subfolders, partag, kinds, _packages_path, \
-    _packages_path_config_file, _packages_path_env, _packages_path_arg, \
-    _dump_sort_cosmetic
+from cobaya.conventions import cobaya_package, subfolders, kinds, \
+    packages_path_config_file, packages_path_env, packages_path_arg, dump_sort_cosmetic
 from cobaya.log import LoggedError
 
 # Set up logger
@@ -91,7 +89,7 @@ def get_base_classes():
     from cobaya.likelihood import Likelihood
     from cobaya.theory import Theory
     from cobaya.sampler import Sampler
-    return {kinds.sampler: Sampler, kinds.likelihood: Likelihood, kinds.theory: Theory}
+    return {"sampler": Sampler, "likelihood": Likelihood, "theory": Theory}
 
 
 def get_kind(name, allow_external=True):
@@ -212,7 +210,7 @@ def get_class(name, kind=None, None_if_not_found=False, allow_external=True,
             return return_class(module_name)
         elif allow_internal:
             internal_module_name = get_internal_class_component_name(module_name, kind)
-            return return_class(internal_module_name, package=_cobaya_package)
+            return return_class(internal_module_name, package=cobaya_package)
         else:
             raise Exception()
     except:
@@ -344,7 +342,7 @@ def get_external_function(string_or_function, name=None):
     Returns the function.
     """
     if isinstance(string_or_function, Mapping):
-        string_or_function = string_or_function.get(partag.value)
+        string_or_function = string_or_function.get("value")
     if isinstance(string_or_function, str):
         try:
             scope = globals()
@@ -499,12 +497,13 @@ def load_DataFrame(file_name, skip=0, root_file_name=None):
             # try getdist format chains with .paramnames file
             if root_file_name and os.path.exists(root_file_name + '.paramnames'):
                 from getdist import ParamNames
-                from cobaya.conventions import _chi2, _separator
+                from cobaya.conventions import OutPar, derived_par_name_separator
                 names = ParamNames(root_file_name + '.paramnames').list()
                 for i, name in enumerate(names):
-                    if name.startswith(_chi2 + '_') and not name.startswith(
-                            _chi2 + _separator):
-                        names[i] = name.replace(_chi2 + '_', _chi2 + _separator)
+                    if name.startswith(OutPar.chi2 + '_') and not name.startswith(
+                            OutPar.chi2 + derived_par_name_separator):
+                        names[i] = name.replace(OutPar.chi2 + '_',
+                                                OutPar.chi2 + derived_par_name_separator)
                 cols = ['weight', 'minuslogpost'] + names
                 inp.seek(0)
             else:
@@ -555,7 +554,7 @@ def get_scipy_1d_pdf(info):
                                "Check documentation for prior specification.")
     # What distribution?
     try:
-        dist = info2.pop(partag.dist).lower()
+        dist = info2.pop("dist").lower()
     # Not specified: uniform by default
     except KeyError:
         dist = "uniform"
@@ -612,6 +611,7 @@ def _fast_norm_logpdf(self, x):
     if not hasattr(self, "_cobaya_mlogscale"):
         self._cobaya_mlogscale = -np.log(self.kwds["scale"])
     x_ = (np.array(x) - self.kwds["loc"]) / self.kwds["scale"]
+    # noinspection PyProtectedMember
     return self.dist._logpdf(x_) + self._cobaya_mlogscale
 
 
@@ -700,7 +700,7 @@ def create_banner(msg, symbol="*", length=None):
     """
     msg_clean = cleandoc(msg)
     if not length:
-        length = max([len(line) for line in msg_clean.split("\n")])
+        length = max(len(line) for line in msg_clean.split("\n"))
     return symbol * length + "\n" + msg_clean + "\n" + symbol * length + "\n"
 
 
@@ -710,6 +710,7 @@ def warn_deprecation_version(logger=None):
     Unless intentionally doing so, please, update asap to the latest version
     (e.g. with ``python -m pip install cobaya --upgrade``).
     """
+    from cobaya import __obsolete__
     if __obsolete__:
         for line in create_banner(msg).split("\n"):
             getattr(logger, "warning", (lambda x: print("*WARNING*", x)))(line)
@@ -742,7 +743,10 @@ def has_non_yaml_reproducible(info):
     return False
 
 
-def deepcopy_where_possible(base):
+_R = TypeVar('_R')
+
+
+def deepcopy_where_possible(base: _R) -> _R:
     """
     Deepcopies an object whenever possible. If the object cannot be copied, returns a
     reference to the original object (this applies recursively to keys and values of
@@ -858,7 +862,7 @@ def get_translated_params(params_info, params_list):
     """
     translations = {}
     for p, pinfo in params_info.items():
-        renames = {p}.union(str_to_list(pinfo.get(partag.renames, [])))
+        renames = {p}.union(str_to_list(pinfo.get("renames", [])))
         try:
             trans = next(r for r in renames if r in params_list)
             translations[p] = trans
@@ -931,7 +935,7 @@ def load_config_file():
     from cobaya.yaml import yaml_load_file
     try:
         return yaml_load_file(
-            os.path.join(get_config_path(), _packages_path_config_file))
+            os.path.join(get_config_path(), packages_path_config_file))
     except:
         return {}
 
@@ -947,7 +951,7 @@ def write_config_file(config_info, append=True):
         if append:
             info.update(load_config_file())
         info.update(config_info)
-        yaml_dump_file(os.path.join(get_config_path(), _packages_path_config_file),
+        yaml_dump_file(os.path.join(get_config_path(), packages_path_config_file),
                        info, error_if_exists=False)
     except Exception as e:
         log.error("Could not write the external packages installation path into the "
@@ -959,7 +963,7 @@ def load_packages_path_from_config_file():
     Returns the external packages path stored in the config file,
     or `None` if it can't be found.
     """
-    return load_config_file().get(_packages_path)
+    return load_config_file().get("packages_path")
 
 
 def write_packages_path_in_config_file(packages_path):
@@ -968,7 +972,7 @@ def write_packages_path_in_config_file(packages_path):
 
     Relative paths are converted into absolute ones.
     """
-    write_config_file({_packages_path: os.path.abspath(packages_path)})
+    write_config_file({"packages_path": os.path.abspath(packages_path)})
 
 
 def resolve_packages_path(infos=None):
@@ -983,7 +987,7 @@ def resolve_packages_path(infos=None):
         in the config file.
     
         If no path at all could be found, returns `None`.
-        """ % _packages_path_env
+        """ % packages_path_env
     if not infos:
         infos = []
     elif isinstance(infos, Mapping):
@@ -992,7 +996,7 @@ def resolve_packages_path(infos=None):
     # BEHAVIOUR TO BE REPLACED BY ERROR:
     [check_deprecated_modules_path(info) for info in infos]
     # END OF DEPRECATION BLOCK
-    paths = set(p for p in [info.get(_packages_path) for info in infos] if p)
+    paths = set(p for p in [info.get("packages_path") for info in infos] if p)
     if len(paths) == 1:
         return list(paths)[0]
     elif len(paths) > 1:
@@ -1000,15 +1004,15 @@ def resolve_packages_path(infos=None):
             log, "More than one packages installation path defined in the given infos. "
                  "Cannot resolve a unique one to use. "
                  "Maybe specify one via a command line argument '-%s [...]'?",
-            _packages_path_arg[0])
-    path_env = os.environ.get(_packages_path_env)
+            packages_path_arg[0])
+    path_env = os.environ.get(packages_path_env)
     # MARKED FOR DEPRECATION IN v3.0
     old_env = "COBAYA_MODULES"
     path_old_env = os.environ.get(old_env)
     if path_old_env and not path_env:
         log.warning("*DEPRECATION*: The env var %r will be deprecated in favor of %r in "
                     "the next version. Please, use that one instead.",
-                    old_env, _packages_path_env)
+                    old_env, packages_path_env)
         # BEHAVIOUR TO BE REPLACED BY ERROR:
         path_env = path_old_env
     # END OF DEPRECATION BLOCK -- CONTINUES BELOW!
@@ -1022,9 +1026,9 @@ def sort_cosmetic(info):
     """
         Returns a sorted version of the given info dict, re-ordered as %r, and finally the
         rest of the blocks/options.
-        """ % _dump_sort_cosmetic
+        """ % dump_sort_cosmetic
     sorted_info = dict()
-    for k in _dump_sort_cosmetic:
+    for k in dump_sort_cosmetic:
         if k in info:
             sorted_info[k] = info[k]
     sorted_info.update({k: v for k, v in info.items() if k not in sorted_info})
@@ -1036,8 +1040,8 @@ def check_deprecated_modules_path(info):
     if info.get("modules"):
         log.warning("*DEPRECATION*: The input field 'modules' will be deprecated in "
                     "favor of %r in the next version. Please, use that one instead.",
-                    _packages_path)
+                    "packages_path")
         # BEHAVIOUR TO BE REPLACED BY ERROR:
-        if not info.get(_packages_path):
-            info[_packages_path] = info["modules"]
+        if not info.get("packages_path"):
+            info["packages_path"] = info["modules"]
 # END OF DEPRECATION BLOCK

--- a/cobaya/typing.py
+++ b/cobaya/typing.py
@@ -1,0 +1,100 @@
+from typing import Dict, Any, Optional, Union, Sequence, Type, Tuple, List
+import numpy as np
+from types import MappingProxyType
+
+# an immutable empty dict (e.g. for argument defaults)
+empty_dict = MappingProxyType({})
+
+InfoDict = Dict[str, Any]
+LikeDict = InfoDict
+TheoryDict = InfoDict
+SamplerDict = InfoDict
+
+ParamValuesDict = Dict[str, Optional[float]]
+TheoriesDict = Dict[str, Union[None, TheoryDict, Type]]
+LikesDict = Dict[str, Union[None, LikeDict, Type]]
+SamplersDict = Dict[str, Optional[SamplerDict]]
+PriorsDict = Dict[str, Union[str, callable]]
+
+partags = {"prior", "ref", "proposal", "value", "drop",
+           "derived", "latex", "renames", "min", "max"}
+
+try:
+    # noinspection PyUnresolvedReferences
+    from typing import TypedDict
+except ImportError:
+    InputDict = InfoDict
+    ParamDict = InfoDict
+    ModelDict = InfoDict
+    PostDict = InfoDict
+    ParamsDict = Dict[str, Union[ParamDict, None, str, float, List[float]]]
+else:
+
+    class SciPyDistDict(TypedDict):
+        dist: str
+        loc: float
+        scale: float
+
+
+    class SciPyMinMaxDict(TypedDict, total=False):
+        dist: str  # default uniform
+        min: float
+        max: float
+
+
+    class ParamDict(TypedDict, total=False):
+        value: Union[float, callable, str]
+        derived: Union[bool, str, callable]
+        prior: Union[None, Tuple[float, float], SciPyDistDict, SciPyMinMaxDict]
+        ref: Union[None, Tuple[float, float], SciPyDistDict, SciPyMinMaxDict]
+        proposal: Optional[float]
+        renames: Union[str, Sequence[str]]
+        latex: str
+        drop: bool  # true if parameter should not be available for assignment to theories
+        min: float  # hard bounds (does not affect prior)
+        max: float
+
+
+    # partags = set(ParamDict.__annotations__)
+
+    ParamsDict = Dict[str, Union[ParamDict, None, str, float, List[float]]]
+
+
+    class ModelDict(TypedDict, total=False):
+        theory: TheoriesDict
+        likelihood: LikesDict
+        prior: PriorsDict
+        params: ParamsDict
+
+
+    class PostDict(TypedDict, total=False):
+        add: Optional[ModelDict]
+        remove: Optional[ModelDict]
+        output: Optional[str]
+        suffix: Optional[str]
+        skip: Union[None, float, int]
+        thin: Optional[int]
+        packages_path: Optional[str]
+
+
+    class InputDict(ModelDict, total=False):
+        sampler: SamplersDict
+        post: Optional[PostDict]
+        force: bool
+        debug: bool
+        debug_file: Optional[str]
+        resume: bool
+        stop_at_error: bool
+        test: bool
+        timing: bool
+        packages_path: Optional[str]
+        output: Optional[str]
+        version: Optional[Union[str, InfoDict]]
+
+try:
+    from numpy.typing import ArrayLike
+except ImportError:
+    ArrayLike = Union[Sequence, np.ndarray]
+
+OptionalArrayLike = Optional[ArrayLike]
+ArrayOrFloat = Union[float, ArrayLike]

--- a/cobaya/yaml.py
+++ b/cobaya/yaml.py
@@ -22,7 +22,7 @@ from typing import Mapping, Optional
 
 # Local
 from cobaya.tools import prepare_comment, recursive_update
-from cobaya.conventions import _yaml_extensions
+from cobaya.conventions import Extension
 
 
 # Exceptions #############################################################################
@@ -70,7 +70,7 @@ def _construct_defaults(loader, node):
     for dfile in defaults_files:
         dfilename = os.path.abspath(os.path.join(folder, dfile))
         try:
-            dfilename += next(ext for ext in [""] + list(_yaml_extensions)
+            dfilename += next(ext for ext in [""] + list(Extension.yamls)
                               if (os.path.basename(dfilename) + ext
                                   in os.listdir(os.path.dirname(dfilename))))
         except StopIteration:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ subfolders = {"likelihood": "likelihoods", "sampler": "samplers", "theory": "the
 
 
 def find_version():
-    init_file = open(path.join(path.dirname(__file__), 'cobaya/__init__.py')).read()
+    init_file = open(path.join(path.dirname(__file__), 'cobaya', '__init__.py')).read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", init_file, re.M)
     if version_match:
         return version_match.group(1)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup, find_packages
 from os import path
 from itertools import chain
 import re
-from cobaya.conventions import subfolders
+
+subfolders = {"likelihood": "likelihoods", "sampler": "samplers", "theory": "theories"}
 
 
 def find_version():

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-# To use a consistent encoding
 from os import path
 from itertools import chain
-# Package data and conventions
-from cobaya import __author__, __version__, __url__
+import re
 from cobaya.conventions import subfolders
+
+
+def find_version():
+    init_file = open(path.join(path.dirname(__file__), 'cobaya/__init__.py')).read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", init_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 
 # Get the long description from the README file
@@ -21,16 +27,16 @@ def get_long_description():
 
 setup(
     name='cobaya',
-    version=__version__,
+    version=find_version(),
     description='Code for Bayesian Analysis',
     long_description=get_long_description(),
-    url=__url__,
+    url="https://cobaya.readthedocs.io",
     project_urls={
         'Source': 'https://github.com/CobayaSampler/cobaya',
         'Tracker': 'https://github.com/CobayaSampler/cobaya/issues',
         'Licensing': 'https://github.com/CobayaSampler/cobaya/blob/master/LICENCE.txt'
     },
-    author=__author__,
+    author="Jesus Torrado and Antony Lewis",
     license='LGPL',
     zip_safe=False,
     classifiers=[

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ def is_travis():
     return os.environ.get('TRAVIS') == 'true'
 
 
-def process_packages_path(packages_path):
+def process_packages_path(packages_path) -> str:
     packages_path = os.getenv('COBAYA_FORCE_PACKAGES_PATH', packages_path)
     if not packages_path:
         if os.path.exists(os.path.join(os.getcwd(), '..', 'packages_path')):

--- a/tests/common_external.py
+++ b/tests/common_external.py
@@ -11,15 +11,14 @@ from copy import deepcopy
 import scipy.stats as stats
 
 # Local
-from cobaya.conventions import _output_prefix, _params, _prior, kinds, _updated_suffix, \
-    _get_chi2_name, _input_params, _output_params, _external
+from cobaya.conventions import FileSuffix, get_chi2_name
 from cobaya.run import run
 from cobaya.yaml import yaml_load
 from cobaya.tools import getfullargspec
 from cobaya.likelihood import Likelihood
 from cobaya import mpi
 
-# Definition of external (log)pdf's
+# Definition of external (log)pdfs
 
 half_ring_str = "lambda x, y: stats.norm.logpdf(np.sqrt(x**2 + y**2), loc=0.5, scale=0.1)"
 half_ring_func = lambda x, y: eval(half_ring_str)(x, y)
@@ -58,43 +57,43 @@ def body_of_test(info_logpdf, kind, tmpdir, derived=False, manual=False):
             shutil.rmtree(prefix)
     # build updated info
     info = {
-        _output_prefix: prefix,
-        _params: {
-            "x": {_prior: {"min": 0, "max": 1}, "proposal": 0.05},
-            "y": {_prior: {"min": -1, "max": 1}, "proposal": 0.05}},
-        kinds.sampler: {
+        "output": prefix,
+        "params": {
+            "x": {"prior": {"min": 0, "max": 1}, "proposal": 0.05},
+            "y": {"prior": {"min": -1, "max": 1}, "proposal": 0.05}},
+        "sampler": {
             "mcmc": {"max_samples": (10 if not manual else 5000),
                      "learn_proposal": False}}
     }
     if derived:
-        info[_params].update({"r": {"min": 0, "max": 1},
-                              "theta": {"min": -0.5, "max": 0.5}})
+        info["params"].update({"r": {"min": 0, "max": 1},
+                               "theta": {"min": -0.5, "max": 0.5}})
     # Complete according to kind
-    if kind == _prior:
-        info.update({_prior: info_logpdf,
-                     kinds.likelihood: {"one": None}})
-    elif kind == kinds.likelihood:
-        info.update({kinds.likelihood: info_logpdf})
+    if kind == "prior":
+        info.update({"prior": info_logpdf,
+                     "likelihood": {"one": None}})
+    elif kind == "likelihood":
+        info.update({"likelihood": info_logpdf})
     else:
         raise ValueError("Kind of test not known.")
     # If there is an ext function that is not a string, don't write output!
     stringy = {k: v for k, v in info_logpdf.items() if isinstance(v, str)}
     if stringy != info_logpdf:
-        info.pop(_output_prefix)
+        info.pop("output")
     # Run
     updated_info, sampler = run(info)
     products = sampler.products()
     # Test values
     logprior_base = - np.log(
-        (info[_params]["x"][_prior]["max"] -
-         info[_params]["x"][_prior]["min"]) *
-        (info[_params]["y"][_prior]["max"] -
-         info[_params]["y"][_prior]["min"]))
+        (info["params"]["x"]["prior"]["max"] -
+         info["params"]["x"]["prior"]["min"]) *
+        (info["params"]["y"]["prior"]["max"] -
+         info["params"]["y"]["prior"]["min"]))
     logps = {name: logpdf(**{arg: products["sample"][arg].values for arg in
                              getfullargspec(logpdf)[0]}) for name, logpdf in
              {"half_ring": half_ring_func, "gaussian_y": gaussian_func}.items()}
-    # Test #1: values of logpdf's
-    if kind == _prior:
+    # Test #1: values of logpdfs
+    if kind == "prior":
         columns_priors = [c for c in products["sample"].data.columns
                           if c.startswith("minuslogprior")]
         assert np.allclose(
@@ -108,10 +107,10 @@ def body_of_test(info_logpdf, kind, tmpdir, derived=False, manual=False):
                                                   'y': products["sample"]["y"][0]}),
                           -products["sample"]["minuslogprior"][0]), (
             "The value of the total prior is not reproduced from mode.logprior.")
-    elif kind == kinds.likelihood:
-        for lik in info[kinds.likelihood]:
+    elif kind == "likelihood":
+        for lik in info["likelihood"]:
             assert np.allclose(-2 * logps[lik],
-                               products["sample"][_get_chi2_name(lik)].values), (
+                               products["sample"][get_chi2_name(lik)].values), (
                     "The value of the likelihood '%s' is not reproduced correctly." % lik)
     assert np.allclose(logprior_base + sum(logps[p] for p in info_logpdf),
                        -products["sample"]["minuslogpost"].values), (
@@ -125,35 +124,35 @@ def body_of_test(info_logpdf, kind, tmpdir, derived=False, manual=False):
                    for p, v in derived_values.items()), (
             "The value of the derived parameters is not reproduced correctly.")
     # Test updated info -- scripted
-    if kind == _prior:
-        assert info[_prior] == updated_info[_prior], (
+    if kind == "prior":
+        assert info["prior"] == updated_info["prior"], (
             "The prior information has not been updated correctly.")
-    elif kind == kinds.likelihood:
+    elif kind == "likelihood":
         # Transform the likelihood info to the "external" convention and add defaults
-        info_likelihood = deepcopy(info[kinds.likelihood])
+        info_likelihood = deepcopy(info["likelihood"])
         for lik, value in list(info_likelihood.items()):
             if not hasattr(value, "get"):
-                info_likelihood[lik] = {_external: value}
+                info_likelihood[lik] = {"external": value}
             info_likelihood[lik].update({k: v for k, v in
                                          Likelihood.get_defaults().items()
                                          if k not in info_likelihood[lik]})
-            for k in [_input_params, _output_params]:
+            for k in ["input_params", "output_params"]:
                 info_likelihood[lik].pop(k, None)
-                updated_info[kinds.likelihood][lik].pop(k)
-        assert info_likelihood == updated_info[kinds.likelihood], (
+                updated_info["likelihood"][lik].pop(k)
+        assert info_likelihood == updated_info["likelihood"], (
                 "The likelihood information has not been updated correctly\n %r vs %r"
-                % (info_likelihood, updated_info[kinds.likelihood]))
+                % (info_likelihood, updated_info["likelihood"]))
     # Test updated info -- yaml
     # For now, only if ALL external pdfs are given as strings,
     # since the YAML load fails otherwise
     if stringy == info_logpdf:
-        updated_output_file = os.path.join(prefix, _updated_suffix + ".yaml")
+        updated_output_file = os.path.join(prefix, FileSuffix.updated + ".yaml")
         with open(updated_output_file) as updated:
             updated_yaml = yaml_load("".join(updated.readlines()))
         for k, v in stringy.items():
             to_test = updated_yaml[kind][k]
-            if kind == kinds.likelihood:
-                to_test = to_test[_external]
+            if kind == "likelihood":
+                to_test = to_test["external"]
             assert to_test == info_logpdf[k], (
                 "The updated external pdf info has not been written correctly.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,13 @@ from cobaya import mpi
 
 # Paths ##################################################################################
 
-from cobaya.conventions import _packages_path_env, _packages_path_arg_posix, \
-    _test_skip_env
+from cobaya.conventions import packages_path_env, packages_path_arg_posix, \
+    test_skip_env
 from cobaya.tools import resolve_packages_path
 
 
 def pytest_addoption(parser):
-    parser.addoption("--" + _packages_path_arg_posix, action="store",
+    parser.addoption("--" + packages_path_arg_posix, action="store",
                      default=resolve_packages_path(),
                      help="Path to folder of automatic installation of packages")
     parser.addoption("--skip-not-installed", action="store_true",
@@ -24,22 +24,22 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def packages_path(request):
-    cmd_packages_path = request.config.getoption("--" + _packages_path_arg_posix, None)
+    cmd_packages_path = request.config.getoption("--" + packages_path_arg_posix, None)
     if not cmd_packages_path:
         raise ValueError("Could not determine packages installation path. "
                          "Either define it in the env variable %r, or pass it as an "
                          "argument with `--%s`" %
-                         (_packages_path_env, _packages_path_arg_posix))
+                         (packages_path_env, packages_path_arg_posix))
     return cmd_packages_path
 
 
 # Skip certain keywords ##################################################################
 
 def pytest_collection_modifyitems(config, items):
-    skip_keywords = os.environ.get(_test_skip_env, "").replace(",", " ").split()
+    skip_keywords = os.environ.get(test_skip_env, "").replace(",", " ").split()
     for k in skip_keywords:
         skip_mark = pytest.mark.skip(
-            reason="'%s' skipped by envvar '%s'" % (k, _test_skip_env))
+            reason="'%s' skipped by envvar '%s'" % (k, test_skip_env))
         for item in items:
             if any((k.lower() in x) for x in [item.name.lower(), item.keywords]):
                 item.add_marker(skip_mark)

--- a/tests/cosmo_timing.ipynb
+++ b/tests/cosmo_timing.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import os\n",
     "\n",
-    "from cobaya.conventions import _likelihood, _theory, _timing, _path_install, _params\n",
+    "from cobaya.conventions import _likelihood, _theory, "timing", _path_install, "params"\n",
     "from cobaya.tools import recursive_update, get_modules\n",
     "from cobaya.cosmo_input import create_input, planck_base_model\n",
     "from cobaya.model import get_model\n",
@@ -38,10 +38,10 @@
     "    \"tau\": 0.0543}\n",
     "\n",
     "info = create_input(planck_names=True, theory=list(info_theory)[0], **planck_base_model)\n",
-    "info[_params][\"H0\"] = {\"prior\": {\"min\": 0, \"max\": 100}}\n",
-    "for p in list(info[_params]):\n",
+    "info["params"][\"H0\"] = {\"prior\": {\"min\": 0, \"max\": 100}}\n",
+    "for p in list(info["params"]):\n",
     "    if p.startswith(\"theta\") or p.startswith(\"cosmomc\"):\n",
-    "        info[_params].pop(p)\n",
+    "        info["params"].pop(p)\n",
     "info = recursive_update(info, {_theory: info_theory})\n",
     "\n",
     "# Constrain to only:\n",
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "info[_timing] = True\n",
+    "info["timing"] = True\n",
     "info[_path_install] = modules\n",
     "model = get_model(info)"
    ]

--- a/tests/test_cosmo_H0.py
+++ b/tests/test_cosmo_H0.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
 
-from cobaya.conventions import kinds, _params, _packages_path
 from cobaya.run import run
 from cobaya.yaml import yaml_load_file
 from .common import process_packages_path
@@ -24,32 +23,32 @@ def test_H0_riess201903(packages_path, skip_not_installed):
 def test_H0_docs(packages_path, skip_not_installed):
     like_info = yaml_load_file(os.path.join(
         os.path.dirname(__file__), "../docs/src_examples/H0/custom_likelihood.yaml"))
-    like_name = list(like_info[kinds.likelihood])[0]
-    like_info[kinds.likelihood][like_name]["external"] = \
-        like_info[kinds.likelihood][like_name]["external"].replace(
+    like_name = list(like_info["likelihood"])[0]
+    like_info["likelihood"][like_name]["external"] = \
+        like_info["likelihood"][like_name]["external"].replace(
             "mu_H0", str(fiducial_H0))
-    like_info[kinds.likelihood][like_name]["external"] = \
-        like_info[kinds.likelihood][like_name]["external"].replace(
+    like_info["likelihood"][like_name]["external"] = \
+        like_info["likelihood"][like_name]["external"].replace(
             "sigma_H0", str(fiducial_H0_std))
-    body_of_test(packages_path, like_info=like_info[kinds.likelihood],
+    body_of_test(packages_path, like_info=like_info["likelihood"],
                  skip_not_installed=skip_not_installed)
 
 
 def body_of_test(packages_path, like_name=None, like_info=None, skip_not_installed=False):
-    info = {_packages_path: process_packages_path(packages_path),
-            kinds.sampler: {"evaluate": None}}
+    info = {"packages_path": process_packages_path(packages_path),
+            "sampler": {"evaluate": None}}
     if like_name:
-        info[kinds.likelihood] = {like_name: None}
+        info["likelihood"] = {like_name: None}
     elif like_info:
-        info[kinds.likelihood] = like_info
+        info["likelihood"] = like_info
         like_name = list(like_info)[0]
-    info[_params] = {"H0": fiducial_H0}
+    info["params"] = {"H0": fiducial_H0}
     updated_info, sampler = install_test_wrapper(skip_not_installed, run, info)
     products = sampler.products()
     # The default values for .get are for the _docs_ test
-    mean = updated_info[kinds.likelihood][like_name].get("H0_mean", fiducial_H0)
-    std = updated_info[kinds.likelihood][like_name].get("H0_std", fiducial_H0_std)
+    mean = updated_info["likelihood"][like_name].get("H0_mean", fiducial_H0)
+    std = updated_info["likelihood"][like_name].get("H0_std", fiducial_H0_std)
     reference_chi2 = (fiducial_H0 - mean) ** 2 / std ** 2
     computed_chi2 = (
-        products["sample"]["chi2__" + list(info[kinds.likelihood])[0]].values[0])
+        products["sample"]["chi2__" + list(info["likelihood"])[0]].values[0])
     assert np.allclose(computed_chi2, reference_chi2)

--- a/tests/test_cosmo_bao.py
+++ b/tests/test_cosmo_bao.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 import pytest
 
-from cobaya.conventions import _class_name
 from cobaya.tools import get_class
 
 from .test_cosmo_planck_2015 import params_lowTEB_highTTTEEE, derived_lowTEB_highTTTEEE
@@ -16,7 +15,7 @@ def test_generic_camb(packages_path, skip_not_installed):
     chi2_generic[like_rename] = chi2_generic.pop(like)
     likelihood_defaults = get_class(like).get_defaults()
     likelihood_defaults.pop("path")
-    likelihood_defaults[_class_name] = "bao.generic"
+    likelihood_defaults["class"] = "bao.generic"
     info_likelihood = {like_rename: likelihood_defaults}
     info_theory = {"camb": None}
     body_of_test(packages_path, best_fit, info_likelihood, info_theory,

--- a/tests/test_cosmo_docs_likelihood.py
+++ b/tests/test_cosmo_docs_likelihood.py
@@ -5,7 +5,6 @@ to make sure it remains up to date.
 
 import os
 
-from cobaya.conventions import _packages_path
 from .common import process_packages_path
 from .conftest import install_test_wrapper
 
@@ -13,7 +12,6 @@ tests_folder = os.path.dirname(os.path.realpath(__file__))
 docs_folder = os.path.join(tests_folder, "..", "docs")
 docs_src_folder = os.path.join(docs_folder, "src_examples", "cosmo_external_likelihood")
 docs_img_folder = os.path.join(docs_folder, "img")
-
 
 
 def test_cosmo_docs_likelihood_camb(packages_path, skip_not_installed):
@@ -26,7 +24,7 @@ def test_cosmo_docs_likelihood_camb(packages_path, skip_not_installed):
         os.chdir(docs_src_folder)
         lines = open(os.path.join(docs_src_folder, "1_fiducial_Cl.py")).readlines()
         for i, line in enumerate(lines):
-            if line.startswith(_packages_path):
+            if line.startswith("packages_path"):
                 lines[i] = "packages_path = '%s'" % packages_path.strip("\'\"")
         globals_example = {}
         install_test_wrapper(skip_not_installed, exec, "\n".join(lines), globals_example)

--- a/tests/test_cosmo_docs_model.py
+++ b/tests/test_cosmo_docs_model.py
@@ -7,7 +7,6 @@ import os
 import numpy as np
 from io import StringIO
 
-from cobaya.conventions import _packages_path
 from .common import process_packages_path, stdout_redirector
 from .conftest import install_test_wrapper
 
@@ -28,7 +27,7 @@ def test_cosmo_docs_model_classy(packages_path, skip_not_installed):
         os.chdir(docs_src_folder)
         globals_example = {}
         exec(open(os.path.join(docs_src_folder, "1.py")).read(), globals_example)
-        globals_example["info"][_packages_path] = packages_path
+        globals_example["info"]["packages_path"] = packages_path
         install_test_wrapper(
             skip_not_installed, exec,
             open(os.path.join(docs_src_folder, "2.py")).read(), globals_example)
@@ -56,16 +55,16 @@ def test_cosmo_docs_model_classy(packages_path, skip_not_installed):
                      globals_example)
             except:
                 assert False, "File %s failed." % filename
-    #        if test_figs:
-    #            # Compare plots
-    #            pre = "cosmo_model_"
-    #            for filename, imgname in zip(["4.py", "5.py"], ["cltt.png", "omegacdm.png"]):
-    #                exec(open(os.path.join(docs_src_folder, filename)).read(), globals_example)
-    #                old_img = imread(os.path.join(docs_img_folder, pre + imgname)).astype(float)
-    #                new_img = imread(imgname).astype(float)
-    #                npixels = (lambda x: x.shape[0] + x.shape[1])(old_img)
-    #                assert np.count_nonzero(old_img == new_img) / (4 * npixels) >= pixel_tolerance, (
-    #                        "Images '%s' are too different!" % imgname)
+        #        if test_figs:
+        #            # Compare plots
+        #            pre = "cosmo_model_"
+        #            for filename, imgname in zip(["4.py", "5.py"], ["cltt.png", "omegacdm.png"]):
+        #                exec(open(os.path.join(docs_src_folder, filename)).read(), globals_example)
+        #                old_img = imread(os.path.join(docs_img_folder, pre + imgname)).astype(float)
+        #                new_img = imread(imgname).astype(float)
+        #                npixels = (lambda x: x.shape[0] + x.shape[1])(old_img)
+        #                assert np.count_nonzero(old_img == new_img) / (4 * npixels) >= pixel_tolerance, (
+        #                        "Images '%s' are too different!" % imgname)
         # Passing the model to a sampler
         exec(open(os.path.join(docs_src_folder, "6.py")).read(), globals_example)
     finally:

--- a/tests/test_cosmo_multi_theory.py
+++ b/tests/test_cosmo_multi_theory.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from cobaya.model import get_model
 from cobaya.theory import Theory
 from cobaya.likelihood import LikelihoodInterface, Likelihood
-from cobaya.conventions import empty_dict, InfoDict
+from cobaya.typing import InputDict, empty_dict
 from .common import process_packages_path
 from .conftest import install_test_wrapper
 from .test_cosmo_camb import get_camb
@@ -60,17 +60,17 @@ camb_params = {
 
 bbn_table = "PRIMAT_Yp_DH_Error.dat"
 debug = True
-info: InfoDict = {'likelihood': {'cmb': cmb_likelihood_info},
-                  'theory': {
-                      'camb': {"extra_args": {"lens_potential_accuracy": 1},
-                               "requires": ['YHe', 'ombh2']},
-                      'bbn': {'external': BBN, 'provides': ['YHe']}},
-                  'params': camb_params,
-                  'debug': debug, 'stop_at_error': True}
+info: InputDict = {'likelihood': {'cmb': cmb_likelihood_info},
+                   'theory': {
+                       'camb': {"extra_args": {"lens_potential_accuracy": 1},
+                                "requires": ['YHe', 'ombh2']},
+                       'bbn': {'external': BBN, 'provides': ['YHe']}},
+                   'params': camb_params,
+                   'debug': debug, 'stop_at_error': True}
 
-info2: InfoDict = {'likelihood': {'cmb': cmb_likelihood_info},
-                   'theory': {'camb': {"requires": ['YHe', 'ombh2']}, 'bbn': BBN2},
-                   'params': camb_params, 'debug': debug}
+info2: InputDict = {'likelihood': {'cmb': cmb_likelihood_info},
+                    'theory': {'camb': {"requires": ['YHe', 'ombh2']}, 'bbn': BBN2},
+                    'params': camb_params, 'debug': debug}
 
 
 def test_bbn_yhe(packages_path, skip_not_installed):
@@ -138,19 +138,20 @@ class BBN_with_theory_errors(BBN, LikelihoodInterface):
         state['logp'] = -params_values_dict['BBN_delta'] ** 2 / 2
 
 
-info_error = {'likelihood': dict([('cmb', cmb_likelihood_info),
-                                  ('BBN', BBN_likelihood)]),
-              'theory': {'camb': {"requires": ['YHe', 'ombh2']}},
-              'params': dict(YHe={'prior': {'min': 0, 'max': 1}}, **camb_params),
-              'debug': debug}
+info_error: InputDict = {'likelihood': dict([('cmb', cmb_likelihood_info),
+                                             ('BBN', BBN_likelihood)]),
+                         'theory': {'camb': {"requires": ['YHe', 'ombh2']}},
+                         'params': dict(YHe={'prior': {'min': 0, 'max': 1}},
+                                        **camb_params),
+                         'debug': debug}
 
-info_error2 = {'likelihood': {'cmb': cmb_likelihood_info,
-                              'BBN': {'external': BBN_with_theory_errors,
-                                      'provides': 'YHe'}},
-               'theory': {'camb': {"requires": ['YHe', 'ombh2']}},
-               'params': dict(BBN_delta={'prior': {'min': -5, 'max': 5}},
-                              **camb_params),
-               'debug': debug}
+info_error2: InputDict = {'likelihood': {'cmb': cmb_likelihood_info,
+                                         'BBN': {'external': BBN_with_theory_errors,
+                                                 'provides': 'YHe'}},
+                          'theory': {'camb': {"requires": ['YHe', 'ombh2']}},
+                          'params': dict(BBN_delta={'prior': {'min': -5, 'max': 5}},
+                                         **camb_params),
+                          'debug': debug}
 
 
 def test_bbn_likelihood(packages_path, skip_not_installed):
@@ -208,20 +209,20 @@ class Pklike(Likelihood):
         return {'Cl': {'tt': 1000}, 'CAMBdata': None}
 
 
-info_pk = {'likelihood': {'cmb': Pklike},
-           'theory': {'camb': {"external_primordial_pk": True},
-                      'my_pk': ExamplePrimordialPk},
-           'params': {
-               "ombh2": 0.022274,
-               "omch2": 0.11913,
-               "cosmomc_theta": 0.01040867,
-               "tau": 0.0639,
-               "nnu": 3.046,
-               'testAs': {'prior': {'min': 1e-9, 'max': 1e-8}},
-               'testns': {'prior': {'min': 0.8, 'max': 1.2}}
-           },
-           'stop_at_error': True,
-           'debug': debug}
+info_pk: InputDict = {'likelihood': {'cmb': Pklike},
+                      'theory': {'camb': {"external_primordial_pk": True},
+                                 'my_pk': ExamplePrimordialPk},
+                      'params': {
+                          "ombh2": 0.022274,
+                          "omch2": 0.11913,
+                          "cosmomc_theta": 0.01040867,
+                          "tau": 0.0639,
+                          "nnu": 3.046,
+                          'testAs': {'prior': {'min': 1e-9, 'max': 1e-8}},
+                          'testns': {'prior': {'min': 0.8, 'max': 1.2}}
+                      },
+                      'stop_at_error': True,
+                      'debug': debug}
 
 
 def test_primordial_pk(packages_path, skip_not_installed):
@@ -285,22 +286,23 @@ def test_pk_binning(packages_path, skip_not_installed):
     k_min_bin = -5.5
     k_max_bin = 2
 
-    _info = {'packages_path': process_packages_path(packages_path),
-             'likelihood': {'cmb': Pklike},
-             'theory': {'camb': {"external_primordial_pk": True},
-                        'my_pk': {"external": BinnedPk,
-                                  'nbins': nbins, 'k_min_bin': k_min_bin,
-                                  'k_max_bin': k_max_bin
-                                  }},
-             'params': {
-                 "ombh2": 0.022274,
-                 "omch2": 0.11913,
-                 "cosmomc_theta": 0.01040867,
-                 "tau": tau,
-                 "nnu": 3.046
-             },
-             'stop_at_error': True,
-             'debug': debug}
+    _info: InputDict = \
+        {'packages_path': process_packages_path(packages_path),
+         'likelihood': {'cmb': Pklike},
+         'theory': {'camb': {"external_primordial_pk": True},
+                    'my_pk': {"external": BinnedPk,
+                              'nbins': nbins, 'k_min_bin': k_min_bin,
+                              'k_max_bin': k_max_bin
+                              }},
+         'params': {
+             "ombh2": 0.022274,
+             "omch2": 0.11913,
+             "cosmomc_theta": 0.01040867,
+             "tau": tau,
+             "nnu": 3.046
+         },
+         'stop_at_error': True,
+         'debug': debug}
     scale = 1e-9
     ks = np.logspace(k_min_bin, k_max_bin, nbins)
 

--- a/tests/test_cosmo_run.py
+++ b/tests/test_cosmo_run.py
@@ -7,7 +7,8 @@ from cobaya.theory import Theory
 from cobaya.run import run
 from cobaya import mpi
 from cobaya.log import LoggedError
-from cobaya.conventions import _packages_path, InfoDict, _dill_extension
+from cobaya.conventions import Extension
+from cobaya.typing import InputDict, PostDict
 from cobaya.tools import deepcopy_where_possible
 from cobaya.cosmo_input.convert_cosmomc import cosmomc_root_to_cobaya_info_dict
 from .common import process_packages_path
@@ -41,7 +42,7 @@ class CTheory(Theory):
     params = {'AsX': None, 'As1000': {'derived': True}}
 
 
-info: InfoDict = {"params": {
+info: InputDict = {"params": {
     "ombh2": 0.0245,
     "H0": 70,
     "ns": 0.965,
@@ -94,12 +95,12 @@ def test_cosmo_run_resume_post(tmpdir, packages_path=None):
     # only vary As, so fast chain
     info['output'] = os.path.join(tmpdir, 'testchain')
     if packages_path:
-        info[_packages_path] = process_packages_path(packages_path)
+        info["packages_path"] = process_packages_path(packages_path)
     run(info, force=True)
     # note that continuing from files leads to text-file precision at read in, so a mix of
     # precision in the output Collection returned from run
     run(info, resume=True, override={'sampler': {'mcmc': {'Rminus1_stop': 0.2}}})
-    updated_info, sampler = run(info['output'] + '.updated' + _dill_extension,
+    updated_info, sampler = run(info['output'] + '.updated' + Extension.dill,
                                 resume=True,
                                 override={'sampler': {'mcmc': {'Rminus1_stop': 0.05}}})
     results = mpi.allgather(sampler.products()["sample"])
@@ -108,12 +109,12 @@ def test_cosmo_run_resume_post(tmpdir, packages_path=None):
     assert abs(samp.mean('sigma8') - 0.69) < 0.02
 
     # post-processing
-    info_post = {'add': {'params': {'h': None},
-                         "likelihood": {"test_likelihood2": likelihood2}},
-                 'remove': {'likelihood': ["test_likelihood"]},
-                 'suffix': 'testpost',
-                 'skip': 0.2, 'thin': 4
-                 }
+    info_post: PostDict = {'add': {'params': {'h': None},
+                                   "likelihood": {"test_likelihood2": likelihood2}},
+                           'remove': {'likelihood': ["test_likelihood"]},
+                           'suffix': 'testpost',
+                           'skip': 0.2, 'thin': 4
+                           }
 
     output_info, products = run(updated_info, override={'post': info_post}, force=True)
     results2 = mpi.allgather(products["sample"])

--- a/tests/test_cosmo_run.py
+++ b/tests/test_cosmo_run.py
@@ -3,12 +3,8 @@ import numpy as np
 import pytest
 from flaky import flaky
 from getdist.mcsamples import MCSamplesFromCobaya, loadMCSamples
-from cobaya.theory import Theory
-from cobaya.run import run
-from cobaya import mpi
-from cobaya.log import LoggedError
+from cobaya import mpi, run, Theory, InputDict, PostDict, LoggedError
 from cobaya.conventions import Extension
-from cobaya.typing import InputDict, PostDict
 from cobaya.tools import deepcopy_where_possible
 from cobaya.cosmo_input.convert_cosmomc import cosmomc_root_to_cobaya_info_dict
 from .common import process_packages_path

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -4,10 +4,10 @@ from cobaya.model import get_model
 from cobaya.theory import Theory
 from cobaya.likelihood import Likelihood
 from cobaya.log import LoggedError
-from cobaya.conventions import InfoDict
+from cobaya.typing import InputDict
 from .common import process_packages_path
 
-debug = True
+debug = False
 
 
 # Aderived = 1
@@ -96,9 +96,9 @@ class Like(Likelihood):
         state["logp"] = res[0] + res[1][0]
 
 
-info: InfoDict = {'likelihood': {'like': Like},
-                  'params': {'Bpar': 3, 'Ain': 5},
-                  'debug': debug}
+info: InputDict = {'likelihood': {'like': Like},
+                   'params': {'Bpar': 3, 'Ain': 5},
+                   'debug': debug}
 
 
 def _test_loglike(theories):
@@ -140,7 +140,7 @@ def test_dependencies(packages_path):
                        ('C', {'external': C, 'provides': ['Bout']})])
     assert "more than one component provides Bout" in str(e.value)
 
-    inf = info.copy()
+    inf: InputDict = info.copy()
     inf['params'] = info['params'].copy()
     inf['params']['notused'] = [1, 10, 2, 5, 1]
     inf['theory'] = dict(theories)
@@ -222,9 +222,9 @@ class Like4(Likelihood):
         pass
 
 
-info2: InfoDict = {'likelihood': {'like': Like2},
-                   'params': {'Ain': 5},
-                   'debug': debug, 'stop_at_error': True}
+info2: InputDict = {'likelihood': {'like': Like2},
+                    'params': {'Ain': 5},
+                    'debug': debug, 'stop_at_error': True}
 
 
 def _test_loglike2(theories):

--- a/tests/test_docs_example_quickstart.py
+++ b/tests/test_docs_example_quickstart.py
@@ -10,7 +10,6 @@ import pytest
 
 from cobaya.yaml import yaml_load_file
 from cobaya.input import is_equal_info
-from cobaya.conventions import _output_prefix
 from cobaya.tools import KL_norm
 from .common_sampler import KL_tolerance
 from .common import stdout_redirector
@@ -31,14 +30,14 @@ def test_example():
     try:
         os.chdir(docs_src_folder)
         info_yaml = yaml_load_file("gaussian.yaml")
-        info_yaml.pop(_output_prefix)
+        info_yaml.pop("output")
         globals_example = {}
         exec(open(os.path.join(docs_src_folder, "create_info.py")).read(),
              globals_example)
         assert is_equal_info(info_yaml, globals_example["info"]), (
             "Inconsistent info between yaml and interactive.")
         exec(open(os.path.join(docs_src_folder, "load_info.py")).read(), globals_example)
-        globals_example["info_from_yaml"].pop(_output_prefix)
+        globals_example["info_from_yaml"].pop("output")
         assert is_equal_info(info_yaml, globals_example["info_from_yaml"]), (
             "Inconsistent info between interactive and *loaded* yaml.")
         # Run the chain -- constant seed so results are the same!

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -6,7 +6,7 @@ import pytest
 import os
 
 # Local
-from cobaya.conventions import kinds, partag, _prior, _params, InputDict
+from cobaya.typing import InputDict
 from cobaya.run import run, run_script
 from cobaya.log import LoggedError
 from cobaya.input import get_default_info
@@ -15,61 +15,61 @@ from cobaya.yaml import yaml_dump_file, yaml_load_file
 # Aux definitions and functions
 
 test_info_common: InputDict = {
-    kinds.likelihood: {"_test": None},
-    kinds.sampler: {"evaluate": None}}
+    "likelihood": {"_test": None},
+    "sampler": {"evaluate": None}}
 
 
 def test_prior_inherit_nonegiven():
     updated_info = run(test_info_common).info
-    likname = list(test_info_common[kinds.likelihood])[0]
-    default_info = get_default_info(likname, kinds.likelihood)
-    assert updated_info[_prior] == default_info[_prior]
+    likname = list(test_info_common["likelihood"])[0]
+    default_info = get_default_info(likname, "likelihood")
+    assert updated_info["prior"] == default_info["prior"]
 
 
 def test_prior_inherit_differentgiven():
     test_info = deepcopy(test_info_common)
-    test_info[_prior] = {"third": "lambda a1: 1"}
+    test_info["prior"] = {"third": "lambda a1: 1"}
     updated_info, _ = run(test_info)
-    likname = list(test_info_common[kinds.likelihood])[0]
-    default_info = get_default_info(likname, kinds.likelihood)
-    default_info[_prior].update(test_info[_prior])
-    assert updated_info[_prior] == default_info[_prior]
+    likname = list(test_info_common["likelihood"])[0]
+    default_info = get_default_info(likname, "likelihood")
+    default_info["prior"].update(test_info["prior"])
+    assert updated_info["prior"] == default_info["prior"]
 
 
 def test_prior_inherit_samegiven():
     test_info = deepcopy(test_info_common)
-    likname = list(test_info_common[kinds.likelihood])[0]
-    default_info = get_default_info(likname, kinds.likelihood)
-    name, prior = deepcopy(default_info[_prior]).popitem()
-    test_info[_prior] = {name: prior}
+    likname = list(test_info_common["likelihood"])[0]
+    default_info = get_default_info(likname, "likelihood")
+    name, prior = deepcopy(default_info["prior"]).popitem()
+    test_info["prior"] = {name: prior}
     updated_info = run(test_info).info
-    assert updated_info[_prior] == default_info[_prior]
+    assert updated_info["prior"] == default_info["prior"]
 
 
 def test_prior_inherit_samegiven_differentdefinition():
     test_info = deepcopy(test_info_common)
-    likname = list(test_info_common[kinds.likelihood])[0]
-    default_info = get_default_info(likname, kinds.likelihood)
-    name, prior = deepcopy(default_info[_prior]).popitem()
-    test_info[_prior] = {name: "this is not a prior"}
+    likname = list(test_info_common["likelihood"])[0]
+    default_info = get_default_info(likname, "likelihood")
+    name, prior = deepcopy(default_info["prior"]).popitem()
+    test_info["prior"] = {name: "this is not a prior"}
     with pytest.raises(LoggedError):
         run(test_info)
 
 
 def test_inherit_label_and_bounds():
     test_info = deepcopy(test_info_common)
-    likname = list(test_info_common[kinds.likelihood])[0]
-    default_info_params = get_default_info(likname, kinds.likelihood)[_params]
-    test_info[_params] = deepcopy(default_info_params)
-    test_info[_params]["a1"].pop(partag.latex, None)
+    likname = list(test_info_common["likelihood"])[0]
+    default_info_params = get_default_info(likname, "likelihood")["params"]
+    test_info["params"] = deepcopy(default_info_params)
+    test_info["params"]["a1"].pop("latex", None)
     # Remove limits, so they are inherited
     test_info = deepcopy(test_info_common)
-    test_info[_params] = deepcopy(default_info_params)
-    test_info[_params]["b1"].pop("min")
-    test_info[_params]["b1"].pop("max")
+    test_info["params"] = deepcopy(default_info_params)
+    test_info["params"]["b1"].pop("min")
+    test_info["params"]["b1"].pop("max")
     updated_info = run(test_info).info
-    assert updated_info[_params]["b1"]["min"] == default_info_params["b1"]["min"]
-    assert updated_info[_params]["b1"]["max"] == default_info_params["b1"]["max"]
+    assert updated_info["params"]["b1"]["min"] == default_info_params["b1"]["min"]
+    assert updated_info["params"]["b1"]["max"] == default_info_params["b1"]["max"]
 
 
 def test_run_file(tmpdir):
@@ -77,7 +77,7 @@ def test_run_file(tmpdir):
     root = os.path.join(tmpdir, 'test')
     yaml_dump_file(input_file, dict(test_info_common, output=root))
     run_script([input_file, '--force'])
-    likname = list(test_info_common[kinds.likelihood])[0]
-    default_info = get_default_info(likname, kinds.likelihood)
+    likname = list(test_info_common["likelihood"])[0]
+    default_info = get_default_info(likname, "likelihood")
     updated_info = yaml_load_file(root + '.updated.yaml')
-    assert updated_info[_prior] == default_info[_prior]
+    assert updated_info["prior"] == default_info["prior"]

--- a/tests/test_likelihood_external.py
+++ b/tests/test_likelihood_external.py
@@ -13,26 +13,25 @@ For manual testing, and observing/plotting the density, pass ``manual=True`` to
 """
 
 # Local
-from cobaya.conventions import kinds
 from .common_external import info_string, info_callable, info_mixed, info_import
 from .common_external import info_derived, body_of_test
 
 
 def test_likelihood_external_string(tmpdir):
-    body_of_test(info_string, kinds.likelihood, tmpdir)
+    body_of_test(info_string, "likelihood", tmpdir)
 
 
 def test_likelihood_external_callable(tmpdir):
-    body_of_test(info_callable, kinds.likelihood, tmpdir)
+    body_of_test(info_callable, "likelihood", tmpdir)
 
 
 def test_likelihood_external_mixed(tmpdir):
-    body_of_test(info_mixed, kinds.likelihood, tmpdir)
+    body_of_test(info_mixed, "likelihood", tmpdir)
 
 
 def test_likelihood_external_import(tmpdir):
-    body_of_test(info_import, kinds.likelihood, tmpdir)
+    body_of_test(info_import, "likelihood", tmpdir)
 
 
 def test_likelihood_external_derived(tmpdir):
-    body_of_test(info_derived, kinds.likelihood, tmpdir, derived=True)
+    body_of_test(info_derived, "likelihood", tmpdir, derived=True)

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -6,6 +6,7 @@ import time
 from cobaya.tools import KL_norm
 from cobaya.likelihood import Likelihood
 from cobaya.run import run
+from cobaya.typing import InputDict, Type
 from cobaya import mpi
 from cobaya.yaml import yaml_load
 from .common_sampler import body_of_test, body_of_test_speeds
@@ -208,7 +209,7 @@ def test_mcmc_dragging():
     body_of_test_speeds(info_mcmc)
 
 
-def _make_gaussian_like(nparam):
+def _make_gaussian_like(nparam) -> Type[Likelihood]:
     class LikeTest(Likelihood):
         params = {'x' + str(name): {'prior': {'min': -5, 'max': 5}, 'proposal': 1}
                   for name in range(nparam)}
@@ -228,7 +229,7 @@ def _test_overhead_timing(dim=15):
     from cobaya.samplers.mcmc import proposal  # one-time numba compile out of profiling
 
     LikeTest = _make_gaussian_like(dim)
-    info = {'likelihood': {'like': LikeTest}, 'debug': False, 'sampler': {
+    info: InputDict = {'likelihood': {'like': LikeTest}, 'debug': False, 'sampler': {
         'mcmc': {'max_samples': 1000, 'burn_in': 0, "learn_proposal": False,
                  "Rminus1_stop": 0.0001}}}
     prof = Profile()

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -6,7 +6,7 @@ from flaky import flaky
 import pytest
 import os
 
-from cobaya.conventions import kinds, InputDict
+from cobaya.typing import InputDict
 from cobaya.run import run
 from cobaya import mpi
 
@@ -37,13 +37,13 @@ def test_minimize_gaussian(tmpdir):
     # ranges = np.array([[0, 1] for _ in range(dimension)])
     # info = info_random_gaussian_mixture(ranges=ranges, n_modes=n_modes,
     #      input_params_prefix = "a_", derived = True)
-    info = info_min.copy()
-    mean = info[kinds.likelihood]["gaussian_mixture"]["means"][0]
-    cov = info[kinds.likelihood]["gaussian_mixture"]["covs"][0]
+    info: InputDict = info_min.copy()
+    mean = info["likelihood"]["gaussian_mixture"]["means"][0]
+    cov = info["likelihood"]["gaussian_mixture"]["covs"][0]
     maxloglik = multivariate_normal.logpdf(mean, mean=mean, cov=cov)
     if mpi.is_main_process():
         print("Maximum of the gaussian mode to be found: %s" % mean)
-    info[kinds.sampler] = {"minimize": {"ignore_prior": True}}
+    info["sampler"] = {"minimize": {"ignore_prior": True}}
     info["debug"] = False
     info["debug_file"] = None
 

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -6,9 +6,7 @@ from flaky import flaky
 import pytest
 import os
 
-from cobaya.typing import InputDict
-from cobaya.run import run
-from cobaya import mpi
+from cobaya import mpi, run, InputDict
 
 pytestmark = pytest.mark.mpi
 
@@ -43,9 +41,7 @@ def test_minimize_gaussian(tmpdir):
     maxloglik = multivariate_normal.logpdf(mean, mean=mean, cov=cov)
     if mpi.is_main_process():
         print("Maximum of the gaussian mode to be found: %s" % mean)
-    info["sampler"] = {"minimize": {"ignore_prior": True}}
-    info["debug"] = False
-    info["debug_file"] = None
+        info["sampler"] = {"minimize": {"ignore_prior": True, "seed": 2}}
 
     products = run(info).sampler.products()
     # Done! --> Tests

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -9,7 +9,6 @@ from scipy.stats import multivariate_normal
 import numpy as np
 from typing import Sequence, Union
 # Local
-from cobaya.conventions import kinds, _params
 from cobaya.yaml import yaml_load
 from cobaya.run import run
 from cobaya.tools import get_external_function
@@ -36,10 +35,10 @@ def loglike(a, b, c, d, h, i, j):
 
 # Info
 info = {
-    kinds.likelihood:
+    "likelihood":
         {"test_lik": {"external": loglike, "output_params": ["x", "e"]}},
-    kinds.sampler: {"mcmc": {"burn_in": 0, "max_samples": 10}},
-    _params: yaml_load("""
+    "sampler": {"mcmc": {"burn_in": 0, "max_samples": 10}},
+    "params": yaml_load("""
        # Fixed to number
        a: 0.01
        # Fixed to function, non-explicitly requested as derived
@@ -93,15 +92,15 @@ def test_parameterization():
     from getdist.mcsamples import MCSamplesFromCobaya
     gdsample = MCSamplesFromCobaya(updated_info, products["sample"])
     for i, point in sample:
-        a = info[_params]["a"]
-        b = get_external_function(info[_params]["b"])(a, point["bprime"])
-        c = get_external_function(info[_params]["c"])(a, point["cprime"])
+        a = info["params"]["a"]
+        b = get_external_function(info["params"]["b"])(a, point["bprime"])
+        c = get_external_function(info["params"]["c"])(a, point["cprime"])
         e = get_external_function(e_func)(b)
         f = get_external_function(f_func)(b)
-        g = get_external_function(info[_params]["g"]["derived"])(x_func(point["c"]))
-        h = get_external_function(info[_params]["h"])(info[_params]["i"])
-        j = get_external_function(info[_params]["j"])(b)
-        k = get_external_function(info[_params]["k"]["derived"])(f)
+        g = get_external_function(info["params"]["g"]["derived"])(x_func(point["c"]))
+        h = get_external_function(info["params"]["h"])(info["params"]["i"])
+        j = get_external_function(info["params"]["j"])(b)
+        k = get_external_function(info["params"]["k"]["derived"])(f)
         assert np.allclose(
             point[["b", "c", "e", "f", "g", "h", "j", "k"]], [b, c, e, f, g, h, j, k])
         # Test for GetDist too (except fixed ones, ignored by GetDist)
@@ -186,7 +185,7 @@ def loglik_OLD(a, b, c, d, h, i, j, _derived: DerivedArg = ("x", "e")):
 
 # MARKED FOR DEPRECATION IN v3.0
 info_OLD = info.copy()
-info_OLD[kinds.likelihood] = {"test_lik": loglik_OLD}
+info_OLD["likelihood"] = {"test_lik": loglik_OLD}
 
 
 # MARKED FOR DEPRECATION IN v3.0
@@ -197,15 +196,15 @@ def test_parameterization_old_derived_specification():
     from getdist.mcsamples import MCSamplesFromCobaya
     gdsample = MCSamplesFromCobaya(updated_info, products["sample"])
     for i, point in sample:
-        a = info[_params]["a"]
-        b = get_external_function(info[_params]["b"])(a, point["bprime"])
-        c = get_external_function(info[_params]["c"])(a, point["cprime"])
+        a = info["params"]["a"]
+        b = get_external_function(info["params"]["b"])(a, point["bprime"])
+        c = get_external_function(info["params"]["c"])(a, point["cprime"])
         e = get_external_function(e_func)(b)
         f = get_external_function(f_func)(b)
-        g = get_external_function(info[_params]["g"]["derived"])(x_func(point["c"]))
-        h = get_external_function(info[_params]["h"])(info[_params]["i"])
-        j = get_external_function(info[_params]["j"])(b)
-        k = get_external_function(info[_params]["k"]["derived"])(f)
+        g = get_external_function(info["params"]["g"]["derived"])(x_func(point["c"]))
+        h = get_external_function(info["params"]["h"])(info["params"]["i"])
+        j = get_external_function(info["params"]["j"])(b)
+        k = get_external_function(info["params"]["k"]["derived"])(f)
         assert np.allclose(
             point[["b", "c", "e", "f", "g", "h", "j", "k"]], [b, c, e, f, g, h, j, k])
         # Test for GetDist too (except fixed ones, ignored by GetDist)

--- a/tests/test_polychord.py
+++ b/tests/test_polychord.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from cobaya.run import run
 from .common_sampler import body_of_test, body_of_test_speeds
-from cobaya.conventions import kinds, _params, partag, _output_prefix
 from .conftest import install_test_wrapper
 
 
@@ -33,20 +32,20 @@ def test_polychord_resume(packages_path, skip_not_installed, tmpdir):
         dead_points = sampler.dead[["a", "b"]].values.copy()
 
     info = {
-        kinds.likelihood: {
+        "likelihood": {
             "A": {"external": "lambda a: stats.norm.logpdf(a)", "speed": 1},
             "B": {"external": "lambda b: stats.norm.logpdf(b)", "speed": 0.01}},
-        _params: {
-            "a": {partag.prior: {"min": 0, "max": 1}},
-            "b": {partag.prior: {"min": 0, "max": 1}}},
-        kinds.sampler: {
+        "params": {
+            "a": {"prior": {"min": 0, "max": 1}},
+            "b": {"prior": {"min": 0, "max": 1}}},
+        "sampler": {
             "polychord": {
                 "measure_speeds": True,
                 "nlive": nlive,
                 "max_ndead": max_ndead,
                 "callback_function": callback,
             }},
-        _output_prefix: str(tmpdir)}
+        "output": str(tmpdir)}
     install_test_wrapper(skip_not_installed, run, info)
     old_dead_points = dead_points.copy()
     info["resume"] = True

--- a/tests/test_prior_external.py
+++ b/tests/test_prior_external.py
@@ -12,22 +12,21 @@ For manual testing, and observing/plotting the density, pass `manual=True`
 to `body of test`.
 """
 # Local
-from cobaya.conventions import _prior
 from .common_external import info_string, info_callable, info_mixed, info_import
 from .common_external import body_of_test
 
 
 def test_prior_external_string(tmpdir):
-    body_of_test(info_string, _prior, tmpdir)
+    body_of_test(info_string, "prior", tmpdir)
 
 
 def test_prior_external_callable(tmpdir):
-    body_of_test(info_callable, _prior, tmpdir)
+    body_of_test(info_callable, "prior", tmpdir)
 
 
 def test_prior_external_mixed(tmpdir):
-    body_of_test(info_mixed, _prior, tmpdir)
+    body_of_test(info_mixed, "prior", tmpdir)
 
 
 def test_prior_external_import(tmpdir):
-    body_of_test(info_import, _prior, tmpdir)
+    body_of_test(info_import, "prior", tmpdir)


### PR DESCRIPTION
This attempts to define TypedDict types for the main input dictionaries, to allow static checking of input (in cobaya.typing, analogous e.g. to numpy.typing). I have to say currently PyCharm's support for actually checking TypedDicts is not currently great - it will correctly flag as soon as I type e.g. "stop_on_error" in an InputDict (rather than the correct and confusable "stop_at_error") , but will not properly check the nested sub-dictionaries. But that will hopefully improve as py38+ support improves... (possibly at the expense of more spurious errors..).

Since dict entry string are then fixed and checked, the conventions constants seems redundant, so the refactor abolishes all the non-private constants starting with _, using string literals in most dicts. This has the advantage that we can then more consistently use underscores only for private variables as in the standard, and makes import statements much shorter. (_cosmo and a small number of other refactors to do).

