### PR TITLE
reset loader folder after recursive defaults

### DIFF
--- a/cobaya/yaml.py
+++ b/cobaya/yaml.py
@@ -83,6 +83,7 @@ def _construct_defaults(loader, node):
                                    "searched for in folder '%s'." % (dfile, folder))
         this_loaded_defaults = yaml_load_file(dfilename)
         loaded_defaults = recursive_update(loaded_defaults, this_loaded_defaults)
+    loader.current_folder = folder
     return loaded_defaults
 
 


### PR DESCRIPTION
This fixes an issue that arrises when loading e.g. both params and priors via the !defaults constructor. The folder must be reset to the directory of the current yaml file so that the following paths can be interpreted relative to that