### PR TITLE
Add (un-)official SPT likelihoods

### DIFF
--- a/docs/likelihood_external.rst
+++ b/docs/likelihood_external.rst
@@ -19,6 +19,7 @@ List of external packages
 
  * `Planck NPIPE hillipop and lollipop <https://github.com/planck-npipe>`_
  * `ACTPol DR4 <https://github.com/ACTCollaboration/pyactlike>`_
+ * `SPT-SZ, SPTPol & SPT-3G <https://github.com/xgarrido/spt_likelihoods>`_
  * `cobaya-mock-cmb <https://github.com/misharash/cobaya_mock_cmb>`_
  * `Example - simple demo <https://github.com/CobayaSampler/example_external_likelihood>`_
  * `Example - Planck lensing <https://github.com/CobayaSampler/planck_lensing_external>`_


### PR DESCRIPTION
- SPTPol EETE likelihood used in Henning et al. https://arxiv.org/abs/1707.09353, 2017.

- SPT-SZ TT likelihood used in Reichardt et al. https://arxiv.org/abs/2002.06197, 2020.

- SPT3G EETE likelihood used in Dutcher et al. https://arxiv.org/abs/2101.01684, 2021.