### PR TITLE
[WIP] Periodic parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added standardized formatting with ruff (removing flake8)
 - Added pre-commit hooks for automated code quality checks (trailing whitespace, end-of-file-fixer, pyupgrade, ruff)
 - Documentation can now be built as markdown for LLM context. Flat context file provided.
+- Periodic sampled parameters implemented (for now fully supported by MCMC only), as well as tagging of derived parameters as periodic for analysis with GetDist.
 
 ## 3.5.7 - 2025-03-31
 

--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -554,7 +554,7 @@ def merge_params_info(params_infos, default_derived=True):
             current_info[p].update(deepcopy(new_info_p))
             # Account for incompatibilities: "prior" and ("value" or "derived"+bounds)
             incompatibilities = {
-                "prior": ["value", "derived", "min", "max"],
+                "prior": ["value", "derived", "min", "max", "periodic"],
                 "value": ["prior", "ref", "proposal"],
                 "derived": ["prior", "drop", "ref", "proposal"],
             }

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -345,6 +345,7 @@ class Model(HasLogger):
         params_values: dict[str, float] | Sequence[float],
         as_dict: bool = False,
         make_finite: bool = False,
+        ignore_periodic: bool = False,
     ) -> np.ndarray | dict[str, float]:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -362,10 +363,16 @@ class Model(HasLogger):
 
         If ``make_finite=True``, it will try to represent infinities as the largest real
         numbers allowed by machine precision.
+
+        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
+        ``-inf`` for periodic parameters outside the prior definition range (faster if the
+        input point can be guaranteed to fall inside it).
         """
         params_values = self.parameterization.check_sampled(params_values)
         params_values_array = self._to_sampled_array(params_values)
-        logpriors = np.asarray(self.prior.logps(params_values_array))
+        logpriors = np.asarray(
+            self.prior.logps(params_values_array, ignore_periodic=ignore_periodic)
+        )
         if make_finite:
             return np.nan_to_num(logpriors)
         if as_dict:
@@ -374,7 +381,10 @@ class Model(HasLogger):
             return logpriors
 
     def logprior(
-        self, params_values: dict[str, float] | Sequence[float], make_finite: bool = False
+        self,
+        params_values: dict[str, float] | Sequence[float],
+        make_finite: bool = False,
+        ignore_periodic: bool = False,
     ) -> float:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -387,8 +397,12 @@ class Model(HasLogger):
 
         If ``make_finite=True``, it will try to represent infinities as the largest real
         numbers allowed by machine precision.
+
+        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
+        ``-inf`` for periodic parameters outside the prior definition range (faster if the
+        input point can be guaranteed to fall inside it).
         """
-        logprior = np.sum(self.logpriors(params_values))
+        logprior = np.sum(self.logpriors(params_values, ignore_periodic=ignore_periodic))
         if make_finite:
             return np.nan_to_num(logprior)
         return logprior
@@ -583,6 +597,7 @@ class Model(HasLogger):
         return_derived: bool = True,
         cached: bool = True,
         _no_check: bool = False,
+        ignore_periodic: bool = False,
     ) -> LogPosterior | dict:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -617,6 +632,10 @@ class Model(HasLogger):
 
         If ``cached=False`` (default: True), it ignores previously computed results that
         could be reused.
