### PR TITLE
Quick fix for 'KeyError: _manual' bug caused by unmet requirements.

### DIFF
--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -767,7 +767,7 @@ class Model(HasLogger):
                         # If failed requirement was manually added,
                         # remove from list, or it will still fail in the next call too
                         requirements[manual_theory] = [
-                            req for req in requirements[manual_theory]
+                            req for req in requirements.get(manual_theory, [])
                             if req.name != requirement.name]
                         raise LoggedError(self.log,
                                           "Requirement %s of %r is not provided by any "


### PR DESCRIPTION
In some instances, whenever requirements are unmet (e.g. a theory/likelihood code relies on a parameter that is neither sampled nor supplied), cobaya attempts to raise a warning containing the info about said unmet requirement. The code right before that raise statement, however, can sometimes fault itself, because Cobaya tries to remove the unmet requirement from the manual input list, which is not necessarily initialized at this point. This causes an error with the cryptic error message:

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
/tmp/ipykernel_69652/2871735423.py in <module>
     47 }
     48 
---> 49 model = get_model(model_dict)

~/.local/lib/python3.10/site-packages/cobaya/model.py in get_model(info_or_yaml_or_file, debug, stop_at_error, packages_path, override)
   1351             yaml_dump(sort_cosmetic(updated_info)))
   1352     # Initialize the parameters and posterior
-> 1353     return Model(updated_info["params"], updated_info["likelihood"],
   1354                  updated_info.get("prior"), updated_info.get("theory"),
   1355                  packages_path=info.get(packages_path_input),

~/.local/lib/python3.10/site-packages/cobaya/model.py in __init__(self, info_params, info_likelihood, info_prior, info_theory, packages_path, timing, allow_renames, stop_at_error, post, skip_unused_theories, dropped_theory_params)
    242         # Assign input/output parameters
    243         self._assign_params(info_likelihood, info_theory, dropped_theory_params)
--> 244         self._set_dependencies_and_providers(skip_unused_theories=skip_unused_theories)
    245         # Add to the updated info some values that are only available after initialisation
    246         self._updated_info = recursive_update(

~/.local/lib/python3.10/site-packages/cobaya/model.py in _set_dependencies_and_providers(self, manual_requirements, skip_unused_theories)
    761                         print(requirements)
    762                         requirements[manual_theory] = [
--> 763                             req for req in requirements[manual_theory]
    764                             if req.name != requirement.name]
    765                         raise LoggedError(self.log,

KeyError: _manual
```

A simple fix for this, provided here, replaces the `requirements[manual_theory]` lookup with `requirements.get(manual_theory, [])`, to avoid the error.