### PR TITLE
Fixing requisites for bao generic with different kinds of observables

### DIFF
--- a/cobaya/likelihoods/base_classes/bao.py
+++ b/cobaya/likelihoods/base_classes/bao.py
@@ -156,7 +156,7 @@ class BAO(InstallableLikelihood):
     type = "BAO"
 
     install_options = {"github_repository": "CobayaSampler/bao_data",
-                       "github_release": "v2.2"}
+                       "github_release": "v2.3"}
 
     prob_dist_bounds: Optional[Sequence[float]]
     measurements_file: Optional[str] = None

--- a/cobaya/likelihoods/base_classes/bao.py
+++ b/cobaya/likelihoods/base_classes/bao.py
@@ -396,15 +396,15 @@ class BAO(InstallableLikelihood):
                 obs_used_not_implemented, list(theory_reqs))
         requisites = {}
         if self.has_type:
-            for observable in theory_reqs:
-                for req,req_values in theory_reqs[observable].items():
+            for observable in self.data["observable"].unique():
+                for req, req_values in theory_reqs[observable].items():
                     if req not in requisites.keys():
                         requisites[req] = req_values
                     else:
-                        if isinstance(req_values,dict):
-                            for k,v in req_values.items():
+                        if isinstance(req_values, dict):
+                            for k, v in req_values.items():
                                 if v is not None:
-                                    requisites[req][k] = np.unique(np.concatenate((requisites[req][k],v)))
+                                    requisites[req][k] = np.unique(np.concatenate((requisites[req][k], v)))
         return requisites
 
     def theory_fun(self, z, observable):

--- a/cobaya/likelihoods/base_classes/bao.py
+++ b/cobaya/likelihoods/base_classes/bao.py
@@ -396,8 +396,15 @@ class BAO(InstallableLikelihood):
                 obs_used_not_implemented, list(theory_reqs))
         requisites = {}
         if self.has_type:
-            for obs in self.data["observable"].unique():
-                requisites.update(theory_reqs[obs])
+            for observable in theory_reqs:
+                for req,req_values in theory_reqs[observable].items():
+                    if req not in requisites.keys():
+                        requisites[req] = req_values
+                    else:
+                        if isinstance(req_values,dict):
+                            for k,v in req_values.items():
+                                if v is not None:
+                                    requisites[req][k] = np.unique(np.concatenate((requisites[req][k],v)))
         return requisites
 
     def theory_fun(self, z, observable):

--- a/cobaya/likelihoods/base_classes/bao.py
+++ b/cobaya/likelihoods/base_classes/bao.py
@@ -326,14 +326,14 @@ class BAO(InstallableLikelihood):
                     self.cov = np.loadtxt(os.path.join(data_file_path, self.cov_file))
                 elif self.invcov_file:
                     invcov = np.loadtxt(os.path.join(data_file_path, self.invcov_file))
-                    self.cov = np.linalg.inv(invcov)
+                    self.cov = np.linalg.inv(np.atleast_2d(invcov))
                 elif "error" in self.data.columns:
                     self.cov = np.diag(self.data["error"] ** 2)
                 else:
                     raise LoggedError(
                         self.log, "No errors provided, either as cov, invcov "
                                   "or as the 3rd column in the data file.")
-                self.invcov = np.linalg.inv(self.cov)
+                self.invcov = np.linalg.inv(np.atleast_2d(self.cov))
             except IOError:
                 raise LoggedError(
                     self.log, "Couldn't find (inv)cov file '%s' in folder '%s'. " % (

--- a/tests/test_cosmo_bao.py
+++ b/tests/test_cosmo_bao.py
@@ -20,6 +20,24 @@ def test_generic_camb(packages_path, skip_not_installed):
     body_of_test(packages_path, best_fit, info_likelihood, info_theory,
                  chi2_generic, skip_not_installed=skip_not_installed)
 
+# Test generic bao class with different kind of observables
+def test_generic_mixed_camb(packages_path, skip_not_installed):
+    like = "bao.sdss_dr12_consensus_bao"
+    like_rename = "bao_mixed_observables"
+    chi2_generic = deepcopy(chi2_sdss_dr12_consensus_bao)
+    chi2_generic.pop(like)
+    chi2_generic[like_rename] = 5.0
+    likelihood_defaults = get_component_class(like).get_defaults()
+    likelihood_defaults.pop("path")
+    likelihood_defaults["class"] = "bao.generic"
+    likelihood_defaults['measurements_file'] = 'bao_data/test_bao_mixed_observables_mean.txt'
+    likelihood_defaults['cov_file'] = 'bao_data/test_bao_mixed_observables_cov.txt'
+    likelihood_defaults['rs_fid'] = 1.0
+    info_likelihood = {like_rename: likelihood_defaults}
+    info_theory = {"camb": None}
+    body_of_test(packages_path, best_fit, info_likelihood, info_theory,
+                 chi2_generic, skip_not_installed=skip_not_installed)
+
 
 def test_sdss_dr16_consensus_baoplus_lrg_camb(packages_path, skip_not_installed):
     like = "bao.sdss_dr16_baoplus_lrg"


### PR DESCRIPTION
Fixing computation of requisites for generic BAO when supplied with measurements_file that contains different kinds of observables at several redshifts. To validate the logic, I tested it on the dummy file in the attachment. The older version incorrectly returns `{'angular_diameter_distance': {'z': array([2.34])}, 'Hubble': {'z': array([2.34])}, 'rdrag': None, 'fsigma8': {'z': array([2.34])}} `.

|    z |   value | observable   |
|-----:|--------:|:-------------|
| 0.29 |     1   | DV_over_rs   |
| 1.31 |     1   | DV_over_rs   |
| 1.31 |     1.5 | F_AP         |
| 0.5  |     1.8 | DV_over_rs   |
| 0.5  |     1.2 | F_AP         |
| 0.7  |     1.1 | DV_over_rs   |
| 0.7  |     1.6 | F_AP         |
| 0.91 |     1.5 | DV_over_rs   |
| 0.91 |     1   | F_AP         |
| 1.49 |     1.5 | DV_over_rs   |
| 2.34 |     2   | DM_over_rs   |
| 2.34 |     5   | DH_over_rs   |
| 2.34 |     2   | f_sigma8     |


[bao_mean_check.txt](https://github.com/CobayaSampler/cobaya/files/13798734/bao_mean_check.txt)