+
+        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
+        ``-inf`` for periodic parameters outside the prior definition range (faster if the
+        input point can be guaranteed to fall inside it).
         """
         if _no_check:
             params_values_array = params_values
@@ -646,7 +665,9 @@ class Model(HasLogger):
                 )
         # Notice that we don't use the make_finite in the prior call,
         # to correctly check if we have to compute the likelihood
-        logpriors_1d = self.prior.logps_internal(params_values_array)
+        logpriors_1d = self.prior.logps_internal(
+            params_values_array, ignore_periodic=ignore_periodic
+        )
         if logpriors_1d == -np.inf:
             logpriors = [-np.inf] * (1 + len(self.prior.external))
         else:
@@ -682,6 +703,7 @@ class Model(HasLogger):
         params_values: dict[str, float] | Sequence[float],
         make_finite: bool = False,
         cached: bool = True,
+        ignore_periodic: bool = False,
     ) -> float:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -696,9 +718,17 @@ class Model(HasLogger):
 
         If ``cached=False`` (default: True), it ignores previously computed results that
         could be reused.
+
+        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
+        ``-inf`` for periodic parameters outside the prior definition range (faster if the
+        input point can be guaranteed to fall inside it).
         """
         return self.logposterior(
-            params_values, make_finite=make_finite, return_derived=False, cached=cached
+            params_values,
+            make_finite=make_finite,
+            return_derived=False,
+            cached=cached,
+            ignore_periodic=ignore_periodic,
         ).logpost
 
     def get_valid_point(

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -580,10 +580,7 @@ def get_literal_param_range(param_info, confidence_for_unbounded=1):
 
     # Sampled
     if is_sampled_param(param_info):
-        prior_info = param_info.get("prior", {})
-        if isinstance(prior_info, Mapping):
-            prior_info.pop("periodic", None)
-        pdf_dist = get_scipy_1d_pdf(prior_info)  # may raise ValueError
+        pdf_dist = get_scipy_1d_pdf(param_info.get("prior", {}))  # may raise ValueError
         lims = pdf_dist.interval(confidence_for_unbounded)
     # Derived
     elif is_derived_param(param_info):

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -179,6 +179,16 @@ class Parameterization(HasLogger):
                 self._sampled_renames[p] = str_to_list(info.get("renames") or [])
             if is_derived_param(info):
                 self._derived[p] = np.nan
+                # Check for consistency for periodic parameters:
+                if info.get("periodic", False) and None in (
+                    info.get("min", None),
+                    info.get("max", None),
+                ):
+                    raise LoggedError(
+                        self.log,
+                        f"Derived parameter '{p}' defined as periodic, but no range "
+                        "specified with 'min' and 'max'.",
+                    )
                 # Dynamical parameters whose value we want to save
                 if info["derived"] is True and is_fixed_or_function_param(info):
                     # parameters that are already known or computed by input funcs

--- a/cobaya/parameterization.py
+++ b/cobaya/parameterization.py
@@ -580,7 +580,10 @@ def get_literal_param_range(param_info, confidence_for_unbounded=1):
 
     # Sampled
     if is_sampled_param(param_info):
-        pdf_dist = get_scipy_1d_pdf(param_info.get("prior", {}))  # may raise ValueError
+        prior_info = param_info.get("prior", {})
+        if isinstance(prior_info, Mapping):
+            prior_info.pop("periodic", None)
+        pdf_dist = get_scipy_1d_pdf(prior_info)  # may raise ValueError
         lims = pdf_dist.interval(confidence_for_unbounded)
     # Derived
     elif is_derived_param(param_info):

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -664,7 +664,8 @@ class Prior(HasLogger):
         Args:
            x (array): Point where the log-prior is evaluated.
            ignore_periodic (bool): If True, ignores the periodicity of the parameters,
-               returning -inf for periodic parameters outside the prior definition range.
+               returning ``-inf`` for periodic parameters outside the prior definition
+               range (faster if the input point can be guaranteed to fall inside it).
 
         Returns:
            An array of the prior log-probability densities of the given point
@@ -690,7 +691,8 @@ class Prior(HasLogger):
         Args:
            x (array): Point where the log-prior is evaluated.
            ignore_periodic (bool): If True, ignores the periodicity of the parameters,
-               returning -inf for periodic parameters outside the prior definition range.
+               returning ``-inf`` for periodic parameters outside the prior definition
+               range (faster if the input point can be guaranteed to fall inside it).
 
         Returns:
            The prior log-probability density of the given point or array of points.
@@ -704,7 +706,8 @@ class Prior(HasLogger):
         Args:
            x (array): Point where the log-prior is evaluated.
            ignore_periodic (bool): If True, ignores the periodicity of the parameters,
-               returning -inf for periodic parameters outside the prior definition range.
+               returning ``-inf`` for periodic parameters outside the prior definition
+               range (faster if the input point can be guaranteed to fall inside it).
 
         Returns:
            The prior log-probability density of the given point

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -467,11 +467,18 @@ class Prior(HasLogger):
                 self._is_periodic.append(bool(prior.pop("periodic", False)))
             else:
                 self._is_periodic.append(False)
-            if self._is_periodic[i] and any(np.isinf(self._bounds[i])):
-                raise LoggedError(
-                    self.log,
-                    f"Parameter '{p}' cannot be periodic if it is not bounded.",
-                )
+            if self._is_periodic[i]:
+                if any(np.isinf(self._bounds[i])):
+                    raise LoggedError(
+                        self.log,
+                        f"Parameter '{p}' cannot be periodic if it is not bounded.",
+                    )
+                if not np.isclose(*self.pdf[i].logpdf(self._bounds[i])):
+                    raise LoggedError(
+                        self.log,
+                        f"Parameter '{p}' was declared periodic, but logprior at bounds "
+                        "is different."
+                    )
         self.is_any_periodic = any(self._is_periodic)
         self._uniform_indices = np.array(
             [i for i, pdf in enumerate(self.pdf) if pdf.dist.name == "uniform"], dtype=int

--- a/cobaya/prior.py
+++ b/cobaya/prior.py
@@ -319,6 +319,44 @@ theory code (e.g. CAMB), you can use:
         external: "lambda _self: stats.norm.logpdf(_self.provider.get_param('omegam'), loc=0.334, scale=0.018)"
         requires: omegam
 
+Periodic parameters
+-------------------
+
+Periodic parameters are indicated with a ``peridic=True`` keyword, which should be placed
+inside the prior definition for **sampled** paramters, and inside the bare parameter
+definition for **derived** parameters:
+
+.. code-block :: yaml
+
+     params:
+
+       a: # sampled
+         prior:
+           min: 0
+           max: 1
+           periodic: True
+
+       b: # derived
+         min: 0
+         max: 1
+         periodic: True
+
+Notice that for periodic sampled parameters, the prior must be bounded, and for periodic
+derived parameters both ``min`` and ``max`` must be used to specify a base range.
+
+When calling log-prior or log-posterior methods of a ``Model``, an ``ignore_periodic``
+keyword can be used to control whether a null prior is assigned to values outside the
+prior base range. By default (``ignore_periodic=False``), these methods behave as
+expected, returning the prior of the value reduced to the base range:
+``logp(x) = logp(x + n*period)``.
+
+Samplers will always call these methods with ``ignore_periodic=True``, either because they
+will support periodic parameters directly (i.e. they will not propose values outside the
+prior definition range) or because they will not support them, in which case they will
+have to treat the prior definition range as hard boundaries (in this case, a warning will
+be raised at initialization). At the time of writing, only the ``mcmc`` sampler fully
+supports periodic parameters.
+
 Vector parameters
 -----------------
 

--- a/cobaya/sampler.py
+++ b/cobaya/sampler.py
@@ -199,6 +199,9 @@ class Sampler(CobayaComponent):
 
     seed: None | int | Sequence[int]
     version: dict | str | None = None
+    # Set to True if sampler is guaranteed to never periodic parameter values outside
+    # the prior definition range.
+    supports_periodic_params: bool = False
 
     _rng: np.random.Generator
 
@@ -280,6 +283,12 @@ class Sampler(CobayaComponent):
         if not model.parameterization.sampled_params():
             self.mpi_warning(
                 "No sampled parameters requested! This will fail for non-mock samplers."
+            )
+        if self.model.prior.is_any_periodic and not self.supports_periodic_params:
+            self.log.warning(
+                "There are periodic sampled parameters, but this sampler does not support"
+                " them. Treating their prior definition range as hard boundaries. This "
+                "may have unexpected effects."
             )
         # Load checkpoint info, if resuming
         if self.output.is_resuming() and not isinstance(self, Minimizer):

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -54,6 +54,7 @@ class MCMC(CovmatSampler):
     \cite{Lewis:2002ah,Lewis:2013hha}.
     """
 
+    supports_periodic_params = True
     _at_resume_prefer_new = CovmatSampler._at_resume_prefer_new + [
         "burn_in",
         "callback_function",

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -333,7 +333,7 @@ class polychord(Sampler):
         # since PolyChord divides by it
 
         def logpost(params_values):
-            result = self.model.logposterior(params_values)
+            result = self.model.logposterior(params_values, ignore_periodic=True)
             loglikes = result.loglikes
             if len(loglikes) != self.n_likes:
                 loglikes = np.full(self.n_likes, np.nan)

--- a/cobaya/theory.py
+++ b/cobaya/theory.py
@@ -431,7 +431,7 @@ class TheoryCollection(ComponentCollection):
             try:
                 return super().__getattribute__(name)
             except AttributeError:
-                self.log.warn(
+                self.log.warning(
                     "No attribute %s of TheoryCollection. Use model.provider "
                     "if you want to access computed requests" % name
                 )

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -650,6 +650,7 @@ def get_scipy_1d_pdf(
         kwargs = {"dist": "uniform", "min": definition[0], "max": definition[1]}
     elif isinstance(definition, dict):
         kwargs = deepcopy(definition)
+        kwargs.pop("periodic", None)  # ignore periodicity silently
     else:
         raise ValueError(
             f"Invalid type {type(definition)} for prior definition: {definition}"

--- a/cobaya/typing.py
+++ b/cobaya/typing.py
@@ -42,6 +42,7 @@ partags = {
     "renames",
     "min",
     "max",
+    "periodic",
 }
 
 LiteralFalse = Literal[False]


### PR DESCRIPTION
Addresses (#438).

This is just an initial implementation, taking care of the prior part with minimal changes.

It does not modify the original point, e.g. if the period is `[0, 2pi]`, then `3pi` is treated correctly in terms of the prior, but still stored as `3pi`. This could be fixed if we could trust that that the values passed to `Prior.logps_internal` are passed by reference, so that a modification inside the method modifies the actual passed value (otherwise we need to make a copy, as in this initial implementation).

We could also make the code cleaner if we are OK with allowing `periodic: True|False` to pass through `tools.get_scipy_1d_pdf`.

@cmbant thoughts?