### PR TITLE
Some `scipy` distributions do not have a `"scale"` parameter

### DIFF
--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -569,7 +569,7 @@ def get_scipy_1d_pdf(definition: Union[float, Sequence, Dict]
                 ) from excpt
         kwargs["loc"] = minmaxvalues["min"]
         kwargs["scale"] = minmaxvalues["max"] - minmaxvalues["min"]
-    if kwargs["scale"] < 0:
+    if kwargs.get("scale", 0) < 0:
         raise ValueError(
             "Invalid negative range or scale. "
             f"Prior definition was {definition}.")

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -569,7 +569,7 @@ def get_scipy_1d_pdf(definition: Union[float, Sequence, Dict]
                 ) from excpt
         kwargs["loc"] = minmaxvalues["min"]
         kwargs["scale"] = minmaxvalues["max"] - minmaxvalues["min"]
-    if kwargs.get("scale", 0) < 0:
+    if kwargs.get("scale", 1) < 0:
         raise ValueError(
             "Invalid negative range or scale. "
             f"Prior definition was {definition}.")


### PR DESCRIPTION
Some of the continuous distributions in `scipy.stats` do not have a "scale" parameter, but cobaya fails if it is not in the kwargs for a general distribution.

e.g:
```yaml
params:
  x:
    prior:
      dist: beta
      a: 2
      b: 1
```
causes the following error:
```
Traceback (most recent call last):
  File "/Users/adam/phd/pinch/pinchihood.py", line 29, in <module>
    cobaya.run("pinch.yaml", resume=resume, force=not resume,
  File "/Users/adam/programming/cobaya/cobaya/run.py", line 120, in run
    with Model(updated_info["params"], updated_info["likelihood"],
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adam/programming/cobaya/cobaya/model.py", line 241, in __init__
    self.prior = Prior(self.parameterization, self._updated_info.get("prior"))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adam/programming/cobaya/cobaya/prior.py", line 426, in __init__
    self.pdf += [get_scipy_1d_pdf(prior)]
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adam/programming/cobaya/cobaya/tools.py", line 572, in get_scipy_1d_pdf
    if kwargs["scale"] < 0:
       ~~~~~~^^^^^^^^^
KeyError: 'scale'
```

I believe this is easily fixed by using `kwargs.get("scale")` rather than `kwargs["scale"]`