### PR TITLE
[WIP] fixes for parallel calls inside Jupyter

### DIFF
--- a/cobaya/collection.py
+++ b/cobaya/collection.py
@@ -1194,7 +1194,7 @@ class SampleCollection(BaseCollection):
     # Make it picklable -- formatters are deleted
     # (they will be generated next time txt is dumped)
     def __getstate__(self):
-        attributes = super().__getstate__().copy()
+        attributes = super().__getstate__()
         for attr in ['_numpy_fmts', '_header_formatter']:
             try:
                 del attributes[attr]

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -282,7 +282,7 @@ class HasLogger:
         return new
 
     def __getstate__(self):
-        return deepcopy(self).__dict__
+        return {k: v for k, v in self.__dict__.items() if k != "log"}
 
     def __setstate__(self, d):
         self.__dict__ = d

--- a/cobaya/log.py
+++ b/cobaya/log.py
@@ -276,12 +276,8 @@ class HasLogger:
         self.log = logging.getLogger(add_color_to_name(name))
 
     # Copying and pickling
-    def __deepcopy__(self, memo=None):
-        new = (lambda cls: cls.__new__(cls))(self.__class__)
-        new.__dict__ = {k: deepcopy(v) for k, v in self.__dict__.items() if k != "log"}
-        return new
-
     def __getstate__(self):
+        """Returns the current state, removing the logger (not picklable)."""
         return {k: v for k, v in self.__dict__.items() if k != "log"}
 
     def __setstate__(self, d):

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -392,9 +392,9 @@ class Prior(HasLogger):
                     self.log,
                     f"Error when creating prior for parameter '{p}': {str(excpt)}"
                 ) from excpt
-            fast_logpdf = fast_logpdfs.get(self.pdf[-1].dist.name)
-            if fast_logpdf:
-                self.pdf[-1].logpdf = MethodType(fast_logpdf, self.pdf[-1])
+            # fast_logpdf = fast_logpdfs.get(self.pdf[-1].dist.name)
+            # if fast_logpdf:
+            #     self.pdf[-1].logpdf = MethodType(fast_logpdf, self.pdf[-1])
             self._bounds[i] = [-np.inf, np.inf]
             try:
                 self._bounds[i] = self.pdf[-1].interval(1)


### PR DESCRIPTION
For now just a workaround, that fixes issues with pickling in ipyparallel.

One of the problems can be fixed by not having `__getstate__` of `HasLogger` return a copy, but the original dict minus the logger. This is indeed what a `__getstate__` is supposed to do, but I still need to test this change.

The other fix removes the fast prior pdfs, because the way the method is assigned maybe does not propagate correctly across copies. It can probably be superseded by creating a custom scipy prior object inheriting from the scipy one and having the new logpdf as a first-class method.

EDIT: Copy fixed cherrypicked and added to https://github.com/CobayaSampler/cobaya/pull/349. Only fast-pdf missing.