### PR TITLE
Pandas 1.3 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,8 @@ jobs:
         - PYDIST="ANACONDA"
         - ANACONDA_CHANNEL="conda-forge"
       python: "3.9"
+  allow_failures:
+    - name: "Latest: gcc-11, Python 3.9 Anaconda (conda-forge)"
 
 before_install:
   # Configure right compiler versions

--- a/DEVEL.rst
+++ b/DEVEL.rst
@@ -7,7 +7,7 @@ This document gathers some notes about the development flow, release checklist, 
 
   This document may not always be up to date
 
-git`` development model
+``git`` development model
 -------------------------
 
 * Non-breaking travis-passing latest changes and fixes are in master

--- a/cobaya/post.py
+++ b/cobaya/post.py
@@ -407,8 +407,8 @@ def post(info_or_yaml_or_file: Union[InputDict, str, os.PathLike],
 
         def set_difflogmax():
             nonlocal difflogmax
-            difflog = (collection_in[OutPar.minuslogpost].to_numpy()[:len(collection_out)]
-                       - collection_out[OutPar.minuslogpost].to_numpy())
+            difflog = (collection_in[OutPar.minuslogpost].to_numpy(dtype=np.float64)[:len(collection_out)]
+                       - collection_out[OutPar.minuslogpost].to_numpy(dtype=np.float64))
             difflogmax = np.max(difflog)
             if abs(difflogmax) < 1:
                 difflogmax = 0  # keep simple when e.g. very similar

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -12,7 +12,6 @@ from pandas import DataFrame
 import datetime
 from typing import Sequence, Optional, Callable
 import re
-import sys
 
 # Local
 from cobaya.sampler import CovmatSampler

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -12,6 +12,7 @@ from pandas import DataFrame
 import datetime
 from typing import Sequence, Optional, Callable
 import re
+import sys
 
 # Local
 from cobaya.sampler import CovmatSampler
@@ -21,7 +22,7 @@ from cobaya.collection import SampleCollection, OneSamplePoint
 from cobaya.conventions import OutPar, Extension, line_width, get_version
 from cobaya.typing import empty_dict
 from cobaya.samplers.mcmc.proposal import BlockedProposer
-from cobaya.log import LoggedError
+from cobaya.log import LoggedError, always_stop_exceptions
 from cobaya.tools import get_external_function, NumberWithUnits, load_DataFrame
 from cobaya.yaml import yaml_dump_file
 from cobaya.model import LogPosterior
@@ -139,15 +140,15 @@ class MCMC(CovmatSampler):
         if self.output.is_resuming() and len(self.collection):
             last = len(self.collection) - 1
             initial_point = (self.collection[self.collection.sampled_params]
-                .iloc[last]).to_numpy(copy=True)
+                .iloc[last]).to_numpy(dtype=np.float64, copy=True)
             results = LogPosterior(
                 logpost=-self.collection[OutPar.minuslogpost].iloc[last],
                 logpriors=-(self.collection[self.collection.minuslogprior_names]
-                            .iloc[last].to_numpy(copy=True)),
+                            .iloc[last].to_numpy(dtype=np.float64, copy=True)),
                 loglikes=-0.5 * (self.collection[self.collection.chi2_names]
-                                 .iloc[last].to_numpy(copy=True)),
+                                 .iloc[last].to_numpy(dtype=np.float64, copy=True)),
                 derived=(self.collection[self.collection.derived_params].iloc[last]
-                         .to_numpy(copy=True)))
+                         .to_numpy(dtype=np.float64, copy=True)))
         else:
             # NB: max_tries adjusted to dim instead of #cycles (blocking not computed yet)
             self.max_tries.set_scale(self.model.prior.d())
@@ -620,7 +621,9 @@ class MCMC(CovmatSampler):
                 covs = np.array(
                     [self.collection.cov(first=i * cut, last=(i + 1) * cut - 1) for i in
                      range(1, m)])
-            except:
+            except always_stop_exceptions:
+                raise
+            except Exception:
                 self.log.info("Not enough points in chain to check convergence. "
                               "Waiting for next checkpoint.")
                 return
@@ -710,6 +713,8 @@ class MCMC(CovmatSampler):
                         self.collection.sampled_to_getdist_mcsamples(
                             first=i * cut, last=(i + 1) * cut - 1)
                         for i in range(1, m)]
