### PR TITLE
Store full set of minima

### DIFF
--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -239,6 +239,7 @@ class Minimize(Minimizer, CovmatSampler):
         self.kwargs = None
         self.result = None
         self.minimum = None
+        self.full_set_of_mins = None
 
     def affine_transform(self, x):
         """Transforms a point into the search space."""
@@ -343,7 +344,7 @@ class Minimize(Minimizer, CovmatSampler):
              [self._inv_affine_transform_matrix] * len(self.initial_points)]))
 
     @mpi.set_from_root(("_inv_affine_transform_matrix", "_affine_transform_baseline",
-                        "result", "minimum"))
+                        "result", "minimum", "full_set_of_mins"))
     def process_results(self, results, successes, affine_transform_baselines,
                         transform_matrices):
         """
@@ -400,14 +401,9 @@ class Minimize(Minimizer, CovmatSampler):
             "Parameter values at minimum:\n%s", self.minimum.data.to_string())
         self.minimum.out_update()
         self.dump_getdist()
-
         if len(results) > 1:
-            mins = [(getattr(r, evals_attr_) if s else np.inf)
-                    for r, s in zip(results, successes)]
             self.full_set_of_mins = mins
             self.log.info("Full set of minima:\n%s", self.full_set_of_mins)
-        else:
-            self.full_set_of_mins = None
 
     def products(self):
         r"""

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -417,6 +417,9 @@ class Minimize(Minimizer, CovmatSampler):
           or `pyBOBYQA
           <https://numericalalgorithmsgroup.github.io/pybobyqa/build/html/userguide.html>`_.
 
+        - ``full_set_of_mins``: list of minima obtained from multiple initial points.
+          ``None`` if only one initial point was used. ``inf`` indicates a failed run.
+
         - ``M``: inverse of the affine transform matrix (see below).
           ``None`` if no transformation applied.
 

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -401,6 +401,14 @@ class Minimize(Minimizer, CovmatSampler):
         self.minimum.out_update()
         self.dump_getdist()
 
+        if len(results) > 1:
+            mins = [(getattr(r, evals_attr_) if s else np.inf)
+                    for r, s in zip(results, successes)]
+            self.full_set_of_mins = mins
+            self.log.info("Full set of minima:\n%s", self.full_set_of_mins)
+        else:
+            self.full_set_of_mins = None
+
     def products(self):
         r"""
         Returns a dictionary containing:
@@ -426,6 +434,7 @@ class Minimize(Minimizer, CovmatSampler):
         ``result_object``.
         """
         return {"minimum": self.minimum, "result_object": self.result,
+                "full_set_of_mins": self.full_set_of_mins,
                 "M": self._inv_affine_transform_matrix,
                 "X0": self._affine_transform_baseline}
 

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -402,7 +402,11 @@ class Minimize(Minimizer, CovmatSampler):
         self.minimum.out_update()
         self.dump_getdist()
         if len(results) > 1:
-            self.full_set_of_mins = mins
+            all_mins = {
+                f"{i}": (getattr(res[0], evals_attr_), res[1])
+                for i, res in enumerate(zip(results, successes))
+            }
+            self.full_set_of_mins = all_mins
             self.log.info("Full set of minima:\n%s", self.full_set_of_mins)
 
     def products(self):
@@ -417,8 +421,10 @@ class Minimize(Minimizer, CovmatSampler):
           or `pyBOBYQA
           <https://numericalalgorithmsgroup.github.io/pybobyqa/build/html/userguide.html>`_.
 
-        - ``full_set_of_mins``: list of minima obtained from multiple initial points.
-          ``None`` if only one initial point was used. ``inf`` indicates a failed run.
+        - ``full_set_of_mins``: dictionary of minima obtained from multiple initial
+          points. For each it stores the value of the minimized function and a boolean
+          indicating whether the minimization was successful or not.
+          ``None`` if only one initial point was run.
 
         - ``M``: inverse of the affine transform matrix (see below).
           ``None`` if no transformation applied.

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -51,6 +51,8 @@ def test_minimize_gaussian(tmpdir):
 
 @mpi.sync_errors
 def test_minimize_single_point(tmpdir):
