### PR TITLE
Fix measure_speeds with fixed references using proposal values

### DIFF
--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -1553,6 +1553,10 @@ class Model(HasLogger):
         self.mpi_info("Measuring speeds... (this may take a few seconds)")
         if n is None:
             n = 1 if mpi.more_than_one_process() else 3
+
+        # Get proposal values for parameters to enable better perturbation from fixed refs
+        proposal_scale = self.parameterization.get_sampled_params_proposals()
+
         n_done = 0
         with timing_on(self):
             while n_done < int(n) + int(discard):
@@ -1561,6 +1565,7 @@ class Model(HasLogger):
                     max_tries=max_tries,
                     ignore_fixed=True,
                     warn_if_no_ref=False,
+                    proposal_scale=proposal_scale,
                 )
                 if self.loglike(point, cached=False)[0] != -np.inf:  # type: ignore
                     n_done += 1

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -298,6 +298,16 @@ class Parameterization(HasLogger):
             if p in self._derived
         }
 
+    def get_sampled_params_proposals(self) -> dict[str, float | None]:
+        """
+        Returns a dictionary of proposal values for sampled parameters.
+        Returns None for parameters without a proposal value defined.
+        """
+        return {
+            p: self._infos[p].get("proposal")
+            for p in self._sampled
+        }
+
     def sampled_input_dependence(self) -> dict[str, list[str]]:
         return deepcopy(self._sampled_input_dependence)
 

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -789,6 +789,7 @@ class Prior(HasLogger):
         ignore_fixed=False,
         warn_if_no_ref=True,
         random_state=None,
+        proposal_scale: dict[str, float | None] | None = None,
     ) -> np.ndarray:
         """
         Returns:
@@ -798,6 +799,12 @@ class Prior(HasLogger):
         If `ignored_fixed=True` (default: `False`), fixed reference values will be ignored
         in favor of the full prior, ensuring some randomness for all parameters (useful
         e.g. to prevent caching when measuring speeds).
+
+        If `proposal_scale` is provided as a dict mapping parameter names to proposal
+        values, and `ignore_fixed=True`, then for parameters with fixed reference values
+        and proposal values, the point will be perturbed from the reference using a
+        Gaussian with the proposal as the standard deviation, rather than sampling from
+        the full prior. This helps avoid extreme values when the prior is very broad.
 
         NB: The way this function works may be a little dangerous:
         if two parameters have an (external)
@@ -819,22 +826,54 @@ class Prior(HasLogger):
             isinstance(r, numbers.Real) and (np.isnan(r) or ignore_fixed)
             for r in self.ref_pdf
         ]
+
+        # Determine which parameters should use proposal-based perturbation
+        # vs sampling from the full prior
+        where_use_proposal = []
+        if proposal_scale and ignore_fixed:
+            for i, (param_name, ref_pdf) in enumerate(zip(self.params, self.ref_pdf)):
+                # Use proposal if: parameter has fixed ref, ignore_fixed=True, and proposal available
+                use_proposal = (
+                    isinstance(ref_pdf, numbers.Real) and not np.isnan(ref_pdf) and
+                    param_name in proposal_scale and proposal_scale[param_name] is not None
+                )
+                where_use_proposal.append(use_proposal)
+        else:
+            where_use_proposal = [False] * len(self.ref_pdf)
+
         tries = 0
         warn_if_tries = read_dnumber(warn_if_tries, self.d())
         ref_sample = np.empty(len(self.ref_pdf))
         while tries < max_tries:
             tries += 1
-            if any(where_ignore_ref):
+
+            # Handle parameters that need sampling from prior (not using proposal)
+            where_sample_prior = np.array([
+                where_ignore_ref[i] and not where_use_proposal[i]
+                for i in range(len(self.ref_pdf))
+            ])
+            if np.any(where_sample_prior):
                 prior_sample = self.sample(
                     ignore_external=True, random_state=random_state
                 )[0]
-                ref_sample[where_ignore_ref] = prior_sample[where_ignore_ref]
+                ref_sample[where_sample_prior] = prior_sample[where_sample_prior]
+
+            # Handle parameters using their reference values or pdfs
             for i, ref_pdf in enumerate(self.ref_pdf):
                 if not where_ignore_ref[i]:
                     if hasattr(ref_pdf, "rvs"):
                         ref_sample[i] = ref_pdf.rvs(random_state=random_state)  # type: ignore
                     else:
                         ref_sample[i] = ref_pdf.real
+                elif where_use_proposal[i]:
+                    # Use proposal-based perturbation from fixed reference
+                    param_name = self.params[i]
+                    ref_value = self.ref_pdf[i].real
+                    proposal_std = proposal_scale[param_name]
+                    if random_state is not None:
+                        ref_sample[i] = random_state.normal(ref_value, proposal_std)
+                    else:
+                        ref_sample[i] = np.random.normal(ref_value, proposal_std)
 
             if self.logp(ref_sample) > -np.inf:
                 return ref_sample


### PR DESCRIPTION
## Summary

Fixes #394: When `ref` is fixed, `measure_speeds` will now perturb from the reference point using proposal values instead of sampling from very broad priors that could cause theory calculation failures.

## Problem

When a parameter has a fixed reference value and `measure_speeds` is called, the function would sample from the full prior distribution. If the prior is very broad (e.g., cosmological parameters with non-informative priors), this can generate extreme values that cause theory calculations to fail.

## Solution

This PR implements the suggestion from issue #394 to use "proposal" values for perturbation when available:

- When `ignore_fixed=True` and a parameter has both a fixed reference value and a proposal value defined, the sampling now perturbs from the reference point using a Gaussian distribution with the proposal as the standard deviation
- Falls back to the original behavior (sampling from prior) for parameters without proposal values
- Maintains full backward compatibility

## Changes

1. **Enhanced `Prior.reference()` method** (`cobaya/prior.py`):
   - Added `proposal_scale` parameter with proper type hints
   - Implemented proposal-based perturbation logic
   - Used numpy vector indexing for improved performance
   - Updated docstring with detailed explanation

2. **Added `get_sampled_params_proposals()` method** (`cobaya/parameterization.py`):
   - Returns dictionary of proposal values for sampled parameters

3. **Updated `measure_and_set_speeds()` method** (`cobaya/model.py`):
   - Gets proposal values from parameterization
   - Passes them to `prior.reference()` for better sampling

## Testing

Tested with various scenarios:
- Parameters with fixed references and proposals (uses new behavior)
- Parameters with fixed references but no proposals (uses old behavior)
- Parameters with reference PDFs (unchanged behavior)
- Complex multi-parameter cases
- Edge cases and backward compatibility

## Example

Before this fix, the following scenario could fail:

```yaml
params:
  H0:
    prior: {min: 0, max: 200}  # Very broad prior
    ref: 70                    # Fixed reference
    proposal: 2                # Reasonable proposal
```

With `measure_speeds`, sampling from the full prior [0, 200] could generate extreme values like H0=5 or H0=150 that cause theory codes to crash.

After this fix, `measure_speeds` will sample around H0=70 ± 2, staying in the reasonable range.

## Backward Compatibility

This change is fully backward compatible:
- All existing functionality works exactly as before
- New behavior only activates when all conditions are met (fixed ref + proposal available + ignore_fixed=True)
- No changes to public APIs beyond the optional new parameter

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author