### PR TITLE
Improve `truncnorm` prior support

### DIFF
--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -65,10 +65,10 @@ The syntax for priors and ref's has the following fields:
    intuitive arguments ``min`` and ``max`` (default: 0 and 1 resp.) instead of ``loc`` and
    ``scale`` (NB: unexpected behaviour for an unbounded pdf).
 
-   For truncated distributions (e.g. ``truncnorm``), you can also use the more intuitive arguments
-   ``min`` and ``max`` instead of ``a`` and ``b`` (the code will take care of properly set ``a`` and
-   ``b`` defined in standard deviation unit see
-   `scipy.stats.truncnorm <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html>`_).
+   When using
+   `scipy.stats.truncnorm <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html>`_,
+   you can also use the more intuitive arguments ``min`` and ``max`` instead of ``a`` and ``b``
+   (the code will take care of properly set ``a`` and ``b`` defined in standard deviation unit).
 
 The order of the parameters is conserved in the table of samples, except that
 derived parameters are always moved to the end.

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -65,6 +65,10 @@ The syntax for priors and ref's has the following fields:
    intuitive arguments ``min`` and ``max`` (default: 0 and 1 resp.) instead of ``loc`` and
    ``scale`` (NB: unexpected behaviour for an unbounded pdf).
 
+   For truncated distributions (e.g. ``truncnorm``), you can also use the more intuitive arguments
+   ``min`` and ``max`` instead of ``a`` and ``b`` (the code will take care of properly set ``a`` and
+   ``b`` defined in standard deviation unit see
+   `scipy.stats.truncnorm <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html>`_).
 
 The order of the parameters is conserved in the table of samples, except that
 derived parameters are always moved to the end.

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -660,6 +660,11 @@ def get_scipy_1d_pdf(
         raise ValueError(f"If present 'dist' must be a string. Got {type(dist)}.")
     if "min" in kwargs or "max" in kwargs:
         if dist == "truncnorm":
+            if "a" in kwargs or "b" in kwargs:
+                raise ValueError(
+                    "You cannot use the 'a/b' convention and the 'min/max' "
+                    "convention at the same time. Either use one or the other."
+                )
             loc, scale = kwargs.get("loc", 0), kwargs.get("scale", 1)
             kwargs["a"] = (kwargs.pop("min") - loc) / scale
             kwargs["b"] = (kwargs.pop("max") - loc) / scale

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -3,7 +3,6 @@ Tests some Prior methods.
 """
 
 import numpy as np
-
 from cobaya.parameterization import Parameterization
 from cobaya.prior import Prior
 
@@ -13,11 +12,27 @@ def test_prior_confidence():
         "a": {"prior": {"dist": "uniform", "min": 0, "max": 1}},
         "b": {"prior": {"dist": "norm", "loc": 0, "scale": 1}},
         "c": {"prior": {"dist": "beta", "min": 0, "max": 1, "a": 2, "b": 5}},
+        "d": {"prior": {"dist": "truncnorm", "loc": 0, "scale": 1, "a": 2, "b": 5}},
     }
     p = Prior(Parameterization(info_params))
     test_confidence_p1 = np.array(
-        [[0.45, 0.55], [-0.12566135, 0.12566135], [0.24325963, 0.28641175]]
+        [
+            [0.45, 0.55],
+            [-0.12566135, 0.12566135],
+            [0.24325963, 0.28641175],
+            [2.24101037, 2.31751979],
+        ]
     )
     assert np.allclose(p.bounds(confidence=0.1), test_confidence_p1)
-    test_bounds_p68 = np.array([[0.0, 1.0], [-0.99445788, 0.99445788], [0.0, 1.0]])
+    test_bounds_p68 = np.array([[0.0, 1.0], [-0.99445788, 0.99445788], [0.0, 1.0], [2.0, 5.0]])
     assert np.allclose(p.bounds(confidence_for_unbounded=0.68), test_bounds_p68)
+
+
+def test_prior_truncnorm():
+    info_params = {
+        "a": {"prior": {"dist": "truncnorm", "loc": 1, "min": 0, "max": 1}},
+        "b": {"prior": {"dist": "truncnorm", "loc": 1, "a": -1, "b": 0}},
+    }
+    p = Prior(Parameterization(info_params))
+    bounds = p.bounds(confidence=0.1)
+    assert np.allclose(bounds[0], bounds[1])

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -3,6 +3,7 @@ Tests some Prior methods.
 """
 
 import numpy as np
+
 from cobaya.parameterization import Parameterization
 from cobaya.prior import Prior
 


### PR DESCRIPTION
The PR adds support to `min/max` attributes for `scipy.stats.truncnorm` distribution. This follows an old discussion and some issue raised [here](https://github.com/CobayaSampler/cobaya/issues/80). 

As far as I understand the code, a truncated normal distribution can be set like that
```yaml
params:
  param1:
    prior:
      dist: truncnorm
      # with a, b = (a_trunc - loc) / scale, (b_trunc - loc) / scale
      a: 0 
      b: 1
```
but the usual and easier way to define a truncated normal distribution in `cobaya` is to do 

```yaml
params:
  param1:
    prior:
      min: 0
      max: 1

prior:
  gaussian_param1: "lambda param1: stats.norm.logpdf(param1, loc=0, scale=1)"
```
as suggested in #80.
 
This PR allows the definition of `truncnorm` prior this way
```yaml
params:
  param1:
    prior:
      dist: truncnorm
      # loc: 0
      # scale: 1
      min: 0
      max: 1
```
The `a` and `b` parameters of `scipy.stats.truncnorm` are computed given `min/max` and `loc/scale` values.