### PR TITLE
Fix automatic selection of covmat

### DIFF
--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -451,9 +451,10 @@ class CovmatSampler(Sampler):
         self.covmat = getattr(self, 'covmat', None)
         if isinstance(self.covmat, str) and self.covmat.lower() == "auto":
             params_infos_covmat = deepcopy_where_possible(params_infos)
-            for p in list(params_infos_covmat):
-                if p not in (auto_params or []):
-                    params_infos_covmat.pop(p, None)
+            if auto_params is not None:
+                for p in list(params_infos_covmat):
+                    if p not in auto_params:
+                        params_infos_covmat.pop(p, None)
             auto_covmat = self.model.get_auto_covmat(params_infos_covmat)
             if auto_covmat:
                 self.covmat = os.path.join(auto_covmat["folder"], auto_covmat["name"])


### PR DESCRIPTION
According to the docstring for `initial_proposal_covmat`, `auto_params=None` should use all parameters, but this is not the case with the current implementation.
This leads to the failure of automatic covmat selection.

An update (`min_score` added for `get_best_score` in c3762300b37bf471bc6c39c3b8048bf63c1de1b2) six months ago exposed this long-standing problem.