### PR TITLE
Fix job ID writing in jobqueue.py

### DIFF
--- a/cobaya/grid_tools/jobqueue.py
+++ b/cobaya/grid_tools/jobqueue.py
@@ -473,7 +473,7 @@ def submitJob(job_name, input_files, sequential=False, msg=False, **kwargs):
                     job_id = parse_job_id_from_output(res)
                     j.jobId = job_id
                     j.subTime = time.time()
-                    TextFile(scriptRoot + jobid_ext).write(job_id)
+                    TextFile(job_id).write(scriptRoot + jobid_ext)
                     addJobIndex(kwargs.get("batchPath"), j)
 
 


### PR DESCRIPTION
Same as 7e6a164779512d024d4c15da748f5a56cc44f1b6
The order of arguments used in `TextFile` is reversed.