### PR TITLE
iMinuit minimizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,10 @@ before_install:
     conda info -a;
     conda create -q -n test-environment -c $ANACONDA_CHANNEL python=$TRAVIS_PYTHON_VERSION scipy matplotlib cython PyYAML pytest pytest-forked pytest-cov flaky dill coverage flake8;
     source activate test-environment;
-    conda install -c conda-forge mpi4py openmpi;
+    conda install -c conda-forge mpi4py openmpi iminuit;
     else
     python -m pip install --upgrade pip setuptools wheel;
-    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8;
+    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8 iminuit;
     fi
   - python --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,10 @@ before_install:
     conda info -a;
     conda create -q -n test-environment -c $ANACONDA_CHANNEL python=$TRAVIS_PYTHON_VERSION scipy matplotlib cython PyYAML pytest pytest-forked pytest-cov flaky dill coverage flake8;
     source activate test-environment;
-    conda install -c conda-forge mpi4py openmpi iminuit;
+    conda install -c conda-forge mpi4py openmpi;
     else
     python -m pip install --upgrade pip setuptools wheel;
-    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8 iminuit;
+    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8;
     fi
   - python --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,10 @@ before_install:
     conda info -a;
     conda create -q -n test-environment -c $ANACONDA_CHANNEL python=$TRAVIS_PYTHON_VERSION scipy matplotlib cython PyYAML pytest pytest-forked pytest-cov flaky dill coverage flake8;
     source activate test-environment;
-    conda install -c conda-forge mpi4py openmpi;
+    conda install -c conda-forge mpi4py openmpi; # iminuit;
     else
     python -m pip install --upgrade pip setuptools wheel;
-    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8;
+    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8; # iminuit;
     fi
   - python --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,10 @@ before_install:
     conda info -a;
     conda create -q -n test-environment -c $ANACONDA_CHANNEL python=$TRAVIS_PYTHON_VERSION scipy matplotlib cython PyYAML pytest pytest-forked pytest-cov flaky dill coverage flake8;
     source activate test-environment;
-    conda install -c conda-forge mpi4py openmpi; # iminuit;
+    conda install -c conda-forge mpi4py openmpi iminuit;
     else
     python -m pip install --upgrade pip setuptools wheel;
-    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8; # iminuit;
+    pip install mpi4py pytest-forked pytest-cov flaky matplotlib dill coverage flake8 iminuit;
     fi
   - python --version
 

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -12,6 +12,7 @@ import sys
 import logging
 import platform
 import traceback
+from collections import ChainMap
 from copy import deepcopy
 import functools
 from random import shuffle, choice
@@ -282,7 +283,8 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return deepcopy(self).__dict__
+        return ChainMap({}, self).__dict__
+        #return deepcopy(self).__dict__
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -12,7 +12,6 @@ import sys
 import logging
 import platform
 import traceback
-from collections import ChainMap
 from copy import deepcopy
 import functools
 from random import shuffle, choice
@@ -283,8 +282,7 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return ChainMap({}, self).__dict__
-        #return deepcopy(self).__dict__
+        return deepcopy(self).__dict__
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -315,7 +315,10 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return deepcopy_where_possible(self)
+        try:
+            return deepcopy_where_possible(self).__dict__
+        except:
+            return deepcopy_where_possible(self)
         # return deepcopy(self).__dict__
 
     def __setstate__(self, d):

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -12,6 +12,7 @@ import sys
 import logging
 import platform
 import traceback
+from collections import ChainMap
 from copy import deepcopy
 import functools
 from random import shuffle, choice
@@ -282,7 +283,8 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return deepcopy(self).__dict__
+        return ChainMap({}, self).__dict__
+        # return deepcopy(self).__dict__
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -319,7 +319,6 @@ class HasLogger:
             return deepcopy_where_possible(self).__dict__
         except:
             return deepcopy_where_possible(self)
-        # return deepcopy(self).__dict__
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -12,7 +12,6 @@ import sys
 import logging
 import platform
 import traceback
-from collections import ChainMap
 from copy import deepcopy
 import functools
 from random import shuffle, choice
