### PR TITLE
Alternative periodic parameter syntax

### DIFF
--- a/cobaya/input.py
+++ b/cobaya/input.py
@@ -554,7 +554,7 @@ def merge_params_info(params_infos, default_derived=True):
             current_info[p].update(deepcopy(new_info_p))
             # Account for incompatibilities: "prior" and ("value" or "derived"+bounds)
             incompatibilities = {
-                "prior": ["value", "derived", "min", "max", "periodic"],
+                "prior": ["value", "derived", "min", "max"],
                 "value": ["prior", "ref", "proposal"],
                 "derived": ["prior", "drop", "ref", "proposal"],
             }

--- a/cobaya/model.py
+++ b/cobaya/model.py
@@ -345,7 +345,6 @@ class Model(HasLogger):
         params_values: dict[str, float] | Sequence[float],
         as_dict: bool = False,
         make_finite: bool = False,
-        ignore_periodic: bool = False,
     ) -> np.ndarray | dict[str, float]:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -363,16 +362,10 @@ class Model(HasLogger):
 
         If ``make_finite=True``, it will try to represent infinities as the largest real
         numbers allowed by machine precision.
-
-        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
-        ``-inf`` for periodic parameters outside the prior definition range (faster if the
-        input point can be guaranteed to fall inside it).
         """
         params_values = self.parameterization.check_sampled(params_values)
         params_values_array = self._to_sampled_array(params_values)
-        logpriors = np.asarray(
-            self.prior.logps(params_values_array, ignore_periodic=ignore_periodic)
-        )
+        logpriors = np.asarray(self.prior.logps(params_values_array))
         if make_finite:
             return np.nan_to_num(logpriors)
         if as_dict:
@@ -384,7 +377,6 @@ class Model(HasLogger):
         self,
         params_values: dict[str, float] | Sequence[float],
         make_finite: bool = False,
-        ignore_periodic: bool = False,
     ) -> float:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -397,12 +389,8 @@ class Model(HasLogger):
 
         If ``make_finite=True``, it will try to represent infinities as the largest real
         numbers allowed by machine precision.
-
-        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
-        ``-inf`` for periodic parameters outside the prior definition range (faster if the
-        input point can be guaranteed to fall inside it).
         """
-        logprior = np.sum(self.logpriors(params_values, ignore_periodic=ignore_periodic))
+        logprior = np.sum(self.logpriors(params_values))
         if make_finite:
             return np.nan_to_num(logprior)
         return logprior
@@ -597,7 +585,6 @@ class Model(HasLogger):
         return_derived: bool = True,
         cached: bool = True,
         _no_check: bool = False,
-        ignore_periodic: bool = False,
     ) -> LogPosterior | dict:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -632,10 +619,6 @@ class Model(HasLogger):
 
         If ``cached=False`` (default: True), it ignores previously computed results that
         could be reused.
-
-        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
-        ``-inf`` for periodic parameters outside the prior definition range (faster if the
-        input point can be guaranteed to fall inside it).
         """
         if _no_check:
             params_values_array = params_values
@@ -665,9 +648,7 @@ class Model(HasLogger):
                 )
         # Notice that we don't use the make_finite in the prior call,
         # to correctly check if we have to compute the likelihood
-        logpriors_1d = self.prior.logps_internal(
-            params_values_array, ignore_periodic=ignore_periodic
-        )
+        logpriors_1d = self.prior.logps_internal(params_values_array)
         if logpriors_1d == -np.inf:
             logpriors = [-np.inf] * (1 + len(self.prior.external))
         else:
@@ -703,7 +684,6 @@ class Model(HasLogger):
         params_values: dict[str, float] | Sequence[float],
         make_finite: bool = False,
         cached: bool = True,
-        ignore_periodic: bool = False,
     ) -> float:
         """
         Takes an array or dictionary of sampled parameter values.
@@ -718,17 +698,12 @@ class Model(HasLogger):
 
         If ``cached=False`` (default: True), it ignores previously computed results that
         could be reused.
