### PR TITLE
Error messages

### DIFF
--- a/cobaya/output.py
+++ b/cobaya/output.py
@@ -94,7 +94,7 @@ class FileLock:
                               "File %s is locked by another process, you are running "
                               "with MPI disabled but may have more than one process. "
                               "Make sure that you have mpi4py installed and working."
-                              "Note that --test should not be used with MPI.")
+                              "Note that --test should not be used with MPI.", self.lock_file)
         if mpi.get_mpi():
             import mpi4py  # pylint: disable=import-outside-toplevel
         else:

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -883,11 +883,11 @@ class CAMB(BoltzmannBase):
             return self.camb.set_params(self._base_params.copy(), **args)
         except self.camb.baseconfig.CAMBParamRangeError as e:
             if self.stop_at_error:
-                raise LoggedError(self.log, "%sOut of bound parameters: %r",
+                raise LoggedError(self.log, "%s\nOut of bound parameters: %r",
                                   e, params_values_dict)
             else:
-                self.log.debug("Out of bounds parameters. "
-                               "Assigning 0 likelihood and going on.")
+                self.log.debug("%s;\n Out of bounds parameters. "
+                               "Assigning 0 likelihood and going on.", e)
         except (self.camb.baseconfig.CAMBValueError, self.camb.baseconfig.CAMBError) as e:
             if self.stop_at_error:
                 self.log.error(

--- a/cobaya/theories/camb/camb.py
+++ b/cobaya/theories/camb/camb.py
@@ -881,10 +881,10 @@ class CAMB(BoltzmannBase):
                 self._base_params = params
             args.update(self._reduced_extra_args)
             return self.camb.set_params(self._base_params.copy(), **args)
-        except self.camb.baseconfig.CAMBParamRangeError:
+        except self.camb.baseconfig.CAMBParamRangeError as e:
             if self.stop_at_error:
-                raise LoggedError(self.log, "Out of bound parameters: %r",
-                                  params_values_dict)
+                raise LoggedError(self.log, "%sOut of bound parameters: %r",
+                                  e, params_values_dict)
             else:
                 self.log.debug("Out of bounds parameters. "
                                "Assigning 0 likelihood and going on.")


### PR DESCRIPTION
Fixed MPI disabled lock error message to show file name.
Extended CAMB out of range error to show full CAMB error (credit: Antony Lewis).