### PR TITLE
Add native lowL EE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ git:
 env:
   global:
     - COBAYA_INSTALL_SKIP=polychord,planck_2015,CamSpec,unbinned
-    - NUMBA_DEBUG=0
 
 #Large CamSpec folders tend to hang, so exclude non-base likelihoods from cache
 cache:
@@ -20,7 +19,8 @@ cache:
     - /home/travis/build/CosmoPars/packages/data/bao_data
     - /home/travis/build/CosmoPars/packages/data/sn_data
     - /home/travis/build/CosmoPars/packages/data/des_data
-    - /home/travis/build/CosmoPars/packages/data/plik_lite
+    - /home/travis/build/CosmoPars/packages/data/planck_2018_pliklite_native
+    - /home/travis/build/CosmoPars/packages/data/planck_2018_lowE_native
 
 # (Pre)Installation
 jobs:
@@ -35,13 +35,13 @@ jobs:
         - GCC_VERSION="6"
       python: "3.6"
     - name: "Typical scenario: latest Ubuntu LTS"
-      dist: focal
+      dist: jammy
       addons:
         apt:
           packages:
             - gfortran
       env:
-        - GCC_VERSION="focal"
+        - GCC_VERSION="ubuntu"
       python: "3.8"
     - name: "Anaconda: gcc-8, Python 3.7"
       addons:
@@ -77,7 +77,7 @@ jobs:
 
 before_install:
   # Configure right compiler versions
-  - if [[ "$GCC_VERSION" != "focal" ]]; then
+  - if [[ "$GCC_VERSION" != "ubuntu" ]]; then
     mkdir -p gcc-symlinks;
     ln -s /usr/bin/gfortran-$GCC_VERSION gcc-symlinks/gfortran;
     ln -s /usr/bin/gcc-$GCC_VERSION gcc-symlinks/gcc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ git:
 env:
   global:
     - COBAYA_INSTALL_SKIP=polychord,planck_2015,CamSpec,unbinned
+    - NUMBA_DEBUG=0
 
 #Large CamSpec folders tend to hang, so exclude non-base likelihoods from cache
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
             - gfortran
       env:
         - GCC_VERSION="ubuntu"
-      python: "3.8"
+      python: "3.9"
     - name: "Anaconda: gcc-8, Python 3.7"
       addons:
         apt:

--- a/cobaya/cosmo_input/input_database.py
+++ b/cobaya/cosmo_input/input_database.py
@@ -720,6 +720,7 @@ install_tests["likelihood"].update({"planck_2015_lowl": None,
                                     "planck_2018_highl_CamSpec.TT": None,
                                     "planck_2018_highl_CamSpec.TT_native": None,
                                     "planck_2018_highl_CamSpec2021.TT": None,
+                                    "planck_2018_lowl.EE_native": None
                                     })
 
 # CONTENTS FOR COMBO-BOXED IN A GUI ######################################################

