### PR TITLE
Testing covmat-disperse

### DIFF
--- a/cobaya/samplers/mcmc/mcmc.py
+++ b/cobaya/samplers/mcmc/mcmc.py
@@ -235,6 +235,7 @@ class MCMC(CovmatSampler):
                 override_covmat=dispersion_covmat,
             )
         self.current_point.add(initial_point, results)
+        self.initial_point = initial_point
         self.log.info("Initial point: %s", self.current_point)
         sync_processes()
         # If resuming but no existing chains, assume failed run and ignore blocking


### PR DESCRIPTION
I tested that `covmat-disperse` behaves as intended. I initialized many chains and verified that the covariance of the initial points matches the covariance provided by the user.

To perform this test, I modified `mcmc.py` to save the initial positions of the chains.

I also attach the Jupyter notebook used for the validation tests: [Test_disperse_covariance.ipynb](https://github.com/user-attachments/files/28468898/Test_disperse_covariance.ipynb)
