### PR TITLE
Fix and extension to the way that PolyChord treats priors

### DIFF
--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -248,7 +248,7 @@ class polychord(Sampler):
             for p in self.model.prior:
                 f_paramnames.write("%s*\t%s\n" % (
                     "logprior" + derived_par_name_separator + p,
-                    r"\pi_\mathrm{" + p.replace("_", r"\ ") + r"}"))
+                    r"\log\pi_\mathrm{" + p.replace("_", r"\ ") + r"}"))
             for p in self.model.likelihood:
                 f_paramnames.write("%s*\t%s\n" % (
                     "loglike" + derived_par_name_separator + p,

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -225,6 +225,8 @@ class polychord(Sampler):
                 theta[i] = self.model.prior.pdf[i].ppf(xi)
             return theta
 
+        if is_main_process():
+            self.dump_paramnames(self.raw_prefix)
         sync_processes()
         self.mpi_info("Calling PolyChord...")
         self.pc.run_polychord(loglikelihood, self.nDims, self.nDerived, self.pc_settings,

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -150,23 +150,6 @@ class polychord(Sampler):
         self.pc_settings = settings.PolyChordSettings(
             self.nDims, self.nDerived, seed=(self.seed if self.seed is not None else -1),
             **{p: getattr(self, p) for p in pc_args if getattr(self, p) is not None})
-        # prior conversion from the hypercube
-        bounds = self.model.prior.bounds(
-            confidence_for_unbounded=self.confidence_for_unbounded)
-        # Check if priors are bounded (nan's to inf)
-        inf = np.where(np.isinf(bounds))
-        if len(inf[0]):
-            params_names = list(self.model.parameterization.sampled_params())
-            params = [params_names[i] for i in sorted(set(inf[0]))]
-            raise LoggedError(
-                self.log, "PolyChord needs bounded priors, but the parameter(s) '"
-                          "', '".join(params) + "' is(are) unbounded.")
-        locs = bounds[:, 0]
-        scales = bounds[:, 1] - bounds[:, 0]
-        # This function re-scales the parameters AND puts them in the right order
-        self.pc_prior = lambda x: (locs + np.array(x)[self.ordering] * scales).tolist()
-        # We will need the volume of the prior domain, since PolyChord divides by it
-        self.logvolume = np.log(np.prod(scales))
         # Prepare callback function
         if self.callback_function is not None:
             self.callback_function_callable = (
@@ -224,10 +207,8 @@ class polychord(Sampler):
         Prepares the posterior function and calls ``PolyChord``'s ``run`` function.
         """
 
-        # Prepare the posterior
-        # Don't forget to multiply by the volume of the physical hypercube,
-        # since PolyChord divides by it
-        def logpost(params_values):
+        # Prepare the polychord likelihood
+        def loglikelihood(params_values):
             result = self.model.logposterior(params_values)
             loglikes = result.loglikes
             if len(loglikes) != self.n_likes:
@@ -236,13 +217,18 @@ class polychord(Sampler):
             if len(derived) != self.n_derived:
                 derived = np.full(self.n_derived, np.nan)
             derived = list(derived) + list(result.logpriors) + list(loglikes)
-            return (max(result.logpost + self.logvolume, self.pc_settings.logzero),
-                    derived)
+            return max(loglikes.sum(), self.pc_settings.logzero), derived
+
+        def prior(cube):
+            theta = np.empty_like(cube)
+            for i, xi in enumerate(np.array(cube)[self.ordering]):
+                theta[i] = self.model.prior.pdf[i].ppf(xi)
+            return theta
 
         sync_processes()
         self.mpi_info("Calling PolyChord...")
-        self.pc.run_polychord(logpost, self.nDims, self.nDerived, self.pc_settings,
-                              self.pc_prior, self.dumper)
+        self.pc.run_polychord(loglikelihood, self.nDims, self.nDerived, self.pc_settings,
+                              prior, self.dumper)
         self.process_raw_output()
 
     @property


### PR DESCRIPTION
In contrast to #232 and #231, this is a slightly more complicated/controversial PR.

The way priors are treated in nested sampling is quite subtle, in particular the way that it makes a clear separation between prior and likelihood. This was first covered by [Chen, Feroz & Hobson](https://arxiv.org/abs/1908.04655), and is something I'm exploring with @appetrosyan as part of his [supernest](https://pypi.org/project/supernest/) package, and in a soon-to-be-released paper. This has been discussed partially in #77

In implementing a prior, one can either incorporate it as an additional density term added to the loglikelihood, or as a transformation from the unit Hypercube. MCMC approaches see these as the same, but nested sampling views them quite differently. Both recover the same posterior and evidence, although one will get different KL divergences and different runtimes/accuracy (as a rule of thumb, the more information you can put in the prior, the lower the DKL, the faster the compression from prior to posterior, the more accurate the nested sampling)

This PR implements how I would establish this in cobaya, although discussion would be useful to see if I've missed any subtleties. It:
1. sums the loglikelihoods for the loglikelihood calculation (ignoring the prior density terms)
2. implements priors (uniform and gaussian and beyond) via scipy ppf functions, recording the prior density as before as derived parameters
3. removes the 'volume' correction, which I believe is now redundant.
 
The only thing this therefore fails at is the treatment of the SZ prior for the plik TT|TTTEEE likelihood. In this framework, you have to manually add this in as a *likelihood* rather than a prior density, in the exact same way as you do for priors, e.g.
```yaml
likelihood:
  planck_2018_highl_plik.TTTEEE: null
  planck_2018_highl_plik.SZ: 'lambda ksz_norm, A_sz: stats.norm.logpdf(ksz_norm+1.6*A_sz, loc=9.5, scale=3.0)'
```

It would be great if cobaya-cosmo-generator could do this -- any hints on how I could implement this?