### PR TITLE
small fix to import path in example

### DIFF
--- a/docs/cobaya-example.ipynb
+++ b/docs/cobaya-example.ipynb
@@ -20,7 +20,7 @@
     "try:\n",
     "    from cobaya import run\n",
     "except ImportError:\n",
-    "    sys.path.insert(0,'../../cobaya')\n",
+    "    sys.path.insert(0,os.path.realpath(os.path.join(os.getcwd(), '../..', 'cobaya')))\n",
     "    from cobaya import run"
    ]
   },


### PR DESCRIPTION
When running the example notebook from a non-standard path, the previous import would fail. This commit resolves the issue by referencing the notebook's own path.