@@ -283,7 +282,7 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return ChainMap({}, self).__dict__
+        return self.__deepcopy__().__dict__
         # return deepcopy(self).__dict__
 
     def __setstate__(self, d):

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -15,7 +15,6 @@ import traceback
 from copy import deepcopy
 import functools
 from random import shuffle, choice
-from typing import Mapping, TypeVar, Callable
 
 # Local
 from cobaya import mpi
@@ -263,38 +262,6 @@ def get_traceback_text(exec_info):
                    ["\n"] + ["-"] * 37)
 
 
-_R = TypeVar('_R')
-
-
-def deepcopy_where_possible(base: _R) -> _R:
-    """
-    Deepcopies an object whenever possible. If the object cannot be copied, returns a
-    reference to the original object (this applies recursively to values of
-    a dictionary, and converts all Mapping objects into dict).
-
-    Rationale: cobaya tries to manipulate its input as non-destructively as possible,
-    and to do that it works on a copy of it; but some of the values passed to cobaya
-    may not be copyable (if they are not pickleable). This function provides a
-    compromise solution. To allow dict comparisons and make the copy mutable it converts
-    MappingProxyType and other Mapping types into plain dict.
-    """
-    if isinstance(base, Mapping):
-        _copy = {}
-        for key, value in base.items():
-            _copy[key] = deepcopy_where_possible(value)
-        return _copy  # type: ignore
-    if isinstance(base, (HasLogger, type)):
-        return base  # type: ignore
-    else:
-        # Special case: instance methods can be copied, but should not be.
-        if isinstance(base, Callable) and hasattr(base, "__self__"):
-            return base
-        try:
-            return deepcopy(base)
-        except:
-            return base
-
-
 class HasLogger:
     """
     Class having a logger with its name (or an alternative one).
@@ -315,10 +282,7 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        try:
-            return deepcopy_where_possible(self).__dict__
-        except:
-            return deepcopy_where_possible(self)
+        return deepcopy(self).__dict__
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -15,6 +15,7 @@ import traceback
 from copy import deepcopy
 import functools
 from random import shuffle, choice
+from typing import Mapping
 
 # Local
 from cobaya import mpi
@@ -282,7 +283,10 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return self.__deepcopy__().__dict__
+        if isinstance(self, Mapping):
+            return {k: self.__getstate__(v) for k, v in self.items()}
+        else:
+            return self
         # return deepcopy(self).__dict__
 
     def __setstate__(self, d):

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -294,6 +294,7 @@ def deepcopy_where_possible(base: _R) -> _R:
         except:
             return base
 
+
 class HasLogger:
     """
     Class having a logger with its name (or an alternative one).
@@ -314,7 +315,7 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return deepcopy_where_possible(self).__dict__
+        return deepcopy_where_possible(self)
         # return deepcopy(self).__dict__
 
     def __setstate__(self, d):

--- a/cobaya/samplers/minimize/minimize.bibtex
+++ b/cobaya/samplers/minimize/minimize.bibtex
@@ -68,3 +68,18 @@ archivePrefix = {arXiv},
   adsurl  = {https://rdcu.be/b08Wh},
   doi     = {10.1038/s41592-019-0686-2},
 }
+
+### If using iMinuit ###
+
+@ARTICLE{1975CoPhC..10..343J,
+       author = {James, Frederick and Roos, Matts},
+        title = "{Minuit - a system for function minimization and analysis of the parameter errors and correlations}",
+      journal = {Computer Physics Communications},
+         year = 1975,
+        month = dec,
+       volume = {10},
+       number = {6},
+        pages = {343-367},
+          doi = {10.1016/0010-4655(75)90039-9},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/1975CoPhC..10..343J},
+}

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -111,7 +111,7 @@ from cobaya.sampler import CovmatSampler
 from cobaya import mpi
 
 # Handling scipy vs BOBYQA vs iMinuit
-evals_attr = {"scipy": "fun", "bobyqa": "f"} #, "iminuit": "fun"}
+evals_attr = {"scipy": "fun", "bobyqa": "f", "iminuit": "fun"}
 valid_methods = tuple(evals_attr)
 
 # Conventions conventions
