### PR TITLE
Add simple Gaussian likelihood with normalized/unnormalized options

### DIFF
--- a/cobaya/likelihoods/gaussian/__init__.py
+++ b/cobaya/likelihoods/gaussian/__init__.py
@@ -1,0 +1,1 @@
+from .gaussian import Gaussian as Gaussian

--- a/cobaya/likelihoods/gaussian/gaussian.py
+++ b/cobaya/likelihoods/gaussian/gaussian.py
@@ -1,0 +1,112 @@
+"""
+.. module:: likelihoods.gaussian
+
+:Synopsis: Simple Gaussian likelihood
+:Author: Antony Lewis
+
+"""
+
+import numpy as np
+
+from cobaya.functions import chi_squared
+from cobaya.likelihood import Likelihood
+from cobaya.log import LoggedError
+from cobaya.typing import Sequence
+
+
+class Gaussian(Likelihood):
+    """
+    Simple Gaussian likelihood.
+    """
+
+    file_base_name = "gaussian"
+
+    # yaml variables
+    mean: float | Sequence | np.ndarray
+    cov: float | Sequence | np.ndarray
+    normalized: bool
+    input_params_prefix: str
+
+    def initialize_with_params(self):
+        """
+        Initializes the gaussian distribution.
+        """
+        self.log.debug("Initializing")
+
+        # Load mean and cov, and check consistency
+        if self.mean is not None and self.cov is not None:
+            # Convert to numpy arrays and ensure proper dimensionality
+            self.mean = np.atleast_1d(self.mean)
+            self.cov = np.atleast_2d(self.cov)
+
+            # Check dimensions
+            mean_dim = len(self.mean)
+            cov_dim1, cov_dim2 = self.cov.shape
+
+            if cov_dim1 != cov_dim2:
+                raise LoggedError(
+                    self.log,
+                    "The covariance matrix does not appear to be square! Got shape %r",
+                    self.cov.shape,
+                )
+
+            if mean_dim != cov_dim1:
+                raise LoggedError(
+                    self.log,
+                    "The dimensionalities of mean (%d) and covariance (%d) do not match!",
+                    mean_dim,
+                    cov_dim1,
+                )
+
+            if mean_dim != len(self.input_params):
+                raise LoggedError(
+                    self.log,
+                    "The dimensionality is %d (from mean and cov) "
+                    "but was passed %d parameters instead.",
+                    mean_dim,
+                    len(self.input_params),
+                )
+        else:
+            raise LoggedError(
+                self.log,
+                "You must specify both a mean and a covariance matrix.",
+            )
+
+        # Precompute inverse covariance matrix
+        try:
+            self.inv_cov = np.linalg.inv(self.cov)
+        except np.linalg.LinAlgError:
+            raise LoggedError(self.log, "The covariance matrix is not invertible!")
+
+        # Precompute normalization constant if needed
+        if getattr(self, "normalized", True):
+            # Calculate log determinant using slogdet for numerical stability
+            sign, logdet = np.linalg.slogdet(self.cov)
+            if sign <= 0:
+                raise LoggedError(
+                    self.log, "The covariance matrix is not positive definite!"
+                )
+
+            # Normalization constant: -0.5 * (k * log(2π) + log|Σ|)
+            k = len(self.mean)
+            self.log_norm = -0.5 * (k * np.log(2 * np.pi) + logdet)
+        else:
+            self.log_norm = 0.0
+
+    def logp(self, **params_values):
+        """
+        Computes the log-likelihood for a given set of parameters.
+        """
+        # Prepare the vector of sampled parameter values
+        x = np.array([params_values[p] for p in self.input_params])
+
+        # Calculate (x - μ)
+        delta = x - self.mean
+
+        # Calculate chi-squared: (x - μ)ᵀ Σ⁻¹ (x - μ) using efficient function
+        chi2 = chi_squared(self.inv_cov, delta)
+
+        # Return log-likelihood
+        # For normalized: -0.5 * chi2 + log_norm
+        # For unnormalized: -0.5 * chi2
+        return -0.5 * chi2 + self.log_norm

