### PR TITLE
Fixing some general issues, including deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.X.Y – YYYY-MM-DD
+
+### Cosmology
+
+#### CLASS
+
+- Updated manual installation instructions and fixed some dependencies.
+- Made more derived parameters available, and documented how to access even more.
+- Fixed #292: wrong normalization for the Cl cross-spectra (thanks @carlosggarcia)
+
 ## 3.3.2 – 2023-07-28
 
 ### General

--- a/cobaya/component.py
+++ b/cobaya/component.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import inspect
 from inspect import cleandoc
@@ -202,6 +203,9 @@ class HasDefaults:
         try:
             if os.path.split(str(file_name))[0]:
                 raise ValueError(f"{file_name} must be a bare file name, without path.")
+            # NB: resources.read_text is considered deprecated from 3.9, and will fail
+            if sys.version_info < (3, 9):
+                return resources.read_text(package, file_name)
             with (resources.files(package) / file_name).open(
                     "r", encoding="utf-8", errors="strict") as fp:
                 text_content = fp.read()

--- a/cobaya/component.py
+++ b/cobaya/component.py
@@ -200,7 +200,12 @@ class HasDefaults:
         """
         package = inspect.getmodule(cls).__package__
         try:
-            return resources.read_text(package, file_name)
+            if os.path.split(str(file_name))[0]:
+                raise ValueError(f"{file_name} must be a bare file name, without path.")
+            with (resources.files(package) / file_name).open(
+                    "r", encoding="utf-8", errors="strict") as fp:
+                text_content = fp.read()
+            return text_content
         except Exception:
             return None
 

--- a/cobaya/cosmo_input/input_database.py
+++ b/cobaya/cosmo_input/input_database.py
@@ -174,13 +174,13 @@ hubble = {
                         'extra_args': {'theta_H0_range': [H0_min, H0_max]}},
                    'classy': {
                        'params': {
-                           'theta_s_1e2': {'prior': {'min': 0.5, 'max': 10},
+                           'theta_s_100': {'prior': {'min': 0.5, 'max': 10},
                                            'ref': {'dist': 'norm', 'loc': 1.0416,
                                                    'scale': 0.0004},
                                            'proposal': 0.0002,
                                            'latex': '100\\theta_\\mathrm{s}',
                                            'drop': True}, '100*theta_s': {
-                               'value': 'lambda theta_s_1e2: theta_s_1e2',
+                               'value': 'lambda theta_s_100: theta_s_100',
                                'derived': False},
                            'H0': {'latex': 'H_0'}}}}},
     'sound_horizon_lensonly': {

--- a/cobaya/install.py
+++ b/cobaya/install.py
@@ -15,12 +15,13 @@ import traceback
 import shutil
 import tempfile
 import logging
+from copy import deepcopy
 from itertools import chain
-from packaging import version
 import importlib
+from typing import List, Mapping, Union
 import requests  # type: ignore
 import tqdm  # type: ignore
-from typing import List, Mapping, Union
+from packaging import version
 
 # Local
 from cobaya.log import logger_setup, LoggedError, NoLogging, get_logger
@@ -526,6 +527,12 @@ def pip_install(packages, upgrade=False, logger=None, options=(), **kwargs):
     if upgrade:
         cmd += ['--upgrade']
     cmd += list(options)
+    # Assume that if the user has installed Cobaya on the system-wide Python,
+    # then it is OK to overwrite system packages:
+    kwargs = deepcopy(kwargs)
+    if "env" not in kwargs:
+        kwargs["env"] = {}
+    kwargs["env"].update({"PIP_BREAK_SYSTEM_PACKAGES": "1"})
     res = subprocess.call(cmd + packages, **kwargs)
     if res:
         msg = f"pip: error installing packages '{packages}'"

--- a/cobaya/likelihood.py
+++ b/cobaya/likelihood.py
@@ -138,7 +138,7 @@ class Likelihood(Theory, LikelihoodInterface):
         derived: Optional[ParamValuesDict] = {} if want_derived else None
         state["logp"] = -np.inf  # in case of exception
         state["logp"] = self.logp(_derived=derived, **params_values_dict)
-        self.log.debug("Computed log-likelihood = %g", state["logp"])
+        self.log.debug("Computed log-likelihood = %r", state["logp"])
         if derived is not None:
             state["derived"] = derived.copy()
 

--- a/cobaya/likelihoods/base_classes/bao.py
+++ b/cobaya/likelihoods/base_classes/bao.py
@@ -419,7 +419,7 @@ class BAO(InstallableLikelihood):
         if self.use_grid_2d:
             x = self.theory_fun(self.redshift, self.observable_1)
             y = self.theory_fun(self.redshift, self.observable_2)
-            chi2 = float(self.interpolator(x, y)[0])
+            chi2 = self.interpolator(x, y)[0][0]
             return chi2
         elif self.use_grid_3d:
             x = self.theory_fun(self.redshift, self.observable_1)

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -654,10 +654,17 @@ class classy(BoltzmannBase):
         units_factor = self._cmb_unit_factor(
             units, self.current_state['derived_extra']['T_cmb'])
         for cl in cls:
-            if cl not in ['pp', 'ell']:
-                cls[cl][2:] *= units_factor ** 2 * ells_factor
-        if lensed and "pp" in cls and ell_factor:
-            cls['pp'][2:] *= ells_factor ** 2 * (2 * np.pi)
+            if cl == "ell":
+                continue
+            units_power = float(sum(cl.count(p) for p in ["t", "e", "b"]))
+            cls[cl][2:] *= units_factor**units_power
+            if ell_factor:
+                if "p" not in cl:
+                    cls[cl][2:] *= ells_factor
+                elif cl == "pp" and lensed:
+                    cls[cl][2:] *= ells_factor ** 2 * (2 * np.pi)
+                elif "p" in cl and lensed:
+                    cls[cl][2:] *= ells_factor ** (3 / 2) * np.sqrt(2 * np.pi)
         return cls
 
     def get_Cl(self, ell_factor=False, units="FIRASmuK2"):

--- a/cobaya/theories/classy/classy.py
+++ b/cobaya/theories/classy/classy.py
@@ -740,7 +740,9 @@ class classy(BoltzmannBase):
             log.info("Code not requested. Nothing to do.")
             return True
         log.info("Installing pre-requisites...")
-        exit_status = pip_install("cython")
+        # TODO: remove version restriction below when this issue is fixed:
+        # https://github.com/lesgourg/class_public/issues/531
+        exit_status = pip_install("cython<3")
         if exit_status:
             log.error("Could not install pre-requisite: cython")
             return False

--- a/cobaya/theories/cosmo/boltzmannbase.py
+++ b/cobaya/theories/cosmo/boltzmannbase.py
@@ -329,8 +329,9 @@ class BoltzmannBase(Theory):
         The ``muK2`` and ``K2`` options use the model's CMB temperature.
 
         If ``ell_factor=True`` (default: ``False``), multiplies the spectra by
-        :math:`\ell(\ell+1)/(2\pi)` (or by :math:`\ell^2(\ell+1)^2/(2\pi)` in the case of
-        the lensing potential ``pp`` spectrum).
+        :math:`\ell(\ell+1)/(2\pi)` (or by :math:`[\ell(\ell+1)]^2/(2\pi)` in the case of
+        the lensing potential ``pp`` spectrum, and :math:`[\ell(\ell+1)]^{3/2}/(2\pi)` for
+        the the cross spectra ``tp`` and ``ep``).
         """
 
     @abstract