@@ -146,7 +146,7 @@ class Minimize(Minimizer, CovmatSampler):
     best_of: int
     override_bobyqa: Optional[dict]
     override_scipy: Optional[dict]
-    # override_iminuit: Optional[dict]
+    override_iminuit: Optional[dict]
     max_evals: Union[str, int]
 
     def initialize(self):
@@ -286,31 +286,31 @@ class Minimize(Minimizer, CovmatSampler):
                             "Finished unsuccessfully. Reason: %s",
                             _bobyqa_errors[result.flag]
                         )
-                # elif self.method.lower() == "iminuit":
-                #     try:
-                #         import iminuit
-                #     except ImportError:
-                #         raise LoggedError(
-                #             self.log, "You need to install iminuit to use the "
-                #             "'iminuit' minimizer. Try 'pip install iminuit'.")
-                #     self.kwargs = {
-                #         "fun": minuslogp_transf,
-                #         "x0": initial_point,
-                #         "bounds": bounds,
-                #         "options": {
-                #             "maxfun": self.max_iter,
-                #             "disp": self.is_debug()}}
-                #     self.kwargs = recursive_update(
-                #         self.kwargs, self.override_iminuit or {}
-                #     )
-                #     self.log.debug(
-                #         "Arguments for iminuit.Minimize:\n%r",
-                #         {k: v for k, v in self.kwargs.items() if k != "fun"},
-                #     )
-                #     result = iminuit.minimize(**self.kwargs, method="migrad")
-                #     success = result.success
-                #     if not success:
-                #         self.log.error("Finished unsuccessfully.")
+                elif self.method.lower() == "iminuit":
+                    try:
+                        import iminuit
+                    except ImportError:
+                        raise LoggedError(
+                            self.log, "You need to install iminuit to use the "
+                            "'iminuit' minimizer. Try 'pip install iminuit'.")
+                    self.kwargs = {
+                        "fun": minuslogp_transf,
+                        "x0": initial_point,
+                        "bounds": bounds,
+                        "options": {
+                            "maxfun": self.max_iter,
+                            "disp": self.is_debug()}}
+                    self.kwargs = recursive_update(
+                        self.kwargs, self.override_iminuit or {}
+                    )
+                    self.log.debug(
+                        "Arguments for iminuit.Minimize:\n%r",
+                        {k: v for k, v in self.kwargs.items() if k != "fun"},
+                    )
+                    result = iminuit.minimize(**self.kwargs, method="migrad")
+                    success = result.success
+                    if not success:
+                        self.log.error("Finished unsuccessfully.")
                 else:
                     self.kwargs = {
                         "fun": minuslogp_transf,
@@ -525,15 +525,14 @@ class Minimize(Minimizer, CovmatSampler):
         desc_scipy = (r"Scipy minimizer \cite{2020SciPy-NMeth} (check citation for the "
                       r"actual algorithm used at \url{https://docs.scipy.org/doc/scipy/re"
                       r"ference/generated/scipy.optimize.Minimize.html}")
-
-        # desc_iminuit = (r"iminuit minimizer(check citation for the "
-        #                 r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}")
+        desc_iminuit = (r"iminuit minimizer(check citation for the "
+                        r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}")
         if method and method.lower() == "bobyqa":
             return desc_bobyqa
         elif method and method.lower() == "scipy":
             return desc_scipy
-        # elif method and method.lower() == "iminuit":
-        #     return desc_iminuit
+        elif method and method.lower() == "iminuit":
+            return desc_iminuit
         else:  # unknown method or no info passed (None)
             return ("Minimizer -- method unknown, possibly one of:"
                     "\na) " + desc_bobyqa + "\nb) " + desc_scipy)

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -396,7 +396,6 @@ class Minimize(Minimizer, CovmatSampler):
         self.log.info(
             "Parameter values at minimum:\n%s", self.minimum.data.to_string())
         self.minimum.out_update()
-        self.log.info("The complete set of minima is: %r", self.full_set_minima)
         self.dump_getdist()
 
     def products(self):

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -356,11 +356,8 @@ class Minimize(Minimizer, CovmatSampler):
             mins = [(getattr(r, evals_attr_) if s else np.inf)
                     for r, s in zip(results, successes)]
             i_min: int = np.argmin(mins)  # type: ignore
-            self.full_set_minima = mins
-            self.log.info("The complete set of minima is: %r", self.full_set_minima)
         else:
             i_min = 0
-            self.full_set_minima = results[i_min].fun
         self.result = results[i_min]
         self._affine_transform_baseline = affine_transform_baselines[i_min]
         self._inv_affine_transform_matrix = transform_matrices[i_min]
@@ -399,6 +396,13 @@ class Minimize(Minimizer, CovmatSampler):
         self.log.info(
             "Parameter values at minimum:\n%s", self.minimum.data.to_string())
         self.minimum.out_update()
+        if len(results) > 1:
+            mins = [(getattr(r, evals_attr_) if s else np.inf)
+                    for r, s in zip(results, successes)]
+            self.full_set_minima = mins
+        else:
+            self.full_set_minima = self.minimum
+        self.log.info("The complete set of minima is: %r", self.full_set_minima)
         self.dump_getdist()
 
     def products(self):

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -356,11 +356,11 @@ class Minimize(Minimizer, CovmatSampler):
             mins = [(getattr(r, evals_attr_) if s else np.inf)
                     for r, s in zip(results, successes)]
             i_min: int = np.argmin(mins)  # type: ignore
-            # self.full_set_minima = mins
-            # self.log.info("The complete set of minima is: %r", self.full_set_minima)
+            self.full_set_minima = mins
+            self.log.info("The complete set of minima is: %r", self.full_set_minima)
         else:
             i_min = 0
-            # self.full_set_minima = results[i_min].fun
+            self.full_set_minima = results[i_min].fun
         self.result = results[i_min]
         self._affine_transform_baseline = affine_transform_baselines[i_min]
         self._inv_affine_transform_matrix = transform_matrices[i_min]
@@ -426,7 +426,7 @@ class Minimize(Minimizer, CovmatSampler):
         ``result_object``.
         """
         return {"minimum": self.minimum, "result_object": self.result,
-                # "full_set_minima": self.full_set_minima,
+                "full_set_minima": self.full_set_minima,
                 "M": self._inv_affine_transform_matrix,
                 "X0": self._affine_transform_baseline}
 

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -100,7 +100,6 @@ import numpy as np
 from scipy import optimize
 import pybobyqa
 from pybobyqa import controller
-import iminuit
 
 # Local
 from cobaya.sampler import Minimizer
@@ -288,6 +287,12 @@ class Minimize(Minimizer, CovmatSampler):
                             _bobyqa_errors[result.flag]
                         )
                 elif self.method.lower() == "iminuit":
+                    try:
+                        import iminuit
+                    except ImportError:
+                        raise LoggedError(
+                            self.log, "You need to install iminuit to use the "
+                            "'iminuit' minimizer. Try 'pip install iminuit'.")
                     self.kwargs = {
                         "fun": minuslogp_transf,
                         "x0": initial_point,

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -351,8 +351,11 @@ class Minimize(Minimizer, CovmatSampler):
             mins = [(getattr(r, evals_attr_) if s else np.inf)
                     for r, s in zip(results, successes)]
             i_min: int = np.argmin(mins)  # type: ignore
+            self.full_set_minima = mins
+            self.log.info("The complete set of minima is: %r", self.full_set_minima)
         else:
             i_min = 0
+            self.full_set_minima = results[i_min].fun
         self.result = results[i_min]
         self._affine_transform_baseline = affine_transform_baselines[i_min]
         self._inv_affine_transform_matrix = transform_matrices[i_min]
@@ -418,6 +421,7 @@ class Minimize(Minimizer, CovmatSampler):
         ``result_object``.
         """
         return {"minimum": self.minimum, "result_object": self.result,
+                "full_set_minima": self.full_set_minima,
                 "M": self._inv_affine_transform_matrix,
                 "X0": self._affine_transform_baseline}
 

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -525,6 +525,7 @@ class Minimize(Minimizer, CovmatSampler):
         desc_scipy = (r"Scipy minimizer \cite{2020SciPy-NMeth} (check citation for the "
                       r"actual algorithm used at \url{https://docs.scipy.org/doc/scipy/re"
                       r"ference/generated/scipy.optimize.Minimize.html}")
+
         # desc_iminuit = (r"iminuit minimizer(check citation for the "
         #                 r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}")
         if method and method.lower() == "bobyqa":

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -111,7 +111,7 @@ from cobaya.sampler import CovmatSampler
 from cobaya import mpi
 
 # Handling scipy vs BOBYQA vs iMinuit
-evals_attr = {"scipy": "fun", "bobyqa": "f"}#, "iminuit": "fun"}
+evals_attr = {"scipy": "fun", "bobyqa": "f"} #, "iminuit": "fun"}
 valid_methods = tuple(evals_attr)
 
 # Conventions conventions
@@ -146,7 +146,7 @@ class Minimize(Minimizer, CovmatSampler):
     best_of: int
     override_bobyqa: Optional[dict]
     override_scipy: Optional[dict]
-    override_iminuit: Optional[dict]
+    # override_iminuit: Optional[dict]
     max_evals: Union[str, int]
 
     def initialize(self):
@@ -286,31 +286,31 @@ class Minimize(Minimizer, CovmatSampler):
                             "Finished unsuccessfully. Reason: %s",
                             _bobyqa_errors[result.flag]
                         )