--- a/cobaya/likelihoods/gaussian/gaussian.yaml
+++ b/cobaya/likelihoods/gaussian/gaussian.yaml
@@ -1,0 +1,10 @@
+# Simple Gaussian likelihood
+
+# Mean vector
+mean:
+# Covariance matrix
+cov:
+# Whether to include normalization constant (default: True)
+normalized: True
+# Prefix of parameter names (if not using explicit input_params)
+input_params_prefix: ""

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -1,0 +1,188 @@
+"""
+Tests for the Gaussian likelihood.
+"""
+
+import numpy as np
+import pytest
+from scipy.stats import multivariate_normal
+
+from cobaya.model import get_model
+from cobaya.typing import InputDict
+
+
+def test_gaussian_1d():
+    """Test 1D Gaussian likelihood for both normalized and unnormalized cases."""
+    mean = 0.5
+    std = 0.2
+    cov = std**2
+
+    for normalized in [True, False]:
+        info: InputDict = {
+            "likelihood": {
+                "gaussian": {
+                    "mean": mean,
+                    "cov": cov,
+                    "normalized": normalized,
+                    "input_params": ["x"],
+                }
+            },
+            "params": {"x": {"prior": {"min": 0, "max": 1}, "proposal": 0.1}},
+        }
+
+        model = get_model(info)
+
+        # Test at various points including mean
+        test_points = [mean, 0.1, 0.3, 0.7, 0.9]
+        for x in test_points:
+            loglike = model.loglike({"x": x})[0]
+            if normalized:
+                expected = multivariate_normal.logpdf([x], [mean], [[cov]])
+            else:
+                chi2_val = (x - mean) ** 2 / cov
+                expected = -0.5 * chi2_val
+            assert np.isclose(loglike, expected, rtol=1e-10)
+
+
+def test_gaussian_2d():
+    """Test 2D Gaussian likelihood for both normalized and unnormalized cases."""
+    mean = np.array([0.5, 1.0])
+    cov = np.array([[0.1, 0.05], [0.05, 0.2]])
+
+    for normalized in [True, False]:
+        # Test with numpy arrays directly (not .tolist())
+        info: InputDict = {
+            "likelihood": {
+                "gaussian": {
+                    "mean": mean,  # numpy array directly
+                    "cov": cov,  # numpy array directly
+                    "normalized": normalized,
+                    "input_params": ["x", "y"],
+                }
+            },
+            "params": {
+                "x": {"prior": {"min": 0, "max": 1}, "proposal": 0.1},
+                "y": {"prior": {"min": 0, "max": 2}, "proposal": 0.1},
+            },
+        }
+
+        model = get_model(info)
+
+        # Test at various points including mean
+        test_points = [(mean[0], mean[1]), (0.2, 0.8), (0.7, 1.3), (0.1, 1.8)]
+        for x, y in test_points:
+            loglike = model.loglike({"x": x, "y": y})[0]
+            if normalized:
+                expected = multivariate_normal.logpdf([x, y], mean, cov)
+            else:
+                inv_cov = np.linalg.inv(cov)
+                delta = np.array([x, y]) - mean
+                chi2_val = delta.T @ inv_cov @ delta
+                expected = -0.5 * chi2_val
+            assert np.isclose(loglike, expected, rtol=1e-10)
+
+
+def test_gaussian_scalar_input():
+    """Test that scalar inputs work for 1D case."""
+    mean = 0.5
+    cov = 0.04  # scalar
+
+    info: InputDict = {
+        "likelihood": {
+            "gaussian": {
+                "mean": mean,  # scalar
+                "cov": cov,  # scalar
+                "normalized": True,
+                "input_params": ["x"],
+            }
+        },
+        "params": {"x": {"prior": {"min": 0, "max": 1}, "proposal": 0.1}},
+    }
+
+    model = get_model(info)
+
+    # Should work the same as 1D array case
+    loglike = model.loglike({"x": 0.3})[0]
+    expected = multivariate_normal.logpdf([0.3], [mean], [[cov]])
+    assert np.isclose(loglike, expected, rtol=1e-10)
+
+
+def test_gaussian_parameter_prefix():
+    """Test using parameter prefix instead of explicit input_params."""
+    mean = np.array([0.5, 1.0])
+    cov = np.array([[0.1, 0.05], [0.05, 0.2]])
+
+    info: InputDict = {
+        "likelihood": {
+            "gaussian": {
+                "mean": mean.tolist(),
+                "cov": cov.tolist(),
+                "normalized": True,
+                "input_params_prefix": "test_",
+            }
+        },
+        "params": {
+            "test_0": {"prior": {"min": 0, "max": 1}, "proposal": 0.1},
+            "test_1": {"prior": {"min": 0, "max": 2}, "proposal": 0.1},
+        },
+    }
+
+    model = get_model(info)
+
+    # Test at mean
+    loglike_mean = model.loglike({"test_0": mean[0], "test_1": mean[1]})[0]
+    expected_mean = multivariate_normal.logpdf(mean, mean, cov)
+    assert np.isclose(loglike_mean, expected_mean, rtol=1e-10)
+
+
+def test_gaussian_errors():
+    """Test error handling."""
+    # Test mismatched dimensions
+    with pytest.raises(Exception):  # Should raise LoggedError
+        info: InputDict = {
+            "likelihood": {
+                "gaussian": {
+                    "mean": [0.5, 1.0],  # 2D
+                    "cov": [[0.1]],  # 1D
+                    "input_params": ["x", "y"],
+                }
+            },
+            "params": {
+                "x": {"prior": {"min": 0, "max": 1}},
+                "y": {"prior": {"min": 0, "max": 2}},
+            },
+        }
+        get_model(info)
+
+    # Test non-square covariance
+    with pytest.raises(Exception):  # Should raise LoggedError
+        info: InputDict = {
+            "likelihood": {
+                "gaussian": {
+                    "mean": [0.5, 1.0],
+                    "cov": [[0.1, 0.05, 0.02], [0.05, 0.2, 0.01]],  # 2x3 matrix
+                    "input_params": ["x", "y"],
+                }
+            },
+            "params": {
+                "x": {"prior": {"min": 0, "max": 1}},
+                "y": {"prior": {"min": 0, "max": 2}},
+            },
+        }
+        get_model(info)
+
+    # Test singular covariance matrix
+    with pytest.raises(Exception):  # Should raise LoggedError
+        info: InputDict = {
+            "likelihood": {
+                "gaussian": {
+                    "mean": [0.5, 1.0],
+                    "cov": [[0.1, 0.1], [0.1, 0.1]],  # Singular matrix
+                    "input_params": ["x", "y"],
+                }
+            },
+            "params": {
+                "x": {"prior": {"min": 0, "max": 1}},
+                "y": {"prior": {"min": 0, "max": 2}},
+            },
+        }
+        get_model(info)