--- a/cobaya/likelihoods/planck_2018_lowl/EE_native.py
+++ b/cobaya/likelihoods/planck_2018_lowl/EE_native.py
@@ -1,0 +1,61 @@
+import os
+import numpy as np
+from cobaya.likelihoods.base_classes import InstallableLikelihood
+
+
+class EE_native(InstallableLikelihood):
+    """
+    Python translation of the Planck 2018 SimALl EE likelihood (python AL, Oct 2022)
+    See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/CMB_spectrum_%26_Likelihood_Code
+    Equivalent to planck_2018_lowl.EE: the public Planck clik likelihood using file
+    simall_100x143_offlike5_EE_Aplanck_B.clik (data converted to prob_table.txt)
+
+    Calibration error is very small compared to EE uncertainty, but calibration can be
+    used; otherwise taken to be 1
+    """
+    install_options = {"github_repository": "CobayaSampler/planck_native_data",
+                       "github_release": "v1", "asset": "planck_2018_lowE.zip",
+                       "directory": "planck_2018_lowE_native"}
+    type = "CMB"
+    aliases = ["lowE"]
+
+    _lmin = 2
+    _lmax = 29
+    _nstepsEE = 3000
+    _stepEE = 0.0001
+
+    @classmethod
+    def get_bibtex(cls):
+        from cobaya.likelihoods.planck_2018_lowl.EE import EE
+        return EE.get_bibtex()
+
+    def initialize(self):
+        if self.get_install_options() and self.packages_path:
+            path = self.get_path(self.packages_path)
+            self.probEE = np.loadtxt(os.path.join(path, 'prob_table.txt'))
+
+    def get_can_support_params(self):
+        return ['A_planck']
+
+    def get_requirements(self):
+        return {'Cl': {'ee': self._lmax}}
+
+    def log_likelihood(self, cls_EE, calib=1):
+        r"""
+        Calculate log likelihood from CMB EE spectrum by using likelihood table
+
+        :param cls_EE: L(L+1)C_L/2pi zero-based array in muK^2 units
+        :param calib: optional calibration parameter
+        :return: log likelihood
+        """
+        EE_index = (cls_EE[self._lmin:self._lmax + 1]
+                    / (calib ** 2 * self._stepEE)).astype(int)
+        try:
+            return np.take_along_axis(self.probEE, EE_index[np.newaxis, :], 0).sum()
+        except IndexError:
+            self.log.warning("low EE multipole out of range, rejecting point")
+            return -np.inf
+
+    def logp(self, **params_values):
+        cls = self.provider.get_Cl(ell_factor=True)['ee']
+        return self.log_likelihood(cls, params_values.get('A_planck', 1))

--- a/tests/test_cosmo_planck_2018.py
+++ b/tests/test_cosmo_planck_2018.py
@@ -35,15 +35,23 @@ def test_planck_2018_t_camb(packages_path, skip_not_installed):
                  skip_not_installed=skip_not_installed)
 
 
-def test_planck_2018_p_camb(packages_path, skip_not_installed):
+def test_planck_2018_p_camb(packages_path, skip_not_installed, native=False):
     best_fit = deepcopy(params_lowTE_highTTTEEE_lensingcmblikes)
     best_fit.pop("H0")
     info_likelihood = lik_info_lowTE_highTTTEEE_lensingcmblikes.copy()
     chi2 = chi2_lowTE_highTTTEEE_lensingcmblikes.copy()
+    if native:
+        info_likelihood["planck_2018_lowl.EE_native"] = \
+            info_likelihood.pop("planck_2018_lowl.EE")
+        chi2["planck_2018_lowl.EE_native"] = chi2.pop("planck_2018_lowl.EE")
     info_theory = {"camb": {"extra_args": cmb_precision["camb"]}}
     best_fit_derived = derived_lowTE_highTTTEEE_lensingcmblikes
     body_of_test(packages_path, best_fit, info_likelihood, info_theory, chi2,
                  best_fit_derived, skip_not_installed=skip_not_installed)
+
+
+def test_planck_2018_p_camb_native(packages_path, skip_not_installed):
+    test_planck_2018_p_camb(packages_path, skip_not_installed, True)
 
 
 # LITES ##################################################################################

--- a/tests/test_cosmo_planck_2018.py
+++ b/tests/test_cosmo_planck_2018.py
@@ -50,7 +50,7 @@ def test_planck_2018_p_camb(packages_path, skip_not_installed, native=False):
                  best_fit_derived, skip_not_installed=skip_not_installed)
 
 
-def test_planck_2018_p_camb_native(packages_path, skip_not_installed):
+def test_planck_2018_p_native_camb(packages_path, skip_not_installed):
     test_planck_2018_p_camb(packages_path, skip_not_installed, True)
 
 


### PR DESCRIPTION
Very simple lowL EE likelihood (just need someone to produce lowL TT - which is more complicated - and we then wouldn't need clik to do latest NPIPE runs)

Any idea why numba gives such long travis debug logs? (already sets log level to Error on module load)