-                elif self.method.lower() == "iminuit":
-                    try:
-                        import iminuit
-                    except ImportError:
-                        raise LoggedError(
-                            self.log, "You need to install iminuit to use the "
-                            "'iminuit' minimizer. Try 'pip install iminuit'.")
-                    self.kwargs = {
-                        "fun": minuslogp_transf,
-                        "x0": initial_point,
-                        "bounds": bounds,
-                        "options": {
-                            "maxfun": self.max_iter,
-                            "disp": self.is_debug()}}
-                    self.kwargs = recursive_update(
-                        self.kwargs, self.override_iminuit or {}
-                    )
-                    self.log.debug(
-                        "Arguments for iminuit.Minimize:\n%r",
-                        {k: v for k, v in self.kwargs.items() if k != "fun"},
-                    )
-                    result = iminuit.minimize(**self.kwargs, method="migrad")
-                    success = result.success
-                    if not success:
-                        self.log.error("Finished unsuccessfully.")
+                # elif self.method.lower() == "iminuit":
+                #     try:
+                #         import iminuit
+                #     except ImportError:
+                #         raise LoggedError(
+                #             self.log, "You need to install iminuit to use the "
+                #             "'iminuit' minimizer. Try 'pip install iminuit'.")
+                #     self.kwargs = {
+                #         "fun": minuslogp_transf,
+                #         "x0": initial_point,
+                #         "bounds": bounds,
+                #         "options": {
+                #             "maxfun": self.max_iter,
+                #             "disp": self.is_debug()}}
+                #     self.kwargs = recursive_update(
+                #         self.kwargs, self.override_iminuit or {}
+                #     )
+                #     self.log.debug(
+                #         "Arguments for iminuit.Minimize:\n%r",
+                #         {k: v for k, v in self.kwargs.items() if k != "fun"},
+                #     )
+                #     result = iminuit.minimize(**self.kwargs, method="migrad")
+                #     success = result.success
+                #     if not success:
+                #         self.log.error("Finished unsuccessfully.")
                 else:
                     self.kwargs = {
                         "fun": minuslogp_transf,
@@ -356,11 +356,11 @@ class Minimize(Minimizer, CovmatSampler):
             mins = [(getattr(r, evals_attr_) if s else np.inf)
                     for r, s in zip(results, successes)]
             i_min: int = np.argmin(mins)  # type: ignore
-            self.full_set_minima = mins
-            self.log.info("The complete set of minima is: %r", self.full_set_minima)
+            # self.full_set_minima = mins
+            # self.log.info("The complete set of minima is: %r", self.full_set_minima)
         else:
             i_min = 0
-            self.full_set_minima = results[i_min].fun
+            # self.full_set_minima = results[i_min].fun
         self.result = results[i_min]
         self._affine_transform_baseline = affine_transform_baselines[i_min]
         self._inv_affine_transform_matrix = transform_matrices[i_min]
@@ -426,7 +426,7 @@ class Minimize(Minimizer, CovmatSampler):
         ``result_object``.
         """
         return {"minimum": self.minimum, "result_object": self.result,
-                "full_set_minima": self.full_set_minima,
+                # "full_set_minima": self.full_set_minima,
                 "M": self._inv_affine_transform_matrix,
                 "X0": self._affine_transform_baseline}
 
@@ -525,14 +525,14 @@ class Minimize(Minimizer, CovmatSampler):
         desc_scipy = (r"Scipy minimizer \cite{2020SciPy-NMeth} (check citation for the "
                       r"actual algorithm used at \url{https://docs.scipy.org/doc/scipy/re"
                       r"ference/generated/scipy.optimize.Minimize.html}")
-        desc_iminuit = (r"iminuit minimizer(check citation for the "
-                        r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}")
+        # desc_iminuit = (r"iminuit minimizer(check citation for the "
+        #                 r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}")
         if method and method.lower() == "bobyqa":
             return desc_bobyqa
         elif method and method.lower() == "scipy":
             return desc_scipy
-        elif method and method.lower() == "iminuit":
-            return desc_iminuit
+        # elif method and method.lower() == "iminuit":
+        #     return desc_iminuit
         else:  # unknown method or no info passed (None)
             return ("Minimizer -- method unknown, possibly one of:"
                     "\na) " + desc_bobyqa + "\nb) " + desc_scipy)

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -100,6 +100,7 @@ import numpy as np
 from scipy import optimize
 import pybobyqa
 from pybobyqa import controller
+import iminuit
 
 # Local
 from cobaya.sampler import Minimizer
@@ -110,8 +111,8 @@ from cobaya.tools import read_dnumber, recursive_update
 from cobaya.sampler import CovmatSampler
 from cobaya import mpi
 
-# Handling scipy vs BOBYQA
-evals_attr = {"scipy": "fun", "bobyqa": "f"}
+# Handling scipy vs BOBYQA vs iMinuit
+evals_attr = {"scipy": "fun", "bobyqa": "f", "iminuit": "fun"}
 valid_methods = tuple(evals_attr)
 
 # Conventions conventions
@@ -146,6 +147,7 @@ class Minimize(Minimizer, CovmatSampler):
     best_of: int
     override_bobyqa: Optional[dict]
     override_scipy: Optional[dict]
+    override_iminuit: Optional[dict]
     max_evals: Union[str, int]
 
     def initialize(self):
@@ -285,6 +287,25 @@ class Minimize(Minimizer, CovmatSampler):
                             "Finished unsuccessfully. Reason: %s",
                             _bobyqa_errors[result.flag]
                         )
+                elif self.method.lower() == "iminuit":
+                    self.kwargs = {
+                        "fun": minuslogp_transf,
+                        "x0": initial_point,
+                        "bounds": bounds,
+                        "options": {
+                            "maxfun": self.max_iter,
+                            "disp": self.is_debug()}}
+                    self.kwargs = recursive_update(
+                        self.kwargs, self.override_iminuit or {}
+                    )
+                    self.log.debug(
+                        "Arguments for iminuit.Minimize:\n%r",
+                        {k: v for k, v in self.kwargs.items() if k != "fun"},
+                    )
+                    result = iminuit.minimize(**self.kwargs, method="migrad")
+                    success = result.success
+                    if not success:
+                        self.log.error("Finished unsuccessfully.")
                 else:
                     self.kwargs = {
                         "fun": minuslogp_transf,
@@ -495,10 +516,16 @@ class Minimize(Minimizer, CovmatSampler):
         desc_scipy = (r"Scipy minimizer \cite{2020SciPy-NMeth} (check citation for the "
                       r"actual algorithm used at \url{https://docs.scipy.org/doc/scipy/re"
                       r"ference/generated/scipy.optimize.Minimize.html}")
+        desc_iminuit = (
+            r"iminuit minimizer(check citation for the "
+            r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}"
+        )
         if method and method.lower() == "bobyqa":
             return desc_bobyqa
         elif method and method.lower() == "scipy":
             return desc_scipy
+        elif method and method.lower() == "iminuit":
+            return desc_iminuit
         else:  # unknown method or no info passed (None)
             return ("Minimizer -- method unknown, possibly one of:"
                     "\na) " + desc_bobyqa + "\nb) " + desc_scipy)

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -525,10 +525,8 @@ class Minimize(Minimizer, CovmatSampler):
         desc_scipy = (r"Scipy minimizer \cite{2020SciPy-NMeth} (check citation for the "
                       r"actual algorithm used at \url{https://docs.scipy.org/doc/scipy/re"
                       r"ference/generated/scipy.optimize.Minimize.html}")
-        desc_iminuit = (
-            r"iminuit minimizer(check citation for the "
-            r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}"
-        )
+        desc_iminuit = (r"iminuit minimizer(check citation for the "
+                        r"actual algorithm used at \url{https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface}")
         if method and method.lower() == "bobyqa":
             return desc_bobyqa
         elif method and method.lower() == "scipy":

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -396,12 +396,6 @@ class Minimize(Minimizer, CovmatSampler):
         self.log.info(
             "Parameter values at minimum:\n%s", self.minimum.data.to_string())
         self.minimum.out_update()
-        if len(results) > 1:
-            mins = [(getattr(r, evals_attr_) if s else np.inf)
-                    for r, s in zip(results, successes)]
-            self.full_set_minima = mins
-        else:
-            self.full_set_minima = self.minimum
         self.log.info("The complete set of minima is: %r", self.full_set_minima)
         self.dump_getdist()
 
@@ -430,7 +424,6 @@ class Minimize(Minimizer, CovmatSampler):
         ``result_object``.
         """
         return {"minimum": self.minimum, "result_object": self.result,
-                "full_set_minima": self.full_set_minima,
                 "M": self._inv_affine_transform_matrix,
                 "X0": self._affine_transform_baseline}
 

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -292,7 +292,7 @@ class Minimize(Minimizer, CovmatSampler):
                     except ImportError:
                         raise LoggedError(
                             self.log, "You need to install iminuit to use the "
-                            "'iminuit' minimizer. Try 'pip install iminuit'.")
+                                      "'iminuit' minimizer. Try 'pip install iminuit'.")
                     self.kwargs = {
                         "fun": minuslogp_transf,
                         "x0": initial_point,
@@ -311,6 +311,7 @@ class Minimize(Minimizer, CovmatSampler):
                     success = result.success
                     if not success:
                         self.log.error("Finished unsuccessfully.")
+                    result.pop("minuit")  # problem with pickle/mpi?
                 else:
                     self.kwargs = {
                         "fun": minuslogp_transf,
@@ -327,9 +328,7 @@ class Minimize(Minimizer, CovmatSampler):
                     if not success:
                         self.log.error("Finished unsuccessfully.")
                 if success:
-                    self.log.info(
-                        "Run %d/%d converged.", i + 1, len(self.initial_points)
-                    )
+                    self.log.info("Run %d/%d converged.", i + 1, len(self.initial_points))
             except Exception as excpt:
                 self.log.error("Minimizer '%s' raised an unexpected error:", self.method)
                 raise excpt

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -111,7 +111,7 @@ from cobaya.sampler import CovmatSampler
 from cobaya import mpi
 
 # Handling scipy vs BOBYQA vs iMinuit
-evals_attr = {"scipy": "fun", "bobyqa": "f", "iminuit": "fun"}
+evals_attr = {"scipy": "fun", "bobyqa": "f"}#, "iminuit": "fun"}
 valid_methods = tuple(evals_attr)
 
 # Conventions conventions

--- a/cobaya/samplers/minimize/minimize.yaml
+++ b/cobaya/samplers/minimize/minimize.yaml
@@ -14,7 +14,7 @@ best_of: 2
 confidence_for_unbounded: 0.9999995  # 5 sigmas of the prior
 # Seeding runs
 seed:  # an initial seed (entropy) for the numpy random generator
-# Override keyword arguments for `scipy.optimize.minimize()` or `pybobyqa.solve()`
+# Override keyword arguments for `scipy.optimize.minimize()` or `pybobyqa.solve()` or `iminuit.minimize()`
 # scipy:
 #  - https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
 #  - options for individual methods
@@ -27,6 +27,11 @@ override_bobyqa:
   # option: value
   # Relaxed convergence criterion for numerically-noisy likelihoods
   rhoend: 0.05
+# iminuit:
+#  - https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface
+#  - options for individual methods
+override_iminuit:
+# option: value
 # File (including path) or matrix defining a covariance matrix for the proposal:
 # - null (default): will be generated from params info (prior and proposal)
 # - matrix: remember to set `covmat_params` to the parameters in the matrix

--- a/cobaya/samplers/minimize/minimize.yaml
+++ b/cobaya/samplers/minimize/minimize.yaml
@@ -30,7 +30,7 @@ override_bobyqa:
 # iminuit:
 #  - https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface
 #  - options for individual methods
-# override_iminuit:
+override_iminuit:
 # option: value
 # File (including path) or matrix defining a covariance matrix for the proposal:
 # - null (default): will be generated from params info (prior and proposal)

--- a/cobaya/samplers/minimize/minimize.yaml
+++ b/cobaya/samplers/minimize/minimize.yaml
@@ -30,7 +30,7 @@ override_bobyqa:
 # iminuit:
 #  - https://iminuit.readthedocs.io/en/stable/reference.html#scipy-like-interface
 #  - options for individual methods
-override_iminuit:
+# override_iminuit:
 # option: value
 # File (including path) or matrix defining a covariance matrix for the proposal:
 # - null (default): will be generated from params info (prior and proposal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-forked", "flaky", "mpi4py"]
+test = ["pytest", "pytest-forked", "flaky", "mpi4py", "iminuit"]
 gui = ["pyside6", "matplotlib"]
 docs = [
     "sphinx", "sphinx_rtd_theme>=1.0", "sphinxcontrib-jquery",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-forked", "flaky", "mpi4py"] #, "iminuit"]
+test = ["pytest", "pytest-forked", "flaky", "mpi4py", "iminuit"]
 gui = ["pyside6", "matplotlib"]
 docs = [
     "sphinx", "sphinx_rtd_theme>=1.0", "sphinxcontrib-jquery",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-forked", "flaky", "mpi4py", "iminuit"]
+test = ["pytest", "pytest-forked", "flaky", "mpi4py"] #, "iminuit"]
 gui = ["pyside6", "matplotlib"]
 docs = [
     "sphinx", "sphinx_rtd_theme>=1.0", "sphinxcontrib-jquery",


### PR DESCRIPTION
Hello, I added iMinuit as an alternative to scipy.optimize and py-BOBYQA. Indeed, iMinuit has a scipy-like interface that allows to essentially copy how the scipy minimization is already implemented in cobaya. In other words, the modifications needed are minimal.

iMinuit has already been used in combination with cobaya in the literature and also multiple times in a cosmological framework, for example within the Planck Collaboration. A recent example is [2205.05617](https://arxiv.org/abs/2205.05617), which reported significantly better performances using iMinuit w.r.t. the other two minimizers.

Alongside the addition of iMinuit, I added an attribute to the Minimize object collecting the complete array of minima found during a minimize run with multiple initial points. In my opinion, this is useful to have on the user-side since the dispersion of the minima can give an insight on the accuracy of the minimization itself. The same quantity is also passed on to the method that extracts the products resulting from minimization.

Running pytest on test_minimize.py produces no errors.