### PR DESCRIPTION
This PR adds a new simple Gaussian likelihood class that addresses issue #416.

## Features

- **Simple Gaussian likelihood** following the gaussian_mixture pattern but much simpler (no mixture)
- **Normalized option** (default True): Includes full normalization constant
- **Unnormalized option**: Only chi-squared term without normalization constant
- **Efficient computation**: Uses precomputed inverse covariance and `chi_squared` function from cobaya.functions
- **Numerical stability**: Uses `numpy.linalg.slogdet` for log determinant calculation
- **Flexible inputs**: Supports scalar, sequence, or ndarray for mean and covariance
- **1D scalar support**: Automatically converts scalars to arrays with `atleast_1d`

## Implementation Details

- Located in `cobaya/likelihoods/gaussian/`
- Proper type annotations: `mean: float | Sequence | np.ndarray`
- No wait/delay parameters (removed unnecessary functionality)
- Supports both explicit `input_params` and `input_params_prefix` approaches

## Testing

- Comprehensive tests in `tests/test_gaussian.py`
- Concise design using loops over normalized/unnormalized cases
- Tests against `scipy.stats.multivariate_normal.logpdf`
- Validates chi-squared calculations for unnormalized case
- Tests both list and numpy array inputs
- Error handling for dimension mismatches and singular matrices

## Addresses Issue #416

As noted in the issue, for a simple Gaussian likelihood, the unnormalized option is well-defined and provides the chi-squared-like piece without the normalization constant. This is useful for cases where only the relative likelihood matters or when the normalization is handled elsewhere.

Fixes #416

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author