### PR TITLE
LogPosterior as dataclass and a couple of Collection improvements

### DIFF
--- a/cobaya/collection.py
+++ b/cobaya/collection.py
@@ -190,10 +190,8 @@ class SampleCollection(BaseCollection):
                         logpriors=logpriors, loglikes=loglikes)
 
     def add_log_posterior(self, values: np.ndarray, results: LogPosterior, weight=1):
-        logprior_sum = sum(results.logpriors)
-        loglike_sum = sum(results.loglikes)
-        assert np.isclose(logprior_sum + loglike_sum, results.logpost)
-        self._cache_add(values, (results.logpost, logprior_sum, loglike_sum),
+        assert np.isclose(results.logprior + results.loglike, results.logpost)
+        self._cache_add(values, (results.logpost, results.logprior, results.loglike),
                         derived=results.derived, weight=weight,
                         logpriors=results.logpriors, loglikes=results.loglikes)
 

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -6,13 +6,14 @@
 
 """
 # Global
+import os
+import dataclasses
+import numpy as np
 from contextlib import contextmanager
 from copy import deepcopy
 from itertools import chain
 from typing import NamedTuple, Sequence, Mapping, Iterable, Optional, \
     Union, List, Any, Dict, Set
-import numpy as np
-import os
 
 # Local
 from cobaya.conventions import overhead_time, debug_default, get_chi2_name, \
@@ -44,12 +45,24 @@ def timing_on(model: 'Model'):
             model.set_timing_on(False)
 
 
-# Log-posterior namedtuple
-class LogPosterior(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class LogPosterior:
+    """
+    Class holding the result of a log-posterior computation, including log-priors,
+    log-likelihoods and derived parameters.
+    """
+
     logpost: float
     logpriors: Sequence[float]
     loglikes: Sequence[float]
     derived: Sequence[float]
+    logprior: float = dataclasses.field(init=False)
+    loglike: float = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        """Sets the sums of priors and posterior."""
+        object.__setattr__(self, 'logprior', sum(self.logpriors))
+        object.__setattr__(self, 'loglike', sum(self.loglikes))
 
 
 class Requirement(NamedTuple):

--- a/cobaya/samplers/evaluate/evaluate.py
+++ b/cobaya/samplers/evaluate/evaluate.py
@@ -69,12 +69,12 @@ class Evaluate(Sampler):
                 logpost=self.logposterior.logpost, logpriors=self.logposterior.logpriors,
                 loglikes=self.logposterior.loglikes)
             self.log.info("log-posterior  = %g", self.logposterior.logpost)
-            self.log.info("log-prior      = %g", sum(self.logposterior.logpriors))
+            self.log.info("log-prior      = %g", self.logposterior.logprior)
             for j, name in enumerate(self.model.prior):
                 self.log.info(
                     "   logprior_" + name + " = %g", self.logposterior.logpriors[j])
-            if sum(self.logposterior.logpriors) > -np.inf:
-                self.log.info("log-likelihood = %g", sum(self.logposterior.loglikes))
+            if self.logposterior.logprior > -np.inf:
+                self.log.info("log-likelihood = %g", self.logposterior.loglike)
                 for j, name in enumerate(self.model.likelihood):
                     self.log.info(
                         "   chi2_" + name + " = %g", (-2 * self.logposterior.loglikes[j]))

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -333,7 +333,7 @@ class Minimize(Minimizer, CovmatSampler):
         self.log.info("-log(%s) minimized to %g",
                       "likelihood" if self.ignore_prior else "posterior", -logp_min)
         recomputed_post_min = self.model.logposterior(x_min, cached=False)
-        recomputed_logp_min = (sum(recomputed_post_min.loglikes) if self.ignore_prior
+        recomputed_logp_min = (recomputed_post_min.loglike if self.ignore_prior
                                else recomputed_post_min.logpost)
         if not np.allclose(logp_min, recomputed_logp_min, atol=1e-2):
             raise LoggedError(

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -228,15 +228,16 @@ class polychord(Sampler):
         # Don't forget to multiply by the volume of the physical hypercube,
         # since PolyChord divides by it
         def logpost(params_values):
-            logposterior, logpriors, loglikes, derived = (
-                self.model.logposterior(params_values))
-            if len(derived) != self.n_derived:
-                derived = np.full(self.n_derived, np.nan)
+            result = self.model.logposterior(params_values)
+            loglikes = result.loglikes
             if len(loglikes) != self.n_likes:
                 loglikes = np.full(self.n_likes, np.nan)
-            derived = list(derived) + list(logpriors) + list(loglikes)
+            derived = result.derived
+            if len(derived) != self.n_derived:
+                derived = np.full(self.n_derived, np.nan)
+            derived = list(derived) + list(result.logpriors) + list(loglikes)
             return (
-                max(logposterior + self.logvolume, self.pc_settings.logzero),
+                max(result.logpost + self.logvolume, self.pc_settings.logzero),
                 derived)
 
         sync_processes()

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ setup(
     install_requires=['numpy>=1.17.0', 'scipy>=1.5', 'pandas>=1.0.1',
                       'PyYAML>=5.1', 'requests>=2.18', 'py-bobyqa>=1.2',
                       'GetDist>=1.3.1', 'fuzzywuzzy>=0.17', 'packaging', 'tqdm',
-                      'portalocker>=2.3.0', 'dill>=0.3.3'],
+                      'portalocker>=2.3.0', 'dill>=0.3.3',
+                      # DEPRECATION NOTICE: remove 'dataclasses' when 3.6 support dropped
+                      #                     (built-in in Python >= 3.7)
+                      'dataclasses>=0.6'],
     extras_require={
         'test': ['pytest', 'pytest-forked', 'flaky', 'mpi4py'],
         'gui': ['pyqt5', 'pyside2', 'matplotlib']},


### PR DESCRIPTION
- [x] LogPosterior is now a dataclass: allows for automatically setting summed logpriors/likelihoods at init (needs `dataclasses` package if Python 3.6 used; package has no effect for 3.7+)
- [ ] ...