### PR TITLE
add CosmoSIS2cobaya to external likelihood list

### DIFF
--- a/docs/likelihood_external.rst
+++ b/docs/likelihood_external.rst
@@ -36,6 +36,7 @@ List of external packages
  * `pyWMAP <https://github.com/HTJense/pyWMAP>`_
  * `Mock CMB-HD <https://github.com/CMB-HD/hdlike>`_
  * `TDCOSMO strong lensing time delays <https://github.com/nataliehogg/tdcosmo_ext>`_
+ * `CosmoSIS2cobaya <https://github.com/JiangJQ2000/cosmosis2cobaya>`_
  * `Example - simple demo <https://github.com/CobayaSampler/example_external_likelihood>`_
  * `Example - Planck lensing <https://github.com/CobayaSampler/planck_lensing_external>`_
 


### PR DESCRIPTION
Add [CosmoSIS2cobaya](https://github.com/JiangJQ2000/cosmosis2cobaya) (with DES Y3 and KiDS-1000 likelihoods) to the external likelihood list.