+    if mpi.get_mpi_size() > 1:
+        return
     for method in reversed(valid_methods):
         NoisyCovLike.noise = 0.005 if method == 'bobyqa' else 0
         info: InputDict = {'likelihood': {'like': NoisyCovLike},

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -60,7 +60,7 @@ def test_minimize_single_point(tmpdir):
         info['output'] = os.path.join(tmpdir, 'testmin')
         products = run(info, force=True)[1].products()
         if mpi.is_main_process():
-            assert isinstance(products["full_set_of_mins"], None)
+            assert products["full_set_of_mins"] is None
 
 
 @mpi.sync_errors

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -49,6 +49,20 @@ def test_minimize_gaussian(tmpdir):
 
 
 @mpi.sync_errors
+def test_minimize_multiple_points(tmpdir):
+    for method in reversed(valid_methods):
+        NoisyCovLike.noise = 0.005 if method == 'bobyqa' else 0
+        info: InputDict = {'likelihood': {'like': NoisyCovLike},
+                           "sampler": {"minimize": {"ignore_prior": True,
+                                                    "method": method,
+                                                    "best_of": 2}}}
+        info['output'] = os.path.join(tmpdir, 'testmin')
+        products = run(info, force=True)[1].products()
+        if mpi.is_main_process():
+            assert isinstance(products["full_set_of_mins"], list)
+
+
+@mpi.sync_errors
 def test_run_minimize(tmpdir):
     NoisyCovLike.noise = 0
     info: InputDict = {'likelihood': {'like': NoisyCovLike},

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -46,7 +46,7 @@ def test_minimize_gaussian(tmpdir):
             assert np.isclose(res["loglike"], products["minimum"]["minuslogpost"])
             for p, v in list(res.items())[:-2]:
                 assert np.isclose(products["minimum"][p], v)
-            assert isinstance(products["full_set_of_mins"], list)
+            assert isinstance(products["full_set_of_mins"], dict)
 
 
 @mpi.sync_errors

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -46,20 +46,21 @@ def test_minimize_gaussian(tmpdir):
             assert np.isclose(res["loglike"], products["minimum"]["minuslogpost"])
             for p, v in list(res.items())[:-2]:
                 assert np.isclose(products["minimum"][p], v)
+            assert isinstance(products["full_set_of_mins"], list)
 
 
 @mpi.sync_errors
-def test_minimize_multiple_points(tmpdir):
+def test_minimize_single_point(tmpdir):
     for method in reversed(valid_methods):
         NoisyCovLike.noise = 0.005 if method == 'bobyqa' else 0
         info: InputDict = {'likelihood': {'like': NoisyCovLike},
                            "sampler": {"minimize": {"ignore_prior": True,
                                                     "method": method,
-                                                    "best_of": 2}}}
+                                                    "best_of": 1}}}
         info['output'] = os.path.join(tmpdir, 'testmin')
         products = run(info, force=True)[1].products()
         if mpi.is_main_process():
-            assert isinstance(products["full_set_of_mins"], list)
+            assert isinstance(products["full_set_of_mins"], None)
 
 
 @mpi.sync_errors


### PR DESCRIPTION
Hello, I wrote an extension of the current minimization part of Cobaya to store the full set of minima from multiple initial points. I think this is valuable for the user, since, for example, the dispersion of the minima from different initial conditions represents a feedback on the precision of the minimization procedure. An example is [this](https://arxiv.org/pdf/1607.02964.pdf) (Fig.4), where this very concept is applied. A similar concept is also shown in the _Planck_'s paper [here](https://arxiv.org/pdf/1311.1657.pdf) (Fig.1), where they show the effect of changing CAMB's accuracy parameters. 

In #332 I already mentioned this feature, which then I decided to leave for later development since it was causing some issues. Those are fixed now and Travis passed all tests on my fork.

Summarizing the changes in `minimize.py`:

- Add an attribute where to store the minima (the aforementioned bug was caused by not passing correctly this through MPI) and default it to `None` called `full_set_of_mins`;
- If multiple initial points are considered, store the minima in a dictionary giving both the value at the minimum and a boolean indicating whether the minimization process was successful or not (this gets also logged);
- Pass this quantity to the `products` function;
- Add a small description of `full_set_of_mins` in docs

For what regards tests, since the default value of `best_of` is 2, I added to the existing test an assert statement checking that `full_set_of_mins` is a dictionary. 
Then, I added a new test checking that if a single initial point is requested `full_set_of_mins = None`. Tho, I had to suppress this test for the MPI-part of tests. I don't know if this is an intended behavior, but in the (weird) case in which `best_of < MPI size` the code will act as if `best_of == MPI size`. This results in having 2 initial points even when I explicitly set `best_of = 1` because one test is run with `MPI size = 2`. 
It doesn't make much sense to me asking intentionally less initial points than processes, so probably this is not something to worry about. Still, it could be a good idea to add a warning in `minimize.py` to make sure that the user is aware of what is going on.

As stated above, Travis passed all checks on my fork, so this time I will not bother you with the debugging. Of course, let me know if the current implementation is satisfactory or if you would make any modifications.