+                except always_stop_exceptions:
+                    raise
                 except:
                     self.log.info("Not enough points in chain to check c.l. convergence. "
                                   "Waiting for next checkpoint.")

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['numpy>=1.17.0', 'scipy>=1.5', 'pandas>=1.0.1',
                       'PyYAML>=5.1', 'requests>=2.18', 'py-bobyqa>=1.2',
-                      'GetDist>=1.2.2', 'fuzzywuzzy>=0.17', 'packaging', 'tqdm',
+                      'GetDist>=1.3.1', 'fuzzywuzzy>=0.17', 'packaging', 'tqdm',
                       'portalocker>=2.3.0', 'dill>=0.3.3'],
     extras_require={
         'test': ['pytest', 'pytest-forked', 'flaky', 'mpi4py'],

--- a/tests/common_sampler.py
+++ b/tests/common_sampler.py
@@ -276,7 +276,8 @@ def body_of_test_speeds(info_sampler, manual_blocking=False,
                 "Chain has %r but should be %r. " % (
                     [chi2_0_chain, chi2_1_chain], [chi2_0_good, chi2_1_good]) +
                 "Full chain point: %r" % products["sample"][i])
-        derived_chain = products["sample"][["sum_like0", "sum_like1"]].values[i]
+        derived_chain = \
+            products["sample"][["sum_like0", "sum_like1"]].to_numpy(dtype=np.float64)[i]
         derived_good = np.array([
             sum(products["sample"][params0].values[i]),
             sum(products["sample"][params1].values[i])])

--- a/tests/test_parameterization.py
+++ b/tests/test_parameterization.py
@@ -102,7 +102,8 @@ def test_parameterization():
         j = get_external_function(info["params"]["j"])(b)
         k = get_external_function(info["params"]["k"]["derived"])(f)
         assert np.allclose(
-            point[["b", "c", "e", "f", "g", "h", "j", "k"]], [b, c, e, f, g, h, j, k])
+            point[["b", "c", "e", "f", "g", "h", "j", "k"]].to_numpy(np.float64),
+            [b, c, e, f, g, h, j, k])
         # Test for GetDist too (except fixed ones, ignored by GetDist)
         bcefffg_getdist = [gdsample.samples[i][gdsample.paramNames.list().index(p)]
                            for p in ["b", "c", "e", "f", "g", "j", "k"]]
@@ -206,7 +207,8 @@ def test_parameterization_old_derived_specification():
         j = get_external_function(info["params"]["j"])(b)
         k = get_external_function(info["params"]["k"]["derived"])(f)
         assert np.allclose(
-            point[["b", "c", "e", "f", "g", "h", "j", "k"]], [b, c, e, f, g, h, j, k])
+            point[["b", "c", "e", "f", "g", "h", "j", "k"]].to_numpy(dtype=np.float64),
+            [b, c, e, f, g, h, j, k])
         # Test for GetDist too (except fixed ones, ignored by GetDist)
         bcefffg_getdist = [gdsample.samples[i][gdsample.paramNames.list().index(p)]
                            for p in ["b", "c", "e", "f", "g", "j", "k"]]

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -22,6 +22,10 @@ sampled = {"mean": mean, "cov": cov}
 target = {"mean": mean + np.array([sigma / 2, 0]), "cov": cov}
 
 
+def allclose(a, b):
+    return np.allclose(a.to_numpy(dtype=np.float64), b.to_numpy(dtype=np.float64))
+
+
 def sampled_pdf(a, b):
     return multivariate_normal.logpdf([a, b], mean=sampled["mean"], cov=sampled["cov"])
 
@@ -148,11 +152,11 @@ def test_post_likelihood():
             new_mean, new_cov = mpi.share()
         assert np.allclose(new_mean, target_mean)
         assert np.allclose(new_cov, target_cov)
-        assert np.allclose(products_post["sample"]["chi2__A"],
-                           products_post["sample"]["chi2__target"])
-        assert np.allclose(products_post["sample"]["chi2__BB"],
-                           products_post["sample"]["chi2__dummy"] +
-                           products_post["sample"]["chi2__dummy_add"])
+        assert allclose(products_post["sample"]["chi2__A"],
+                        products_post["sample"]["chi2__target"])
+        assert allclose(products_post["sample"]["chi2__BB"],
+                        products_post["sample"]["chi2__dummy"] +
+                        products_post["sample"]["chi2__dummy_add"])
     finally:
         OutputOptions.output_inteveral_s = orig_interval
 
@@ -183,10 +187,9 @@ def test_post_params():
     info_post.update(updated_info_gaussian)
     products = post(info_post, products_gaussian["sample"]).products
     # Compare parameters
-    assert np.allclose(
-        products["sample"]["a"] - products["sample"]["b"],
-        products["sample"]["a_minus_b"])
-    assert np.allclose(
-        products["sample"]["cprime"], info_post["post"]["add"]["params"]["c"])
-    assert np.allclose(
-        products["sample"]["my_chi2__target"], products["sample"]["chi2__target"])
+    assert allclose(products["sample"]["a"] - products["sample"]["b"],
+                    products["sample"]["a_minus_b"])
+    assert np.allclose(products["sample"]["cprime"].to_numpy(dtype=np.float64),
+                       info_post["post"]["add"]["params"]["c"])
+    assert allclose(products["sample"]["my_chi2__target"],
+                    products["sample"]["chi2__target"])


### PR DESCRIPTION
Pandas 1.3 seems to have royally messed up a bunch of things, with series objects apparently returning an object-type array that doesn't work with various numpy functions any more. I've attempted to change to use explicit .to_numpy(dtype=np.float64). Seems to work except bleeding edge conda-forge.

@JesusTorrado, we should probably do a new version ASAP as the pandas changes break many tests.