-
-        If ``ignore_periodic=True``, ignores the periodicity of the parameters, returning
-        ``-inf`` for periodic parameters outside the prior definition range (faster if the
-        input point can be guaranteed to fall inside it).
         """
         return self.logposterior(
             params_values,
             make_finite=make_finite,
             return_derived=False,
             cached=cached,
-            ignore_periodic=ignore_periodic,
         ).logpost
 
     def get_valid_point(

--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -560,7 +560,7 @@ class MCMC(CovmatSampler):
         trial = self.current_point.values.copy()
         self.proposer.get_proposal(trial)
         trial = self.model.prior.reduce_periodic(trial, copy=False)
-        trial_results = self.model.logposterior(trial, ignore_periodic=True)
+        trial_results = self.model.logposterior(trial)
         accept = self.metropolis_accept(trial_results.logpost, self.current_point.logpost)
         self.process_accept_or_reject(accept, trial, trial_results)
         return accept
@@ -590,7 +590,7 @@ class MCMC(CovmatSampler):
         self.log.debug("Proposed slow end-point: %r", current_end_point)
         # Save derived parameters of delta_slow jump, in case I reject all the dragging
         # steps but accept the move in the slow direction only
-        current_end = self.model.logposterior(current_end_point, ignore_periodic=True)
+        current_end = self.model.logposterior(current_end_point)
         if current_end.logpost == -np.inf:
             self.current_point.weight += 1
             return False
@@ -621,7 +621,6 @@ class MCMC(CovmatSampler):
                 proposal_start_point,
                 return_derived=bool(derived),
                 _no_check=True,
-                ignore_periodic=True,
             ).logpost
             if proposal_start_logpost != -np.inf:
                 proposal_end_point = current_end_point + delta_fast
@@ -629,7 +628,6 @@ class MCMC(CovmatSampler):
                     proposal_end_point,
                     return_derived=bool(derived),
                     _no_check=True,
-                    ignore_periodic=True,
                 )
                 if proposal_end.logpost != -np.inf:
                     # create the interpolated probability and do a Metropolis test
@@ -667,7 +665,7 @@ class MCMC(CovmatSampler):
         )
         if accept and not derived:
             # recompute with derived parameters (slow parameter ones should be cached)
-            current_end = self.model.logposterior(current_end_point, ignore_periodic=True)
+            current_end = self.model.logposterior(current_end_point)
 
         self.process_accept_or_reject(accept, current_end_point, current_end)
         self.log.debug("TOTAL step: %s", ("accepted" if accept else "rejected"))

--- a/cobaya/samplers/minimize/minimize.py
+++ b/cobaya/samplers/minimize/minimize.py
@@ -172,7 +172,7 @@ class Minimize(Minimizer, CovmatSampler):
             )
         else:
             self.logp = partial(
-                self.model.logpost, make_finite=True, ignore_periodic=True
+                self.model.logpost, make_finite=True
             )
         # Try to load info from previous samples.
         # If none, sample from reference (make sure that it has finite like/post)

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -333,7 +333,7 @@ class polychord(Sampler):
         # since PolyChord divides by it
 
         def logpost(params_values):
-            result = self.model.logposterior(params_values, ignore_periodic=True)
+            result = self.model.logposterior(params_values)
             loglikes = result.loglikes
             if len(loglikes) != self.n_likes:
                 loglikes = np.full(self.n_likes, np.nan)

--- a/cobaya/tools.py
+++ b/cobaya/tools.py
@@ -650,7 +650,6 @@ def get_scipy_1d_pdf(
         kwargs = {"dist": "uniform", "min": definition[0], "max": definition[1]}
     elif isinstance(definition, dict):
         kwargs = deepcopy(definition)
-        kwargs.pop("periodic", None)  # ignore periodicity silently
     else:
         raise ValueError(
             f"Invalid type {type(definition)} for prior definition: {definition}"


### PR DESCRIPTION
This PR refactors periodic parameter handling to simplify the API and make the syntax more intuitive.

## Changes

- **Move periodic flag to parameter level**: `periodic: True` is now specified at the parameter level, not inside the prior definition
- **Remove ignore_periodic API**: Eliminated the `ignore_periodic` parameter from all prior/posterior methods (`logpriors`, `logprior`, `logposterior`, `logpost`)
- **Simplify internal structure**: Replace `_is_periodic` array and `is_any_periodic` flag with a compact `_periodic_bounds` list of tuples
- **Update documentation**: Reflect the new parameter-level syntax and clarify that only MCMC currently implements parameter wrapping
- **Remove incompatibility**: `periodic` is no longer incompatible with `prior` in `merge_params_info`

## New Syntax

```yaml
params:
  theta:  # sampled parameter
    prior:
      min: 0
      max: 6.28
    periodic: True  # <- at parameter level
    
  phi:  # derived parameter  
    min: 0
    max: 3.14
    periodic: True  # <- at parameter level
```

## Benefits

- Cleaner, more intuitive syntax
- Simplified API without `ignore_periodic` complexity
- More efficient internal representation
- Better separation of concerns (periodic is a parameter property, not a prior property)

## Backward Compatibility

- The prior itself remains a plain range prior
- `reduce_periodic` method is still available and works as before
- Samplers continue to handle periodic reduction as needed

Follows up on PR #440 which was merged.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author