### PR TITLE
Add the TDCOSMO likelihood to likelihood_external.rst

### DIFF
--- a/docs/likelihood_external.rst
+++ b/docs/likelihood_external.rst
@@ -25,6 +25,7 @@ List of external packages
  * `cobaya-mock-cmb <https://github.com/misharash/cobaya_mock_cmb>`_
  * `pyWMAP <https://github.com/HTJense/pyWMAP>`_
  * `Mock CMB-HD <https://github.com/CMB-HD/hdlike>`_
+ * `TDCOSMO strong lensing time delays <https://github.com/nataliehogg/tdcosmo_ext>`_
  * `Example - simple demo <https://github.com/CobayaSampler/example_external_likelihood>`_
  * `Example - Planck lensing <https://github.com/CobayaSampler/planck_lensing_external>`_
 


### PR DESCRIPTION
Adds the hierarchical strong lensing time delay likelihood of TDCOSMO IV ([Birrer et al. 2020](https://arxiv.org/abs/2007.02941)) to the docs.