### PR TITLE
Added act_dr6_lenslike to external packages

### DIFF
--- a/docs/likelihood_external.rst
+++ b/docs/likelihood_external.rst
@@ -20,6 +20,7 @@ List of external packages
  * `Planck NPIPE lensing <https://github.com/carronj/planck_PR4_lensing>`_
  * `Planck NPIPE hillipop and lollipop <https://github.com/planck-npipe>`_
  * `ACTPol DR4 <https://github.com/ACTCollaboration/pyactlike>`_
+ * `ACT DR6 Lensing <https://github.com/ACTCollaboration/act_dr6_lenslike>`_
  * `SPT-SZ, SPTPol & SPT-3G <https://github.com/xgarrido/spt_likelihoods>`_
  * `cobaya-mock-cmb <https://github.com/misharash/cobaya_mock_cmb>`_
  * `pyWMAP <https://github.com/HTJense/pyWMAP>`_


### PR DESCRIPTION
Adds the `act_dr6_lenslike` to the external packages list in the docs.