### PR TITLE
Fix CMBlikes CL ordering consistency (issue #437)

### DIFF
--- a/cobaya/likelihoods/base_classes/cmblikes.py
+++ b/cobaya/likelihoods/base_classes/cmblikes.py
@@ -31,7 +31,7 @@ class CMBlikes(DataSetLikelihood):
     def get_requirements(self):
         # State requisites to the theory code
         requested_cls = [
-            self.field_names[i] + self.field_names[j]
+            self.field_names[min(i, j)] + self.field_names[max(i, j)]
             for i, j in zip(*np.where(self.cl_lmax != 0))
         ]
         # l_max has to take into account the window function of the lensing


### PR DESCRIPTION
Fixes issue #437 where `CMBlikes.get_requirements()` requests `'ET'` but `get_theory_map_cls()` later uses `'te'`, causing silent fallback to zero arrays when theory codes only provide what was initially requested.

## Problem

The PR4 lensing likelihood is a `CMBlikes(DataSetLikelihood)` likelihood with `fields_use = P` and `fields_required = T E P` in the `.dataset` file.

In `CMBlikes.get_requirements()` the line:
```python
requested_cls = [self.field_names[i] + self.field_names[j]
                 for i, j in zip(*np.where(self.cl_lmax != 0))]
```
leads to `requested_cls = ['TT', 'ET', 'EE', 'PP']`.

However, in `CMBlikes.get_theory_map_cls()` the line:
```python
combination = "".join([self.field_names[k] for k in CL.theory_ij]).lower()
```
will create the tags `'tt'`, `'te'`, `'ee'`, `'tp'`, `'ep'`, and `'pp'`.

When running with CAMB, everything is fine, because CAMB will provide both `'et'` and `'te'`. But if a theory code only provides whatever is initially requested (i.e. `'et'` in this case), then Cobaya will silently fall back to a zero array for `'te'`.

## Solution

The fix ensures consistent ordering by using `min(i,j), max(i,j)` in `get_requirements()`, matching the canonical ordering used in `get_theory_map_cls()` via `MapPair_to_Theory_i_j()`.

## Changes

- Modified `CMBlikes.get_requirements()` to use `self.field_names[min(i, j)] + self.field_names[max(i, j)]` instead of `self.field_names[i] + self.field_names[j]`

This ensures that whichever tag is used in the requested list matches the one that is ultimately used, preventing silent fallback to zero arrays.

## Testing

Existing tests should cover this change, particularly the Planck 2015/2018 lensing tests that use CMBlikes-based likelihoods.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author