### PR TITLE
Fix for BAO, DES, SN likelihoods docs

### DIFF
--- a/docs/likelihood_bao.rst
+++ b/docs/likelihood_bao.rst
@@ -1,5 +1,5 @@
 Baryonic Acoustic Oscillations
 ==============================
 
-.. automodule:: cobaya.likelihoods.base_classes.BAO
+.. automodule:: cobaya.likelihoods.base_classes.bao
    :noindex:

--- a/docs/likelihood_des.rst
+++ b/docs/likelihood_des.rst
@@ -1,5 +1,5 @@
 Clustering and weak lensing from DES Y1
 =======================================
 
-.. automodule:: cobaya.likelihoods.base_classes.DES
+.. automodule:: cobaya.likelihoods.base_classes.des
    :noindex:

--- a/docs/likelihood_sn.rst
+++ b/docs/likelihood_sn.rst
@@ -1,5 +1,5 @@
 Type Ia Supernovae
 ==================
 
-.. automodule:: cobaya.likelihoods.base_classes.SN
+.. automodule:: cobaya.likelihoods.base_classes.sn
    :noindex:


### PR DESCRIPTION
Currently the docs for BAO, DES, SN likelihoods are pretty blank. The cause turned out to be a simple case mismatch in file names. I fixed it and checked by compiling docs on my computer - the issue is resolved indeed.