--- a/docs/src_examples/cosmo_basic/basic_classy.yaml
+++ b/docs/src_examples/cosmo_basic/basic_classy.yaml
@@ -35,7 +35,7 @@ params:
       scale: 0.004
     proposal: 0.002
     latex: n_\mathrm{s}
-  theta_s_1e2:
+  theta_s_100:
     prior:
       min: 0.5
       max: 10
@@ -47,7 +47,7 @@ params:
     latex: 100\theta_\mathrm{s}
     drop: true
   100*theta_s:
-    value: 'lambda theta_s_1e2: theta_s_1e2'
+    value: 'lambda theta_s_100: theta_s_100'
     derived: false
   H0:
     latex: H_0

--- a/docs/theory_camb.rst
+++ b/docs/theory_camb.rst
@@ -4,8 +4,8 @@ CAMB
 .. automodule:: theories.camb.camb
    :noindex:
 
-camb class
-----------
+Documentation of the ``camb`` wrapper class
+-------------------------------------------
    
 .. autoclass:: theories.camb.CAMB
    :members:

--- a/docs/theory_class.rst
+++ b/docs/theory_class.rst
@@ -4,8 +4,8 @@ CLASS (``classy``)
 .. automodule:: theories.classy.classy
    :noindex:
 
-``classy`` class
-----------------
+Documentation of the ``classy`` wrapper class
+---------------------------------------------
    
 .. autoclass:: theories.classy.classy
    :members:

--- a/tests/test_cosmo_camb.py
+++ b/tests/test_cosmo_camb.py
@@ -15,7 +15,7 @@ def get_camb(packages_path):
     try:
         return load_module("camb", path=os.path.join(process_packages_path(packages_path),
                                                      "code", "CAMB"))
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, SystemExit):
         raise ComponentNotInstalledError('camb')
 
 

--- a/tests/test_cosmo_planck_NPIPE.py
+++ b/tests/test_cosmo_planck_NPIPE.py
@@ -1,11 +1,10 @@
 import numpy as np
-import pytest
 
-from cobaya.install import install
 from cobaya.model import get_model
 from cobaya.yaml import yaml_load
 
 from .common import process_packages_path
+from .conftest import install_test_wrapper
 
 yaml = r"""
 theory:
@@ -35,15 +34,11 @@ params:
 """
 
 
-def test_planck_NPIPE_p_CamSpec_camb_install(packages_path):
+def test_planck_NPIPE_p_CamSpec_camb_install(packages_path, skip_not_installed):
     packages_path = process_packages_path(packages_path)
     info = yaml_load(yaml)
-    result = install(info, path=packages_path)
-    if result is False:
-        raise pytest.xfail("Some component(s) skipped")
-
-    model = get_model(info, packages_path=packages_path)
+    model = install_test_wrapper(
+        skip_not_installed, get_model, info, packages_path=packages_path)
     pars = (0.99818025, 10.35947284, 18.67072461, 7.54932654, 0.83715482,
             0.94987418, 1.23385364, 0.98781552, 1.013345)
-
     assert np.isclose(model.logposterior(pars).logpost, -5889.873, rtol=1e-4)

--- a/tests/test_cosmo_run.py
+++ b/tests/test_cosmo_run.py
@@ -10,6 +10,7 @@ from cobaya.tools import deepcopy_where_possible
 from cobaya.cosmo_input.convert_cosmomc import cosmomc_root_to_cobaya_info_dict
 from cobaya.log import NoLogging
 from .common import process_packages_path
+from .conftest import install_test_wrapper
 
 pytestmark = pytest.mark.mpi
 
@@ -87,12 +88,12 @@ def test_cosmo_run_not_found():
 
 
 @mpi.sync_errors
-def test_cosmo_run_resume_post(tmpdir, packages_path=None):
+def test_cosmo_run_resume_post(tmpdir, skip_not_installed, packages_path=None):
     # only vary As, so fast chain. Chain does not need to converge (tested elsewhere).
     info['output'] = os.path.join(tmpdir, 'testchain')
     if packages_path:
         info["packages_path"] = process_packages_path(packages_path)
-    run(info, force=True)
+    install_test_wrapper(skip_not_installed, run, info, force=True)
     # note that continuing from files leads to text-file precision at read in, so a mix of
     # precision in the output SampleCollection returned from run
     run(info, resume=True, override={'sampler': {'mcmc': {'Rminus1_stop': 0.2}}})


### PR DESCRIPTION
Fixing random stuff that has come up in some issues and cosmo coffee topics, as well as deprecation warnings after updating my laptop to Python 3.11 and the latest versions of some libs.

A particularly annoying is this one: https://github.com/numpy/numpy/pull/10615. Not sure if we will be able to catch all occurrences before it actually fails.